### PR TITLE
🔀 :: (#70) - Device에 대한 각각의 모델을 Preview에서도 확인이 가능하도록 했습니다.

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,7 @@ android {
 
 dependencies {
     // todo : Add Other Project Implementation -> ex) implementation(project(":core:___")) / (project(":feature:____"))
+    implementation(project(":core:ui"))
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext)

--- a/app/src/main/java/com/school_of_company/expo_android/MainActivity.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/MainActivity.kt
@@ -42,10 +42,7 @@ fun Greeting(name: String, modifier: Modifier = Modifier) {
             .fillMaxSize()
             .background(Color.White)
     )
-    Text(
-        text = "Hello $name!",
-        modifier = Modifier
-    )
+    Text(text = "Hello $name!")
 }
 
 @ExpoPreviews

--- a/app/src/main/java/com/school_of_company/expo_android/MainActivity.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/MainActivity.kt
@@ -4,14 +4,17 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.graphics.Color
 import com.school_of_company.expo_android.ui.theme.ExpoAndroidTheme
+import com.school_of_company.ui.preview.ExpoPreviews
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -34,13 +37,18 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun Greeting(name: String, modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.White)
+    )
     Text(
         text = "Hello $name!",
-        modifier = modifier
+        modifier = Modifier
     )
 }
 
-@Preview(showBackground = true)
+@ExpoPreviews
 @Composable
 fun GreetingPreview() {
     ExpoAndroidTheme {

--- a/core/ui/src/main/java/com/school_of_company/ui/preview/ExpoPreviews.kt
+++ b/core/ui/src/main/java/com/school_of_company/ui/preview/ExpoPreviews.kt
@@ -1,0 +1,10 @@
+package com.school_of_company.ui.preview
+
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(name = "phone_1", device = "spec:shape=Normal,width=360,height=880,unit=dp,dpi=480")
+@Preview(name = "phone_2", device = "spec:shape=Normal,width=412,height=732,unit=dp,dpi=420")
+@Preview(name = "s23", device = "spec:shape=Normal,width=360,height=780,unit=dp,dpi=480")
+@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
+@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
+annotation class ExpoPreviews

--- a/core/ui/src/main/java/com/school_of_company/ui/preview/ExpoPreviews.kt
+++ b/core/ui/src/main/java/com/school_of_company/ui/preview/ExpoPreviews.kt
@@ -2,6 +2,21 @@ package com.school_of_company.ui.preview
 
 import androidx.compose.ui.tooling.preview.Preview
 
+/**
+ * 다양한 기기 구성에 대한 Compose UI 프리뷰를 생성합니다.
+ *
+ * 이 어노테이션을 사용하면 여러 기기 유형(폰, 폴더블, 태블릿)에 대한
+ * UI 프리뷰를 한 번에 생성할 수 있습니다.
+ *
+ * 사용 예:
+ * ```
+ * @ExpoPreviews
+ * @Composable
+ * fun MyComposablePreview() {
+ *     MyComposable()
+ * }
+ * ```
+ */
 @Preview(name = "phone_1", device = "spec:shape=Normal,width=360,height=880,unit=dp,dpi=480")
 @Preview(name = "phone_2", device = "spec:shape=Normal,width=412,height=732,unit=dp,dpi=420")
 @Preview(name = "s23", device = "spec:shape=Normal,width=360,height=780,unit=dp,dpi=480")


### PR DESCRIPTION
## 💡 개요
- Device에 대한 각각의 모델을 Preview에서도 확인이 가능하도록 하는 것이 개발을 하는데 있어 효율이 좋아보였습니다.
## 📃 작업내용
- Device에 대한 각각의 모델을 Preview에서도 확인이 가능하도록 했습니다.
- Before
   <img width="153" alt="스크린샷 2024-10-10 오후 2 57 47" src="https://github.com/user-attachments/assets/d4775d0a-0254-47be-8d4f-814502a0bc56">

- After 
   <img width="668" alt="스크린샷 2024-10-10 오후 2 58 16" src="https://github.com/user-attachments/assets/1305c1ad-ea85-42a9-befb-9326909054e4">

## 🔀 변경사항
- add ExpoPreviews
- add util Package
- chore build.gradle.kts(:app)
- remove Unused .gitkeep File
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이산한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- Feature 모듈에서 Ui 작업을 할때 @Preview 대신 @ExpoPreview를 사용하면 됩니다.
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- UI 미리보기를 위한 `ExpoPreviews` 주석 추가.
	- UI 개선을 위한 `Greeting` 컴포저블 함수 업데이트.
- **버그 수정**
	- `@Preview` 주석을 `@ExpoPreviews`로 변경하여 미리보기 처리 방식 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->