### PR TITLE
🔀 :: (#149) - TopBar 컴포넌트를 제작해 재사용 할 수 있게 합니다.

### DIFF
--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/text/ExpoSubjectBodyText.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/text/ExpoSubjectBodyText.kt
@@ -1,0 +1,19 @@
+package com.school_of_company.design_system.component.text
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+fun ExpoSubjectTitleText(subjectText: String, ) {
+    ExpoAndroidTheme { colors, typography ->
+        Column {
+            Text(
+                text = subjectText,
+                color = colors.black,
+                style = typography.bodyBold1,
+            )
+        }
+    }
+}

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/text/ExpoSubjectBodyText.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/text/ExpoSubjectBodyText.kt
@@ -6,14 +6,12 @@ import androidx.compose.runtime.Composable
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 
 @Composable
-fun ExpoSubjectTitleText(subjectText: String, ) {
+fun ExpoSubjectTitleText(subjectText: String) {
     ExpoAndroidTheme { colors, typography ->
-        Column {
-            Text(
-                text = subjectText,
-                color = colors.black,
-                style = typography.bodyBold1,
-            )
-        }
+        Text(
+            text = subjectText,
+            color = colors.black,
+            style = typography.bodyBold1,
+        )
     }
 }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/topbar/ExpoTopBar.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/topbar/ExpoTopBar.kt
@@ -1,14 +1,18 @@
 package com.school_of_company.design_system.component.topbar
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.component.text.ExpoSubjectTitleText
@@ -43,8 +47,14 @@ fun ExpoTopBar(
 @Preview
 @Composable
 private fun ExpoTopBarPreview() {
-    ExpoTopBar(
-        startIcon = { LeftArrowIcon() },
-        betweenText = "2024 AI광주미래교육박람회"
-    )
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        ExpoTopBar(
+            startIcon = { LeftArrowIcon() },
+            betweenText = "2024 AI광주미래교육박람회"
+        )
+    }
 }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/topbar/ExpoTopBar.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/topbar/ExpoTopBar.kt
@@ -24,9 +24,9 @@ fun ExpoTopBar(
     modifier: Modifier = Modifier,
     startIcon: @Composable () -> Unit,
     betweenText: String = "",
-    endIcon: @Composable () -> Unit = { Spacer(modifier = modifier.size(24.dp)) }
+    endIcon: @Composable () -> Unit = { Spacer(modifier = Modifier.size(24.dp)) }
 ) {
-    ExpoAndroidTheme { colors, typography ->
+    ExpoAndroidTheme { _, _ ->
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/topbar/ExpoTopBar.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/topbar/ExpoTopBar.kt
@@ -1,0 +1,50 @@
+package com.school_of_company.design_system.component.topbar
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.component.text.ExpoSubjectTitleText
+import com.school_of_company.design_system.icon.LeftArrowIcon
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+fun ExpoTopBar(
+    modifier: Modifier = Modifier,
+    startIcon: @Composable () -> Unit,
+    betweenText: String = "",
+    endIcon: @Composable () -> Unit = { Spacer(modifier = modifier.size(24.dp)) }
+) {
+    ExpoAndroidTheme { colors, typography ->
+        Row(
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = 24.dp,
+                    vertical = 15.dp
+                )
+        ) {
+            startIcon()
+            ExpoSubjectTitleText(subjectText = betweenText)
+            endIcon()
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ExpoTopBarPreview() {
+    ExpoTopBar(
+        startIcon = { LeftArrowIcon() },
+        betweenText = "2024 AI광주미래교육박람회"
+    )
+}


### PR DESCRIPTION
## 💡 개요
- TopBar 컴포넌트를 제작하여 재사용하면 좋을 것 같다는 생각을 해보았습니다.
## 📃 작업내용
- TopBar 컴포넌트를 제작하여 재사용성을 높였습니다.
<img width="435" alt="스크린샷 2024-10-24 오후 6 26 24" src="https://github.com/user-attachments/assets/dbe9e374-4d76-42b6-ad9f-3f24e3aa6750">

## 🔀 변경사항
- add ExpoSubBodyText
- add ExpoTopBar
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이산한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
<img width="409" alt="스크린샷 2024-10-24 오후 6 25 02" src="https://github.com/user-attachments/assets/21a54923-5802-40e9-a72d-e4fad427fded">

## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- `ExpoSubjectTitleText` 함수 추가: 주제 텍스트를 표시하는 구성 요소로, 일관된 테마와 스타일을 제공합니다.
	- `ExpoTopBar` 함수 추가: 상단 바 레이아웃을 구성하며, 아이콘과 텍스트를 수평으로 배치합니다.
	- `ExpoTopBarPreview` 미리보기 기능 추가: 상단 바의 시각적 표현을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->