### PR TITLE
🔀 :: (#90) - 중복 클릭 이벤트 처리를 하기위한 Modifier의 clickable 함수를 커스텀하여 사용하도록 하였습니다.

### DIFF
--- a/core/design-system/build.gradle.kts
+++ b/core/design-system/build.gradle.kts
@@ -10,4 +10,5 @@ android {
 
 dependencies {
     implementation(libs.coil.kt)
+    implementation(libs.androidx.material.ripple)
 }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/modifier/clickable/MultipleEventsCutter.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/modifier/clickable/MultipleEventsCutter.kt
@@ -1,0 +1,24 @@
+package com.school_of_company.design_system.component.modifier.clickable
+
+internal interface MultipleEventsCutter {
+    fun processEvent(event: () -> Unit)
+
+    companion object
+}
+
+internal fun MultipleEventsCutter.Companion.get(intervalMs: Long) : MultipleEventsCutter =
+    MultipleEventsCutterImpl(intervalMs = intervalMs)
+
+private class MultipleEventsCutterImpl(private val intervalMs: Long) : MultipleEventsCutter {
+    private val now: Long
+        get() = System.currentTimeMillis()
+
+    private var lastEventTimeMs: Long = 0L
+
+    override fun processEvent(event: () -> Unit) {
+        if (now - lastEventTimeMs >= intervalMs) {
+            event.invoke()
+        }
+        lastEventTimeMs = now
+    }
+}

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/modifier/clickable/MultipleEventsCutter.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/modifier/clickable/MultipleEventsCutter.kt
@@ -18,7 +18,7 @@ private class MultipleEventsCutterImpl(private val intervalMs: Long) : MultipleE
     override fun processEvent(event: () -> Unit) {
         if (now - lastEventTimeMs >= intervalMs) {
             event.invoke()
+            lastEventTimeMs = now
         }
-        lastEventTimeMs = now
     }
 }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/modifier/clickable/expoClickable.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/modifier/clickable/expoClickable.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
@@ -21,18 +22,19 @@ fun Modifier.expoClickable(
     onClick: () -> Unit
 ) = composed(
     inspectorInfo = debugInspectorInfo {
-        name = "clickable"
+        name = "expoClickable"
         properties["enabled"] = enabled
         properties["onClickLabel"] = onClickLabel
         properties["role"] = role
         properties["onClick"] = onClick
     }
 ) {
+    val currentOnClick = rememberUpdatedState(onClick)
     val multipleEventsCutter = remember { MultipleEventsCutter.get(intervalMs = interval) }
     Modifier.clickable(
         enabled = enabled,
         onClickLabel = onClickLabel,
-        onClick = { multipleEventsCutter.processEvent { onClick() } },
+        onClick = { multipleEventsCutter.processEvent { currentOnClick.value() } },
         role = role,
         indication = if (isIndication) {
             rippleColor?.let {

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/modifier/clickable/expoClickable.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/modifier/clickable/expoClickable.kt
@@ -1,0 +1,47 @@
+package com.school_of_company.design_system.component.modifier.clickable
+
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.semantics.Role
+
+fun Modifier.expoClickable(
+    enabled: Boolean = true,
+    isIndication: Boolean = false,
+    rippleColor: Color? = null,
+    onClickLabel: String? = null,
+    role: Role? = null,
+    interval: Long = 1_000L,
+    onClick: () -> Unit
+) = composed(
+    inspectorInfo = debugInspectorInfo {
+        name = "clickable"
+        properties["enabled"] = enabled
+        properties["onClickLabel"] = onClickLabel
+        properties["role"] = role
+        properties["onClick"] = onClick
+    }
+) {
+    val multipleEventsCutter = remember { MultipleEventsCutter.get(intervalMs = interval) }
+    Modifier.clickable(
+        enabled = enabled,
+        onClickLabel = onClickLabel,
+        onClick = { multipleEventsCutter.processEvent { onClick() } },
+        role = role,
+        indication = if (isIndication) {
+            rippleColor?.let {
+                ripple(
+                    color = it,
+                    bounded = false
+                )
+            } ?: LocalIndication.current
+        } else null,
+        interactionSource = remember { MutableInteractionSource() }
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ lint = "31.7.0"
 lifecycle-runtime-ktx = "2.8.6"
 lottie = "6.5.2"
 material = "1.3.0"
+materialRipple = "1.7.3"
 mlkit = "17.3.0"
 moshi = "1.15.0"
 okhttp = "4.11.0"
@@ -94,6 +95,7 @@ androidx-lifecycle-runtimeCompose = { group = "androidx.lifecycle", name = "life
 androidx-lifecycle-viewModelCompose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewModel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "androidxLifecycle" }
+androidx-material-ripple = { module = "androidx.compose.material:material-ripple", version.ref = "materialRipple" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxNavigation" }
 androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspresso" }


### PR DESCRIPTION
## 💡 개요
- 중복 클릭 이벤트 처리를 해야 해서 Modifier의 clickable을 커스텀하여 사용하면 좋을 것 같다는 생각을 했습니다.
## 📃 작업내용
- 중복 클릭 이벤트 처리를 하기위한 Modifier의 clickable 함수를 커스텀하여 사용하도록 하였습니다.
- material2에서 사용되는 rememberRipple()은 더이상 사용되지 않아 material3에서 사용될 수 있는 ripple()을 사용할 수 있도록 하였습니다.
## 🔀 변경사항
- chore libs.versions.toml File
- chore build.gradle.kts(:core:design-system)
- add MultipleEventsCutter
- add expoClickable
- remove Unused .gitkeep File
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이산한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
<img width="195" alt="스크린샷 2024-10-11 오후 3 51 27" src="https://github.com/user-attachments/assets/2710cdd7-4368-42e8-8740-0a507f4e1f5a">

<img width="198" alt="스크린샷 2024-10-11 오후 3 52 15" src="https://github.com/user-attachments/assets/0b3a75fe-0493-4087-a782-a9d3cd098d0a">

## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 클릭 이벤트를 제어할 수 있는 `expoClickable` 확장 함수 추가.
	- 이벤트 처리 및 스로틀링을 위한 `MultipleEventsCutter` 인터페이스 도입.
- **의존성 추가**
	- 머티리얼 리플 효과를 위한 새로운 의존성 추가.
- **버전 업데이트**
	- 여러 라이브러리의 버전 업데이트, 특히 `materialRipple` 버전 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->