### PR TITLE
🔀 :: (#120) - Color, ColorTheme을 생성하고, ExpoAndroidTheme를 생성하였습니다.

### DIFF
--- a/core/design-system/src/main/java/com/school_of_company/design_system/theme/ExpoTheme.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/theme/ExpoTheme.kt
@@ -1,0 +1,14 @@
+package com.school_of_company.design_system.theme
+
+import androidx.compose.runtime.Composable
+import com.school_of_company.design_system.theme.color.ColorTheme
+import com.school_of_company.design_system.theme.color.ExpoColor
+
+@Composable
+fun ExpoAndroidTheme(
+    colors: ColorTheme = ExpoColor,
+    typography: ExpoTypography,
+    content: @Composable (colors: ColorTheme, typography: ExpoTypography) -> Unit
+) {
+    content(colors, typography)
+}

--- a/core/design-system/src/main/java/com/school_of_company/design_system/theme/ExpoTypography.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/theme/ExpoTypography.kt
@@ -20,6 +20,7 @@ object ExpoTypography {
         Font(R.font.pretendard_thin, FontWeight.Thin),
     )
 
+    // Title Medium 1
     @Stable
     val titleMedium1 = TextStyle(
         fontFamily = pretendard,
@@ -28,6 +29,7 @@ object ExpoTypography {
         lineHeight = 36.sp
     )
 
+    // Title SemiBold 2
     @Stable
     val titleBold2 = TextStyle(
         fontFamily = pretendard,
@@ -36,6 +38,7 @@ object ExpoTypography {
         lineHeight = 28.8.sp
     )
 
+    // Title Regular 2
     @Stable
     val titleRegular2 = TextStyle(
         fontFamily = pretendard,
@@ -44,6 +47,7 @@ object ExpoTypography {
         lineHeight = 28.8.sp
     )
 
+    // Title SemiBold 3
     @Stable
     val titleBold3 = TextStyle(
         fontFamily = pretendard,
@@ -52,6 +56,7 @@ object ExpoTypography {
         lineHeight = 24.sp
     )
 
+    // Title Regular 3
     @Stable
     val titleRegular3 = TextStyle(
         fontFamily = pretendard,
@@ -60,6 +65,7 @@ object ExpoTypography {
         lineHeight = 24.sp
     )
 
+    // Body SemiBold 1
     @Stable
     val bodyBold1 = TextStyle(
         fontFamily = pretendard,
@@ -68,6 +74,7 @@ object ExpoTypography {
         lineHeight = 21.6.sp
     )
 
+    // Body Regular 1
     @Stable
     val bodyRegular1 = TextStyle(
         fontFamily = pretendard,
@@ -76,6 +83,7 @@ object ExpoTypography {
         lineHeight = 21.6.sp
     )
 
+    // Body SemiBold 2
     @Stable
     val bodyBold2 = TextStyle(
         fontFamily = pretendard,
@@ -84,6 +92,7 @@ object ExpoTypography {
         lineHeight = 19.2.sp
     )
 
+    // Body Regular 2
     @Stable
     val bodyRegular2 = TextStyle(
         fontFamily = pretendard,
@@ -92,6 +101,7 @@ object ExpoTypography {
         lineHeight = 19.2.sp
     )
 
+    // Caption SemiBold 1
     @Stable
     val captionBold1 = TextStyle(
         fontFamily = pretendard,
@@ -100,6 +110,7 @@ object ExpoTypography {
         lineHeight = 19.6.sp
     )
 
+    // Caption Regular 1
     @Stable
     val captionRegular1 = TextStyle(
         fontFamily = pretendard,
@@ -108,6 +119,7 @@ object ExpoTypography {
         lineHeight = 19.6.sp
     )
 
+    // Caption SemiBold 2
     @Stable
     val captionBold2 = TextStyle(
         fontFamily = pretendard,
@@ -116,6 +128,7 @@ object ExpoTypography {
         lineHeight = 16.8.sp
     )
 
+    // Caption Regular 2
     @Stable
     val captionRegular2 = TextStyle(
         fontFamily = pretendard,

--- a/core/design-system/src/main/java/com/school_of_company/design_system/theme/color/ColorTheme.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/theme/color/ColorTheme.kt
@@ -1,0 +1,33 @@
+package com.school_of_company.design_system.theme.color
+
+import androidx.compose.ui.graphics.Color
+
+abstract class ColorTheme {
+
+    // Main ColorTheme
+    abstract val main: Color
+    abstract val main500: Color
+    abstract val main400: Color
+    abstract val main300: Color
+    abstract val main200: Color
+    abstract val main100: Color
+
+    // Gray ColorTHeme
+    abstract val gray900: Color
+    abstract val gray800: Color
+    abstract val gray700: Color
+    abstract val gray600: Color
+    abstract val gray500: Color
+    abstract val gray400: Color
+    abstract val gray300: Color
+    abstract val gray200: Color
+    abstract val gray100: Color
+
+    // System ColorTheme
+    abstract val error: Color
+    abstract val clear: Color
+
+    // Black And White ColorTheme
+    abstract val black: Color
+    abstract val white: Color
+}

--- a/core/design-system/src/main/java/com/school_of_company/design_system/theme/color/ExpoColor.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/theme/color/ExpoColor.kt
@@ -1,0 +1,33 @@
+package com.school_of_company.design_system.theme.color
+
+import androidx.compose.ui.graphics.Color
+
+object ExpoColor : ColorTheme() {
+
+    // Main Color
+    override val main = Color(0xFF448FFF)
+    override val main500 = Color(0xFF63A2FF)
+    override val main400 = Color(0xFF82B4FF)
+    override val main300 = Color(0xFFA2C7FF)
+    override val main200 = Color(0xFFC1DAFF)
+    override val main100 = Color(0xFFE0ECFF)
+
+    // Gray Color
+    override val gray900 = Color(0xFF383838)
+    override val gray800 = Color(0xFF4E4E4E)
+    override val gray700 = Color(0xFF646464)
+    override val gray600 = Color(0xFF7A7A7A)
+    override val gray500 = Color(0xFF909090)
+    override val gray400 = Color(0xFFA7A7A7)
+    override val gray300 = Color(0xFFBDBDBD)
+    override val gray200 = Color(0xFFD3D3D3)
+    override val gray100 = Color(0xFFE9E9E9)
+
+    // System Color
+    override val error = Color(0xFFFF3434)
+    override val clear = Color(0xFF4CFF34)
+
+    // Black And White Color
+    override val black = Color(0xFF121212)
+    override val white = Color(0xFFFFFFFF)
+}


### PR DESCRIPTION
## 💡 개요
- 프로젝트 안에서 사용이 되는 색상들을 지정하고, 이를 테마로 만들어 프로젝트 전역에서 편하게 사용할 수 있도록 하면 좋을 것 같았습니다.
## 📃 작업내용
- 프로젝트 안에서 사용이 되는 색상들을 지정하고, 이를 테마로 만들어 프로젝트 전역에서 편하게 사용할 수 있도록 하였습니다.
## 🔀 변경사항
- chore ExpoTypography(Add Comment)
- add ExpoColor
- add ColorTheme
- add ExpoTheme
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이산한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
<img width="382" alt="스크린샷 2024-10-22 오전 12 36 12" src="https://github.com/user-attachments/assets/1d66cba3-48e2-4266-97d2-d75935fc794a">

## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- `ExpoAndroidTheme` 함수 추가로 테마 설정 가능.
	- `ExpoTypography`에 다양한 텍스트 스타일 추가로 텍스트 표현력 향상.
	- `ColorTheme` 추상 클래스 및 `ExpoColor` 객체 추가로 색상 관리 체계화.

- **문서화**
	- 디자인 시스템의 색상 및 타이포그래피 관련 문서화 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->