### PR TITLE
🔀 :: (#143) - TextField 컴포넌트 제작을 하였습니다.

### DIFF
--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 
 @Composable
-fun ExpoOutlineTextField(
+fun ExpoOutlinedTextField(
     modifier: Modifier = Modifier,
     label: String,
     value: String,

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 
 @Composable
-fun ExpoOutlinedTextField(
+fun ExpoOutlineTextField(
     modifier: Modifier = Modifier,
     label: String,
     value: String,

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
@@ -143,13 +143,13 @@ fun ErrorText(
 
 @Preview
 @Composable
-fun ExpoOutlinedTextField() {
+fun ExpoOutlinedTextFieldPreview() {
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(Color.White)
     ) {
-        Column(verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),) {
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top)) {
             ExpoOutlineTextField(
                 label = "아이디",
                 value = "",

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
@@ -1,0 +1,162 @@
+package com.school_of_company.design_system.component.textfield
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+fun ExpoOutlineTextField(
+    modifier: Modifier = Modifier,
+    label: String,
+    value: String,
+    isError: Boolean = false,
+    placeholder: String = "",
+    errorPlaceholder: String = "",
+    readOnly: Boolean = false,
+    focusManager: FocusManager = LocalFocusManager.current,
+    focusRequester: FocusRequester = FocusRequester(),
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    maxLines: Int = Int.MAX_VALUE,
+    singleLine: Boolean = false,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
+    onValueChange: (String) -> Unit = {},
+    maxLength: Int = Int.MAX_VALUE,
+) {
+    val isFocused = remember { mutableStateOf(false) }
+
+    ExpoAndroidTheme { colors, typography ->
+
+        DisposableEffect(Unit) {
+            onDispose {
+                focusManager.clearFocus()
+            }
+        }
+
+        Column{
+            Text(
+                text = label,
+                style = typography.bodyBold2,
+                fontWeight = FontWeight.Bold,
+                color = colors.black
+            )
+
+            Spacer(modifier = modifier.padding(bottom = 10.dp))
+
+            OutlinedTextField(
+                value = value,
+                onValueChange = {
+                    val filteredText = it.filterNot { text -> text.isWhitespace() }
+                    if (filteredText.length <= maxLength) {
+                        onValueChange(filteredText)
+                    }
+                },
+                placeholder = {
+                    if (isError) {
+                        ErrorText(text = errorPlaceholder)
+                    } else {
+                        Text(
+                            text = placeholder,
+                            style = typography.captionRegular1,
+                            fontWeight = FontWeight.Normal,
+                            color = colors.gray200
+                        )
+                    }
+                },
+                maxLines = maxLines,
+                singleLine = singleLine,
+                keyboardActions = keyboardActions,
+                keyboardOptions = keyboardOptions,
+                readOnly = readOnly,
+                visualTransformation = visualTransformation,
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedTextColor = if (isError) colors.error else colors.black,
+                    unfocusedTextColor = if (isError) colors.error else colors.black,
+                    focusedPlaceholderColor = if (isError) colors.error else colors.gray200,
+                    unfocusedPlaceholderColor = if (isError) colors.error else colors.gray200,
+                    focusedBorderColor = Color.Transparent,
+                    unfocusedBorderColor = Color.Transparent,
+                    cursorColor = colors.gray400
+                ),
+                modifier = modifier
+                    .fillMaxWidth()
+                    .height(55.dp)
+                    .focusRequester(focusRequester)
+                    .clip(RoundedCornerShape(6.dp))
+                    .border(
+                        width = 1.dp,
+                        color = if (isError) colors.error else colors.gray100,
+                        shape = RoundedCornerShape(6.dp)
+                    )
+                    .background(colors.white)
+                    .onFocusChanged { isFocused.value = it.isFocused }
+            )
+        }
+    }
+}
+
+@Composable
+fun ErrorText(
+    text: String,
+) {
+    ExpoAndroidTheme { colors, typography ->
+        Text(
+            text = text,
+            color = colors.error,
+            style = typography.captionRegular1,
+            fontWeight = FontWeight.Normal
+        )
+    }
+}
+
+
+@Preview
+@Composable
+fun ExpoOutlinedTextField() {
+    Column(verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),) {
+        ExpoOutlineTextField(
+            label = "아이디",
+            value = "",
+            onValueChange = {},
+            placeholder = "아이디를 입력해주세요",
+        )
+        ExpoOutlineTextField(
+            label = "로그인",
+            value = "",
+            onValueChange = {},
+            placeholder = "아이디를 입력해주세요.",
+            errorPlaceholder = "아이디를 잘못입력했습니다.",
+            isError = true
+        )
+    }
+}

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
@@ -3,8 +3,10 @@ package com.school_of_company.design_system.component.textfield
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -142,20 +144,26 @@ fun ErrorText(
 @Preview
 @Composable
 fun ExpoOutlinedTextField() {
-    Column(verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),) {
-        ExpoOutlineTextField(
-            label = "아이디",
-            value = "",
-            onValueChange = {},
-            placeholder = "아이디를 입력해주세요",
-        )
-        ExpoOutlineTextField(
-            label = "로그인",
-            value = "",
-            onValueChange = {},
-            placeholder = "아이디를 입력해주세요.",
-            errorPlaceholder = "아이디를 잘못입력했습니다.",
-            isError = true
-        )
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.Top),) {
+            ExpoOutlineTextField(
+                label = "아이디",
+                value = "",
+                onValueChange = {},
+                placeholder = "아이디를 입력해주세요",
+            )
+            ExpoOutlineTextField(
+                label = "로그인",
+                value = "",
+                onValueChange = {},
+                placeholder = "아이디를 입력해주세요.",
+                errorPlaceholder = "아이디를 잘못입력했습니다.",
+                isError = true
+            )
+        }
     }
 }


### PR DESCRIPTION
## 💡 개요
- TextField 컴포넌트 제작이 필요해보였습니다.
## 📃 작업내용
- TextField 컴포넌트 제작을 하였습니다.
<img width="599" alt="스크린샷 2024-10-24 오후 2 40 16" src="https://github.com/user-attachments/assets/9cfcbbde-9a9f-46f0-bc1f-797e9f2b371d">

## 🔀 변경사항
- add ExpoOutlinedTextField
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이산한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
<img width="592" alt="스크린샷 2024-10-24 오후 2 39 32" src="https://github.com/user-attachments/assets/188f28a0-af1b-453e-9d0e-2e489f6b143a">

## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- Jetpack Compose UI에서 사용할 수 있는 커스터마이즈 가능한 아웃라인 텍스트 필드 컴포넌트 추가.
	- 실시간 입력 유효성 검사를 지원하며, 오류 상태에 대한 시각적 피드백 제공.
	- 오류 메시지를 일관된 스타일로 표시하는 기능 추가.
	- 텍스트 필드의 미리보기 기능 제공.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->