### PR TITLE
🔀 :: (#28) - 네트워크 통신을 하기위한 세팅을 했습니다.

### DIFF
--- a/core/network/src/main/java/com/school_of_company/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/school_of_company/network/di/NetworkModule.kt
@@ -1,0 +1,73 @@
+package com.school_of_company.network.di
+
+import android.content.Context
+import android.util.Log
+import com.school_of_company.network.util.AuthInterceptor
+import com.school_of_company.network.util.TokenAuthenticator
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import okhttp3.CookieJar
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import java.util.concurrent.TimeUnit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+    @Provides
+    fun provideHttpLoggingInterceptor() : HttpLoggingInterceptor =
+        HttpLoggingInterceptor { message -> Log.v("Http", message) }
+            .setLevel(HttpLoggingInterceptor.Level.BODY)
+
+    @Provides
+    @Singleton
+    fun provideHttpClient(
+        @ApplicationContext context: Context,
+        httpLoggingInterceptor: HttpLoggingInterceptor,
+        authInterceptor: AuthInterceptor,
+        tokenAuthenticator: TokenAuthenticator,
+    ) : OkHttpClient {
+        return OkHttpClient.Builder()
+            .cookieJar(CookieJar.NO_COOKIES)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .addInterceptor(httpLoggingInterceptor)
+            .addInterceptor(authInterceptor)
+            .authenticator(tokenAuthenticator)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideMoshiInstance() : Moshi {
+        return Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideMoshiConverterFactory(moshi: Moshi) : MoshiConverterFactory {
+        return MoshiConverterFactory.create(moshi)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRetrofitInstance(
+        okHttpClient: OkHttpClient,
+        moshiConverterFactory: MoshiConverterFactory
+    ) : Retrofit {
+        return Retrofit.Builder()
+            .baseUrl("") // todo : Add BaseUrl -> Use buildConfig
+            .client(okHttpClient)
+            .addConverterFactory(moshiConverterFactory)
+            .build()
+    }
+}

--- a/core/network/src/main/java/com/school_of_company/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/school_of_company/network/di/NetworkModule.kt
@@ -25,7 +25,7 @@ object NetworkModule {
     @Provides
     fun provideHttpLoggingInterceptor() : HttpLoggingInterceptor =
         HttpLoggingInterceptor { message -> Log.v("Http", message) }
-            .setLevel(HttpLoggingInterceptor.Level.BODY)
+            .setLevel(HttpLoggingInterceptor.Level.BASIC)
 
     @Provides
     @Singleton

--- a/core/network/src/main/java/com/school_of_company/network/util/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/school_of_company/network/util/AuthInterceptor.kt
@@ -1,0 +1,13 @@
+package com.school_of_company.network.util
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+class AuthInterceptor @Inject constructor(
+    // todo : Add LocalDataSource
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        TODO("Not yet implemented")
+    }
+}

--- a/core/network/src/main/java/com/school_of_company/network/util/TokenAuthenticator.kt
+++ b/core/network/src/main/java/com/school_of_company/network/util/TokenAuthenticator.kt
@@ -1,0 +1,16 @@
+package com.school_of_company.network.util
+
+import kotlinx.serialization.Serializer
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import javax.inject.Inject
+
+class TokenAuthenticator @Inject constructor(
+    // todo : Add LocalDataSource
+) : Authenticator {
+    override fun authenticate(route: Route?, response: Response): Request? {
+        TODO("Not yet implemented")
+    }
+}


### PR DESCRIPTION
## 💡 개요
- 네트워크 통신을 하기위한 기본적인 세팅을 해야합니다.
## 📃 작업내용
- Moshi, Retrofit2, OkHttp3 등의 라이브러리를 사용하기 위해 core:network 단의 build.gradle.kts 파일에 의존성을 추가하였습니다.
- NetworkModule의 Kotlin 파일을 생성후 GsonConverter 대신 성능적으로 더 좋은 MoshiConverter를 사용하여 네트워크 세팅을 하였습니다.
- Authinterceptor, TokenAuthenticator을 생성하여 기본적인 코드 작성을 하였습니다.
## 🔀 변경사항
- add NetworkModule
- add AuthInterceptor
- add TokenAuthenticator
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- 기본적인 Network를 설정한 후에(dto -> api) NetworkModule에 해당 API를 설정해줍니다.
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 네트워크 계층을 위한 의존성 주입 모듈이 추가되었습니다.
  - HTTP 로깅, 클라이언트, JSON 처리 및 Retrofit 인스턴스를 위한 여러 제공 메소드가 포함되었습니다.
  - 인증을 위한 `AuthInterceptor` 클래스가 추가되었습니다.
  - 토큰 인증을 위한 `TokenAuthenticator` 클래스가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->