### PR TITLE
🔀 :: (#132) - 바텀네비게이션바를 구현하였습니다.

### DIFF
--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/navigation/ExpoNavigationBar.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/navigation/ExpoNavigationBar.kt
@@ -24,7 +24,7 @@ fun RowScope.ExpoNavigationBarItem(
     onClick: () -> Unit,
     icon: @Composable () -> Unit,
     selectedIcon: @Composable () -> Unit = icon,
-    label: @Composable (() -> Unit)? = null,
+    label: @Composable () -> Unit,
     enabled: Boolean = true,
     alwaysShowLabel: Boolean = true
 ) {

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/navigation/ExpoNavigationBar.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/navigation/ExpoNavigationBar.kt
@@ -1,0 +1,115 @@
+package com.school_of_company.design_system.component.navigation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.R
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.design_system.theme.color.ExpoColor
+
+@Composable
+fun RowScope.ExpoNavigationBarItem(
+    modifier: Modifier = Modifier,
+    selected: Boolean,
+    onClick: () -> Unit,
+    icon: @Composable () -> Unit,
+    selectedIcon: @Composable () -> Unit = icon,
+    label: @Composable (() -> Unit)? = null,
+    enabled: Boolean = true,
+    alwaysShowLabel: Boolean = true
+) {
+    NavigationBarItem(
+        modifier = modifier,
+        selected = selected,
+        onClick = onClick,
+        label = label,
+        icon = if (selected) selectedIcon else icon,
+        enabled = enabled,
+        alwaysShowLabel = alwaysShowLabel,
+        colors = NavigationBarItemDefaults.colors(
+            selectedIconColor = ExpoColor.main,
+            unselectedIconColor = ExpoColor.gray500,
+            selectedTextColor = ExpoColor.main,
+            unselectedTextColor = ExpoColor.gray500,
+            indicatorColor = ExpoColor.white
+        )
+    )
+}
+
+@Composable
+fun ExpoNavigationBar(
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit
+) {
+    ExpoAndroidTheme { colors, _ ->
+        Column {
+            HorizontalDivider(
+                thickness = 1.dp,
+                color = colors.gray200
+            )
+            NavigationBar(
+                modifier = modifier,
+                containerColor = colors.white,
+                contentColor = colors.gray500,
+                tonalElevation = 0.dp,
+                content = content
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ExpoNavigationPreview() {
+    val items = listOf(
+        "홈",
+        "명단 관리",
+        "박람회 생성",
+        "프로필"
+    )
+    val icons = listOf(
+        R.drawable.ic_house,
+        R.drawable.ic_append,
+        R.drawable.ic_expo,
+        R.drawable.ic_user
+    )
+    ExpoAndroidTheme { colors, typography ->
+        ExpoNavigationBar {
+            items.forEachIndexed { index, item ->
+                ExpoNavigationBarItem(
+                    icon = {
+                        Icon(
+                            painter = painterResource(id = icons[index]),
+                            contentDescription = item
+                        )
+                    },
+                    selectedIcon = {
+                        Icon(
+                            painter = painterResource(id = icons[index]),
+                            contentDescription = item,
+                            tint = colors.main
+                        )
+                    },
+                    label = {
+                        Text(
+                            text = item,
+                            style = typography.captionRegular2
+                        )
+                    },
+                    selected = index == 0,
+                    onClick = {},
+                )
+            }
+        }
+    }
+}

--- a/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
@@ -231,3 +231,21 @@ fun ShortContentIcon(modifier: Modifier = Modifier) {
         modifier = modifier
     )
 }
+
+@Composable
+fun HomeIcon(modifier: Modifier = Modifier) {
+    Icon(
+        painter = painterResource(id = R.drawable.ic_house),
+        contentDescription = stringResource(id = R.string.home_description),
+        modifier = modifier
+    )
+}
+
+@Composable
+fun AppendIcon(modifier: Modifier = Modifier) {
+    Icon(
+        painter = painterResource(id = R.drawable.ic_append),
+        contentDescription = stringResource(id = R.string.append_description),
+        modifier = modifier
+    )
+}

--- a/core/design-system/src/main/java/com/school_of_company/design_system/theme/ExpoTheme.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/theme/ExpoTheme.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.design_system.theme
 
+import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
 import com.school_of_company.design_system.theme.color.ColorTheme
 import com.school_of_company.design_system.theme.color.ExpoColor
@@ -7,7 +8,7 @@ import com.school_of_company.design_system.theme.color.ExpoColor
 @Composable
 fun ExpoAndroidTheme(
     colors: ColorTheme = ExpoColor,
-    typography: ExpoTypography,
+    typography: ExpoTypography = ExpoTypography,
     content: @Composable (colors: ColorTheme, typography: ExpoTypography) -> Unit
 ) {
     content(colors, typography)

--- a/core/design-system/src/main/res/drawable/ic_append.xml
+++ b/core/design-system/src/main/res/drawable/ic_append.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M19.5,3h-2.3v-0.8a0.7,0.7 0,1 0,-1.4 0L15.8,3L8.2,3v-0.8a0.8,0.8 0,0 0,-1.4 0L6.8,3L4.5,3A1.5,1.5 0,0 0,3 4.5v15A1.5,1.5 0,0 0,4.5 21h15a1.5,1.5 0,0 0,1.5 -1.5v-15A1.5,1.5 0,0 0,19.5 3ZM6.7,4.5v0.8a0.8,0.8 0,0 0,1.5 0v-0.8h7.6v0.8a0.7,0.7 0,1 0,1.4 0v-0.8h2.3v3h-15v-3h2.3ZM19.5,19.5h-15L4.5,9h15v10.5ZM15.9,11.5a0.7,0.7 0,0 1,0 1L11.4,17a0.7,0.7 0,0 1,-1 0L8,14.8a0.8,0.8 0,1 1,1 -1l1.8,1.6 4,-4a0.7,0.7 0,0 1,1 0Z"
+      android:fillColor="#121212"/>
+</vector>

--- a/core/design-system/src/main/res/drawable/ic_house.xml
+++ b/core/design-system/src/main/res/drawable/ic_house.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M20.6,10.2 L13,2.7a1.5,1.5 0,0 0,-2.2 0l-7.5,7.5a1.5,1.5 0,0 0,-0.4 1v9a0.7,0.7 0,0 0,0.8 0.8h6a0.7,0.7 0,0 0,0.7 -0.8L10.4,15h3v5.3a0.7,0.7 0,0 0,0.8 0.7h6a0.7,0.7 0,0 0,0.7 -0.8v-9a1.5,1.5 0,0 0,-0.4 -1ZM19.5,19.5L15,19.5v-5.3a0.7,0.7 0,0 0,-0.8 -0.7L9.8,13.5a0.7,0.7 0,0 0,-0.8 0.8v5.2L4.5,19.5v-8.3L12,3.8l7.5,7.5v8.2Z"
+      android:fillColor="#121212"/>
+</vector>

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -25,4 +25,6 @@
     <string name="two_circle_description">질문 아이콘</string>
     <string name="long_content_description">장문 아이콘</string>
     <string name="short_content_description">단문 아이콘</string>
+    <string name="home_description">홈 아이콘</string>
+    <string name="append_description">출력 아이콘</string>
 </resources>


### PR DESCRIPTION
## 💡 개요
- 바텀네비게이션바가 디자인상에 있어 이를 구현해야할 것 같았습니다.
## 📃 작업내용
<img width="435" alt="스크린샷 2024-10-23 오후 6 15 47" src="https://github.com/user-attachments/assets/2de78572-7be7-467d-9f94-c875d1034254">

- 바텀네비게이션바를 구현하였습니다.
- 바텀네비게이션바에 필요한 아이콘을 추가하였습니다.
- ExpoAndroidTheme에 잘못 타입을 지정한 코드를 수정하여 에러를 잡았습니다.
## 🔀 변경사항
- chore strings.xml
- chore ExpoIcon
- chore ExpoAndroidTheme
- add ExpoNavigationBar
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이산한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- appState, app에서 각각의 아이콘에 Destination(목적지)를 설정하여 화면간 이동이 될 수 있도록 하고 Scaffold에 넣어 사용하면 됩니다.
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 내비게이션 바와 아이템을 위한 새로운 구성 요소 추가.
  - 홈 아이콘 및 추가 아이콘을 위한 새로운 아이콘 구성 요소 추가.
  
- **버그 수정**
  - `ExpoAndroidTheme` 함수에서 `typography` 매개변수에 기본값 추가로 사용 간소화.

- **문서화**
  - 새로운 문자열 리소스 추가: "홈 아이콘" 및 "출력 아이콘". 

- **스타일**
  - 새로운 벡터 드로어블 아이콘 추가: `ic_house` 및 `ic_append`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->