### PR TITLE
🔀 :: (#147) - apply navigation bar design

### DIFF
--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
@@ -60,7 +60,7 @@ fun ExpoButton(
 @Composable
 private fun ExpoButtonPreview() {
     val isPositiveActionDialogVisible = remember { mutableStateOf(false) }
-    
+
     Column {
         ExpoButton(
             modifier = Modifier

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/navigation/ExpoNavigationBar.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/navigation/ExpoNavigationBar.kt
@@ -73,15 +73,17 @@ fun ExpoNavigationBar(
 fun ExpoNavigationPreview() {
     val items = listOf(
         "홈",
+        "프로그램",
         "명단 관리",
         "박람회 생성",
-        "프로필"
+        "프로필",
     )
     val icons = listOf(
         R.drawable.ic_house,
+        R.drawable.ic_program,
         R.drawable.ic_append,
         R.drawable.ic_expo,
-        R.drawable.ic_user
+        R.drawable.ic_user,
     )
     ExpoAndroidTheme { colors, typography ->
         ExpoNavigationBar {

--- a/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
@@ -249,3 +249,12 @@ fun AppendIcon(modifier: Modifier = Modifier) {
         modifier = modifier
     )
 }
+
+@Composable
+fun ProgramIcon(modifier: Modifier = Modifier) {
+    Icon(
+        painter = painterResource(id = R.drawable.ic_program),
+        contentDescription = stringResource(id = R.string.program_description),
+        modifier = modifier
+    )
+}

--- a/core/design-system/src/main/res/drawable/ic_program.xml
+++ b/core/design-system/src/main/res/drawable/ic_program.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M6.5,8.8 L2.7,12l3.8,3.2a0.7,0.7 0,1 1,-1 1.1L1,12.6a0.7,0.7 0,0 1,0 -1.2l4.5,-3.7a0.8,0.8 0,0 1,1 1.1ZM23,11.4l-4.5,-3.7a0.7,0.7 0,1 0,-1 1.1l3.8,3.2 -3.8,3.2a0.7,0.7 0,0 0,0.7 1.3l0.3,-0.2 4.5,-3.7a0.8,0.8 0,0 0,0 -1.2ZM15.3,3a0.7,0.7 0,0 0,-1 0.5L8.3,20a0.7,0.7 0,1 0,1.4 0.5l6,-16.5a0.7,0.7 0,0 0,-0.4 -1Z"
+      android:fillColor="#000"/>
+</vector>

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="short_content_description">단문 아이콘</string>
     <string name="home_description">홈 아이콘</string>
     <string name="append_description">출력 아이콘</string>
+    <string name="program_description">프로그래밍 아이콘</string>
 
     <string name="close_app">\'뒤로\'버튼 한번 더 누르시면 종료됩니다.</string>
     <string name="error_for_bidden">학생회 권한인 학생만 요청 가능해요</string>


### PR DESCRIPTION
## 💡 개요
- 디자인이 변경된 부분을 수용합니다.
## 📃 작업내용
- 네비게이션바가 수정된 부분을 수용합니다.
<img width="416" alt="스크린샷 2024-10-24 오후 5 43 11" src="https://github.com/user-attachments/assets/60859fce-5681-44a7-b782-98735774c7f0">

## 🔀 변경사항
- chore ExpoIcon
- chore strings.xml
- add program Icon svg File
- chore ExpoNavigationBar
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이산한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 내비게이션 바에 "프로그램" 항목과 아이콘 추가.
	- 새로운 아이콘 `ProgramIcon` 추가로 아이콘 선택의 다양성 확대.
- **버그 수정**
	- `ExpoButtonPreview`에서 불필요한 빈 줄 제거.
- **문서화**
	- 새로운 문자열 리소스 "프로그래밍 아이콘" 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->