### PR TITLE
🔀 :: (#36) - Hilt를 사용하기 위한 Application을 만들어 연결했습니다.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".ExpoApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -15,7 +16,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.ExpoAndroid">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/school_of_company/expo_android/ExpoApplication.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/ExpoApplication.kt
@@ -1,0 +1,7 @@
+package com.school_of_company.expo_android
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class ExpoApplication : Application()

--- a/app/src/main/java/com/school_of_company/expo_android/MainActivity.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/MainActivity.kt
@@ -12,7 +12,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.school_of_company.expo_android.ui.theme.ExpoAndroidTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)


### PR DESCRIPTION
## 💡 개요
- Hilt를 사용하기 위해서 Application을 만들어 연결이 필요했습니다.
## 📃 작업내용
- Hilt를 사용하기 위해 Applicaton을 생성한 후  AndroidManifest에 연결을 하였습니다.
- MainActivity에 @AndroidEntryPoint 어노테이션을 사용하였습니다.
## 🔀 변경사항
- chore AndroidManifest.xml
- chore MainActivity
- add ExpoApplication
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- `ExpoApplication` 클래스를 사용하도록 애플리케이션 설정 변경.
	- Dagger Hilt 의존성 주입 프레임워크를 `MainActivity`에 통합.

- **버그 수정**
	- `MainActivity`의 `android:label` 속성 제거.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->