### PR TITLE
🔀 :: (#62) - BuildConfig를 사용할 수 있도록 하였습니다.

### DIFF
--- a/.github/workflows/expo_ci.yml
+++ b/.github/workflows/expo_ci.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      #- name: Create LOCAL_PROPERTIES
-      #  run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
+      - name: Create LOCAL_PROPERTIES
+        run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -1,10 +1,23 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     id("expo.android.core")
     id("expo.android.hilt")
 }
 
 android {
-    // todo : buildConfig
+    buildFeatures {
+        buildConfig = true
+    }
+
+    defaultConfig {
+        buildConfigField(
+            type = "String",
+            name = "BASE_URL",
+            getApiKey("BASE_URL")
+        )
+    }
 
     namespace = "com.school_of_company.network"
 }
@@ -23,4 +36,9 @@ dependencies {
     ksp(libs.retrofit.moshi.codegen)
 }
 
-// todo : Create getApiKey
+fun getApiKey(propertyKey: String) : String {
+    val propFile = rootProject.file("./local.properties")
+    val properties = Properties()
+    properties.load(FileInputStream(propFile))
+    return properties.getProperty(propertyKey) ?: throw IllegalArgumentException("Property $propertyKey not found in local.properties")
+}

--- a/core/network/src/main/java/com/school_of_company/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/school_of_company/network/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.school_of_company.network.di
 
 import android.content.Context
 import android.util.Log
+import com.school_of_company.network.BuildConfig
 import com.school_of_company.network.util.AuthInterceptor
 import com.school_of_company.network.util.TokenAuthenticator
 import com.squareup.moshi.Moshi
@@ -65,7 +66,7 @@ object NetworkModule {
         moshiConverterFactory: MoshiConverterFactory
     ) : Retrofit {
         return Retrofit.Builder()
-            .baseUrl("") // todo : Add BaseUrl -> Use buildConfig
+            .baseUrl(BuildConfig.BASE_URL)
             .client(okHttpClient)
             .addConverterFactory(moshiConverterFactory)
             .build()


### PR DESCRIPTION
## 💡 개요
- local.properties에 baseUrl 값을 넣어 해당 정보를 보호할 수 있게 하도록 하면 Remote 저장소에는 Push가 되지 않으므로 이를 사용하기 위해 BuildConfig를 사용할 필요가 있어보였습니다.
## 📃 작업내용
- BuildConfig를 세팅하고 이를 적용시켰습니다.
## 🔀 변경사항
- chore build.gradle.kts(:core:network)
- chore NetworkModule
- chore expo_ci.yml File
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이산한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- BASE_URL을 사용할 부분에 buildConfig.BASE_URL 이런식으로 사용해서 원래있던 문자열 대신 넣어주면 됩니다.

<img width="226" alt="스크린샷 2024-10-09 오후 2 39 59" src="https://github.com/user-attachments/assets/2d5cb671-55bb-49a0-a0b9-5d9a20473142">
 
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- CI 워크플로우에 `local.properties` 파일 생성 단계 추가.
	- Retrofit 인스턴스의 기본 URL을 빌드 구성에서 동적으로 가져오도록 업데이트.

- **버그 수정**
	- `build.gradle.kts` 파일에서 API 키를 로드하는 기능 추가. 

- **문서화**
	- 코드 구조 변경에 대한 주석 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->