### PR TITLE
🔀 ::  (#184) - 박람회 상세보기 화면을 퍼블리싱하였습니다.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,5 @@ fabric.properties
 !/gradle/wrapper/gradle-wrapper.jar
 
 # End of https://www.toptal.com/developers/gitignore/api/androidstudio,windows,macos,android
+
+core/design-system/src/main/res/values/expo_app_key.xml

--- a/.gitignore
+++ b/.gitignore
@@ -223,4 +223,3 @@ fabric.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/androidstudio,windows,macos,android
 
-core/design-system/src/main/res/values/expo_app_key.xml

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,10 +1,25 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     id("expo.android.application")
     id("expo.android.hilt")
 }
 
 android {
-    namespace = "com.school_of_company.expo_android"
+
+    buildFeatures {
+        buildConfig = true
+    }
+
+    defaultConfig {
+        buildConfigField(
+            "String",
+            "NATIVE_APP_KEY",
+            getApiKey("NATIVE_APP_KEY")
+        )
+    }
+
 
     packaging {
         resources {
@@ -12,6 +27,8 @@ android {
             excludes += "META-INF/DEPENDENCIES"
         }
     }
+
+    namespace = "com.school_of_company.expo_android"
 }
 
 dependencies {
@@ -29,4 +46,13 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext)
     implementation(libs.app.update.ktx)
+
+    implementation(libs.android.kakao.map)
+}
+
+fun getApiKey(propertyKey: String) : String {
+    val propFile = rootProject.file("./local.properties")
+    val properties = Properties()
+    properties.load(FileInputStream(propFile))
+    return properties.getProperty(propertyKey) ?: throw IllegalArgumentException("Property $propertyKey not found in local.properties")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
     <application
         android:name=".ExpoApplication"
@@ -14,6 +17,11 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.App.Starting"
         tools:targetApi="31">
+
+        <meta-data
+            android:name="com.kakao.sdk.AppKey"
+            android:value="@string/app_key" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/school_of_company/expo_android/ExpoApplication.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/ExpoApplication.kt
@@ -1,7 +1,21 @@
 package com.school_of_company.expo_android
 
 import android.app.Application
+import com.kakao.vectormap.KakaoMapSdk
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
+import javax.inject.Named
 
 @HiltAndroidApp
-class ExpoApplication : Application()
+class ExpoApplication : Application() {
+
+    @Inject
+    @Named("NATIVE_APP_KEY")
+    lateinit var nativeAppKey: String
+
+    override fun onCreate() {
+        super.onCreate()
+
+        KakaoMapSdk.init(this, nativeAppKey)
+    }
+}

--- a/app/src/main/java/com/school_of_company/expo_android/di/AppConfigModule.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/di/AppConfigModule.kt
@@ -1,0 +1,17 @@
+package com.msg.bitgoeul_android.di
+
+import com.school_of_company.expo_android.BuildConfig
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Named
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppConfigModule {
+
+    @Provides
+    @Named("NATIVE_APP_KEY")
+    fun provideNativeAppKey(): String = BuildConfig.NATIVE_APP_KEY
+}

--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -109,7 +109,12 @@ fun ExpoNavHost(
         )
 
         homeDetailScreen(
-            onBackClick = navController::popBackStack
+            onBackClick = navController::popBackStack,
+            onMessageClick = {},
+            onCheckClick = {},
+            onQrGenerateClick = {},
+            onModifyClick = {},
+            onProgramClick = {}
         )
     }
 }

--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -11,8 +11,10 @@ import androidx.navigation.compose.NavHost
 import com.school_of_company.common.exception.*
 import com.school_of_company.design_system.R
 import com.school_of_company.expo_android.ui.ExpoAppState
+import com.school_of_company.home.navigation.homeDetailScreen
 import com.school_of_company.home.navigation.homeScreen
 import com.school_of_company.home.navigation.navigateToHome
+import com.school_of_company.home.navigation.navigateToHomeDetail
 import com.school_of_company.navigation.navigateToSignIn
 import com.school_of_company.navigation.sigInRoute
 import com.school_of_company.navigation.signInScreen
@@ -103,7 +105,11 @@ fun ExpoNavHost(
         )
 
         homeScreen(
-            navigationToDetail = { /* todo : navigateToDetail */ }
+            navigationToDetail = navController::navigateToHomeDetail
+        )
+
+        homeDetailScreen(
+            onBackClick = navController::popBackStack
         )
     }
 }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
@@ -126,6 +126,35 @@ fun ExpoEnableButton(
     }
 }
 
+@Composable
+fun ExpoEnableDetailButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    onClick: () -> Unit,
+) {
+    ExpoAndroidTheme { colors, typography ->
+
+        val interactionSource = remember { MutableInteractionSource() }
+
+        Button(
+            modifier = modifier,
+            interactionSource = interactionSource,
+            contentPadding = PaddingValues(vertical = 16.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = colors.main100,
+                contentColor = colors.main,
+            ),
+            shape = RoundedCornerShape(6.dp),
+            onClick = onClick,
+        ) {
+            Text(
+                text = text,
+                style = typography.bodyBold2,
+                color = colors.main
+            )
+        }
+    }
+}
 
 @Preview
 @Composable

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -90,6 +91,36 @@ fun ExpoStateButton(
             Text(
                 text = text,
                 style = typography.bodyBold2
+            )
+        }
+    }
+}
+
+@Composable
+fun ExpoEnableButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    onClick: () -> Unit,
+) {
+    ExpoAndroidTheme { colors, typography ->
+
+        val interactionSource = remember { MutableInteractionSource() }
+
+        Button(
+            modifier = modifier,
+            interactionSource = interactionSource,
+            contentPadding = PaddingValues(vertical = 16.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = colors.white,
+                contentColor = colors.white,
+            ),
+            shape = RoundedCornerShape(6.dp),
+            onClick = onClick,
+        ) {
+            Text(
+                text = text,
+                style = typography.bodyBold2,
+                color = colors.main
             )
         }
     }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/text/ExpoSubjectBodyText.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/text/ExpoSubjectBodyText.kt
@@ -1,8 +1,8 @@
 package com.school_of_company.design_system.component.text
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.style.TextOverflow
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 
 @Composable
@@ -12,6 +12,8 @@ fun ExpoSubjectTitleText(subjectText: String) {
             text = subjectText,
             color = colors.black,
             style = typography.bodyBold1,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/topbar/ExpoTopBar.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/topbar/ExpoTopBar.kt
@@ -30,15 +30,12 @@ fun ExpoTopBar(
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(
-                    horizontal = 24.dp,
-                    vertical = 15.dp
-                )
+            modifier = modifier.fillMaxWidth()
         ) {
             startIcon()
-            ExpoSubjectTitleText(subjectText = betweenText)
+            ExpoSubjectTitleText(
+                subjectText = betweenText
+            )
             endIcon()
         }
     }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
@@ -272,3 +272,16 @@ fun ProgramIcon(modifier: Modifier = Modifier) {
         modifier = modifier
     )
 }
+
+@Composable
+fun LocationIcon(
+    modifier: Modifier = Modifier,
+    tint: Color = Color.Unspecified
+) {
+    Icon(
+        painter = painterResource(id = R.drawable.ic_location),
+        contentDescription = stringResource(id = R.string.location_icon_description),
+        modifier = modifier,
+        tint = tint
+    )
+}

--- a/core/design-system/src/main/res/drawable/ic_location.xml
+++ b/core/design-system/src/main/res/drawable/ic_location.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="40"
+    android:viewportHeight="40">
+  <path
+      android:pathData="M12,6a3.7,3.7 0,1 0,0 7.5A3.7,3.7 0,0 0,12 6ZM12,12a2.3,2.3 0,1 1,0 -4.5,2.3 2.3,0 0,1 0,4.5ZM12,1.5a8.3,8.3 0,0 0,-8.3 8.3c0,2.9 1.4,6 4,9 1.1,1.3 2.4,2.5 3.9,3.6a0.8,0.8 0,0 0,0.8 0c1.5,-1 2.8,-2.3 4,-3.6 2.5,-3 3.9,-6.1 3.9,-9A8.3,8.3 0,0 0,12 1.4ZM12,20.8c-1.5,-1.2 -6.8,-5.7 -6.8,-11a6.8,6.8 0,0 1,13.6 0c0,5.3 -5.3,9.8 -6.8,11Z"
+      android:fillColor="#121212"/>
+</vector>

--- a/core/design-system/src/main/res/values/expo_app_key.xml
+++ b/core/design-system/src/main/res/values/expo_app_key.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_key">f0cb1da9a6984d34cc007b51044dea48</string>
+</resources>

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="append_description">출력 아이콘</string>
     <string name="program_description">프로그래밍 아이콘</string>
     <string name="HomeScreen_Image_description">홈스크린 리스트 이미지</string>
+    <string name="location_icon_description">위치 아이콘</string>
 
     <string name="close_app">\'뒤로\'버튼 한번 더 누르시면 종료됩니다.</string>
     <string name="error_for_bidden">학생회 권한인 학생만 요청 가능해요</string>

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -9,4 +9,5 @@ android {
 
 dependencies {
     implementation(libs.coil.kt)
+    implementation(libs.android.kakao.map)
 }

--- a/feature/home/src/main/AndroidManifest.xml
+++ b/feature/home/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission android:name="android.permission.INTERNET" />
+
 </manifest>

--- a/feature/home/src/main/java/com/school_of_company/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/navigation/HomeNavigation.kt
@@ -4,12 +4,18 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.school_of_company.home.view.HomeDetailRoute
 import com.school_of_company.home.view.HomeRoute
 
 const val homeRoute = "home_route"
+const val homeDetailRoute=  "home_detail_route"
 
 fun NavController.navigateToHome(navOptions: NavOptions? = null) {
     this.navigate(homeRoute, navOptions)
+}
+
+fun NavController.navigateToHomeDetail(navOptions: NavOptions? = null) {
+    this.navigate(homeDetailRoute, navOptions)
 }
 
 fun NavGraphBuilder.homeScreen(
@@ -19,5 +25,13 @@ fun NavGraphBuilder.homeScreen(
         HomeRoute(
             navigationToDetail = navigationToDetail
         )
+    }
+}
+
+fun NavGraphBuilder.homeDetailScreen(
+    onBackClick: () -> Unit
+) {
+    composable(route = homeDetailRoute) {
+        HomeDetailRoute(onBackClick = onBackClick)
     }
 }

--- a/feature/home/src/main/java/com/school_of_company/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/navigation/HomeNavigation.kt
@@ -29,9 +29,21 @@ fun NavGraphBuilder.homeScreen(
 }
 
 fun NavGraphBuilder.homeDetailScreen(
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    onMessageClick: () -> Unit,
+    onCheckClick: () -> Unit,
+    onQrGenerateClick: () -> Unit,
+    onModifyClick: () -> Unit,
+    onProgramClick: () -> Unit
 ) {
     composable(route = homeDetailRoute) {
-        HomeDetailRoute(onBackClick = onBackClick)
+        HomeDetailRoute(
+            onBackClick = onBackClick,
+            onMessageClick = onMessageClick,
+            onCheckClick = onCheckClick,
+            onQrGenerateClick = onQrGenerateClick,
+            onModifyClick = onModifyClick,
+            onProgramClick = onProgramClick
+        )
     }
 }

--- a/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailScreen.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailScreen.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -31,6 +33,7 @@ import coil.compose.rememberAsyncImagePainter
 import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.button.ExpoButton
 import com.school_of_company.design_system.component.button.ExpoEnableButton
+import com.school_of_company.design_system.component.button.ExpoEnableDetailButton
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.component.modifier.padding.paddingVertical
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
@@ -43,7 +46,12 @@ import com.school_of_company.ui.util.formatServerDate
 
 @Composable
 internal fun HomeDetailRoute(
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    onMessageClick: () -> Unit,
+    onCheckClick: () -> Unit,
+    onQrGenerateClick: () -> Unit,
+    onModifyClick: () -> Unit,
+    onProgramClick: () -> Unit
 ) {
     HomeDetailScreen(
         data = HomeTempData(
@@ -53,7 +61,12 @@ internal fun HomeDetailRoute(
             title = "2024 AI 광주 미래교육",
             content = "2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육"
         ),
-        onBackClick = onBackClick
+        onBackClick = onBackClick,
+        onMessageClick = onMessageClick,
+        onCheckClick = onCheckClick,
+        onQrGenerateClick = onQrGenerateClick,
+        onModifyClick = onModifyClick,
+        onProgramClick = onProgramClick
     )
 }
 
@@ -63,7 +76,15 @@ internal fun HomeDetailScreen(
     scrollState: ScrollState = rememberScrollState(),
     data: HomeTempData,
     onBackClick: () -> Unit,
+    onMessageClick: () -> Unit,
+    onCheckClick: () -> Unit,
+    onQrGenerateClick: () -> Unit,
+    onModifyClick: () -> Unit,
+    onProgramClick: () -> Unit
 ) {
+    val (openDialog, isOpenDialog) = rememberSaveable { mutableStateOf(false) }
+    val (openQrDialog, isOpenQrDialog) = rememberSaveable { mutableStateOf(false) }
+
     ExpoAndroidTheme { colors, typography ->
         Column(
             modifier = modifier
@@ -84,7 +105,7 @@ internal fun HomeDetailScreen(
 
             Spacer(modifier = Modifier.height(28.dp))
 
-            Column(modifier = Modifier.verticalScroll(scrollState)) {
+            Column(modifier = Modifier.verticalScroll(scrollState)){
                 Image(
                     painter = rememberAsyncImagePainter(model = data.image),
                     contentDescription = stringResource(id = R.string.HomeScreen_Image_description),
@@ -113,17 +134,7 @@ internal fun HomeDetailScreen(
                     Text(
                         text = "안녕하세요!\n" +
                                 "2024 AI광주미래교육박람회 사전 등록 페이지에 오신 것을 환영합니다.\n" +
-                                "아래 양식을 작성해주시면 등록이 완료됩니다.\n" +
-                                "많은 관심과 참여 부탁드립니다\n\n\n" +
-                                "연수 종류" +
-                                "\n" +
-                                "\n" +
-                                "- 내가 경험한 AI 광주미래교육\n" +
-                                "- AI 팩토리 수업 시연\n" +
-                                "- Google for Education\n" +
-                                "\n" +
-                                "장소\n" +
-                                "광주 소프트웨어 마이스터고등학교",
+                                "아래 양식을 작성해주시면 등록이 완료됩니다.",
                         style = typography.bodyRegular2,
                         color = colors.gray400
                     )
@@ -151,11 +162,37 @@ internal fun HomeDetailScreen(
                 Spacer(modifier = Modifier.height(18.dp))
 
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Bottom)) {
+
+                    Text(
+                        text = "연수",
+                        style = typography.bodyRegular2,
+                        color = colors.gray600,
+                        fontWeight = FontWeight(600),
+                    )
+
+                    Text(
+                        text = "안녕하세요!\n" +
+                                "2024 AI광주미래교육박람회 사전 등록 페이지에 오신 것을 환영합니다.\n" +
+                                "아래 양식을 작성해주시면 등록이 완료됩니다.",
+                        style = typography.bodyRegular2,
+                        color = colors.gray400
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(18.dp))
+
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Bottom)) {
                     Text(
                         text = "장소 지도",
                         style = typography.bodyRegular2,
                         color = colors.gray600,
                         fontWeight = FontWeight(600),
+                    )
+
+                    Text(
+                        text = "장소 : 광주소프트웨어마이스터고등학교",
+                        style = typography.bodyRegular2,
+                        color = colors.gray400,
                     )
 
                     Text(
@@ -177,55 +214,76 @@ internal fun HomeDetailScreen(
                     )
                 }
 
-                Spacer(
-                    modifier = Modifier.weight(1f))
+                Spacer(modifier = Modifier.weight(1f))
 
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 38.dp)
-                ) {
-                    ExpoButton(
-                        text = "문자 보내기",
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top),) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(
+                            16.dp,
+                            Alignment.CenterHorizontally
+                        ),
+                        verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier
-                            .weight(1f)
-                            .padding(
-                                vertical = 15.dp,
-                                horizontal = 41.5.dp
-                            )
-
+                            .fillMaxWidth()
+                            .padding(top = 38.dp)
                     ) {
+                        ExpoButton(
+                            text = "문자 보내기",
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(
+                                    vertical = 15.dp,
+                                    horizontal = 41.5.dp
+                                )
+                        ) { onMessageClick() }
 
+                        ExpoButton(
+                            text = "QR 조회하기",
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(
+                                    vertical = 15.dp,
+                                    horizontal = 37.dp
+                                )
+                        ) { onQrGenerateClick() }
                     }
 
-                    ExpoButton(
-                        text = "QR 생성하기",
+                    ExpoEnableDetailButton(
+                        text = "프로그램",
+                        onClick = onProgramClick,
                         modifier = Modifier
-                            .weight(1f)
-                            .padding(
-                                vertical = 15.dp,
-                                horizontal = 37.dp
+                            .fillMaxWidth()
+                            .border(
+                                width = 1.dp,
+                                color = colors.main,
+                                shape = RoundedCornerShape(6.dp)
                             )
-                    ) {
+                    )
 
-                    }
+                    ExpoEnableDetailButton(
+                        text = "조회하기",
+                        onClick = onCheckClick,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .border(
+                                width = 1.dp,
+                                color = colors.main,
+                                shape = RoundedCornerShape(6.dp)
+                            )
+                    )
+
+                    ExpoEnableButton(
+                        text = "수정하기",
+                        onClick = onModifyClick,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .border(
+                                width = 1.dp,
+                                color = colors.main,
+                                shape = RoundedCornerShape(6.dp)
+                            )
+                    )
                 }
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                ExpoEnableButton(
-                    text = "수정하기",
-                    onClick = {},
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .border(
-                            width = 1.dp,
-                            color = colors.main,
-                            shape = RoundedCornerShape(6.dp)
-                        )
-                )
 
                 Spacer(modifier = Modifier.padding(bottom = 28.dp))
             }
@@ -245,6 +303,11 @@ private fun HomeDetailScreenPreview() {
             content = "2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육"
         ),
         scrollState = ScrollState(0),
-        onBackClick = {}
+        onBackClick = {},
+        onMessageClick = {},
+        onCheckClick = {},
+        onQrGenerateClick = {},
+        onModifyClick = {},
+        onProgramClick = {}
     )
 }

--- a/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailScreen.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailScreen.kt
@@ -1,0 +1,250 @@
+package com.school_of_company.home.view
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.school_of_company.design_system.R
+import com.school_of_company.design_system.component.button.ExpoButton
+import com.school_of_company.design_system.component.button.ExpoEnableButton
+import com.school_of_company.design_system.component.modifier.clickable.expoClickable
+import com.school_of_company.design_system.component.modifier.padding.paddingVertical
+import com.school_of_company.design_system.component.topbar.ExpoTopBar
+import com.school_of_company.design_system.icon.LeftArrowIcon
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.home.view.component.HomeKakaoMap
+import com.school_of_company.home.view.component.HomeTempData
+import com.school_of_company.ui.preview.ExpoPreviews
+import com.school_of_company.ui.util.formatServerDate
+
+@Composable
+internal fun HomeDetailRoute(
+    onBackClick: () -> Unit
+) {
+    HomeDetailScreen(
+        data = HomeTempData(
+            image = "https://image.dongascience.com/Photo/2019/12/fb4f7da04758d289a466f81478f5f488.jpg",
+            started_at = "09-01",
+            ended_at = "09-30",
+            title = "2024 AI 광주 미래교육",
+            content = "2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육"
+        ),
+        onBackClick = onBackClick
+    )
+}
+
+@Composable
+internal fun HomeDetailScreen(
+    modifier: Modifier = Modifier,
+    scrollState: ScrollState = rememberScrollState(),
+    data: HomeTempData,
+    onBackClick: () -> Unit,
+) {
+    ExpoAndroidTheme { colors, typography ->
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .background(color = colors.white)
+                .padding(horizontal = 16.dp)
+        ) {
+            ExpoTopBar(
+                startIcon = {
+                    LeftArrowIcon(
+                        tint = colors.black,
+                        modifier = Modifier.expoClickable { onBackClick() }
+                    )
+                },
+                betweenText = data.title,
+                modifier = Modifier.padding(top = 50.dp)
+            )
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            Column(modifier = Modifier.verticalScroll(scrollState)) {
+                Image(
+                    painter = rememberAsyncImagePainter(model = data.image),
+                    contentDescription = stringResource(id = R.string.HomeScreen_Image_description),
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(178.dp)
+                        .clip(RoundedCornerShape(6.dp))
+                        .border(
+                            width = 1.dp,
+                            color = colors.gray200,
+                            shape = RoundedCornerShape(size = 6.dp)
+                        )
+                )
+
+                Spacer(modifier = Modifier.height(18.dp))
+
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Bottom)) {
+                    Text(
+                        text = "소개 글",
+                        style = typography.bodyRegular2,
+                        color = colors.gray600,
+                        fontWeight = FontWeight(600),
+                    )
+
+                    Text(
+                        text = "안녕하세요!\n" +
+                                "2024 AI광주미래교육박람회 사전 등록 페이지에 오신 것을 환영합니다.\n" +
+                                "아래 양식을 작성해주시면 등록이 완료됩니다.\n" +
+                                "많은 관심과 참여 부탁드립니다\n\n\n" +
+                                "연수 종류" +
+                                "\n" +
+                                "\n" +
+                                "- 내가 경험한 AI 광주미래교육\n" +
+                                "- AI 팩토리 수업 시연\n" +
+                                "- Google for Education\n" +
+                                "\n" +
+                                "장소\n" +
+                                "광주 소프트웨어 마이스터고등학교",
+                        style = typography.bodyRegular2,
+                        color = colors.gray400
+                    )
+
+                    Row(horizontalArrangement = Arrangement.spacedBy(11.dp, Alignment.Start)) {
+
+                        Text(
+                            text = stringResource(id = R.string.register_temp),
+                            style = typography.captionRegular2,
+                            color = colors.gray600
+                        )
+
+                        Text(
+                            text = stringResource(
+                                R.string.date_type,
+                                data.started_at.formatServerDate(),
+                                data.ended_at.formatServerDate()
+                            ),
+                            style = typography.captionRegular2,
+                            color = colors.gray600,
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(18.dp))
+
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Bottom)) {
+                    Text(
+                        text = "장소 지도",
+                        style = typography.bodyRegular2,
+                        color = colors.gray600,
+                        fontWeight = FontWeight(600),
+                    )
+
+                    Text(
+                        text = "주소 : 광주광역시 광산구 상무대로 312",
+                        style = typography.bodyRegular2,
+                        color = colors.gray400,
+                    )
+
+                    HomeKakaoMap(
+                        locationY = 126.80042860412009,
+                        locationX = 35.14308063423194,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .border(
+                                width = 1.dp,
+                                color = colors.gray200,
+                                shape = RoundedCornerShape(6.dp)
+                            )
+                    )
+                }
+
+                Spacer(
+                    modifier = Modifier.weight(1f))
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 38.dp)
+                ) {
+                    ExpoButton(
+                        text = "문자 보내기",
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(
+                                vertical = 15.dp,
+                                horizontal = 41.5.dp
+                            )
+
+                    ) {
+
+                    }
+
+                    ExpoButton(
+                        text = "QR 생성하기",
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(
+                                vertical = 15.dp,
+                                horizontal = 37.dp
+                            )
+                    ) {
+
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                ExpoEnableButton(
+                    text = "수정하기",
+                    onClick = {},
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .border(
+                            width = 1.dp,
+                            color = colors.main,
+                            shape = RoundedCornerShape(6.dp)
+                        )
+                )
+
+                Spacer(modifier = Modifier.padding(bottom = 28.dp))
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun HomeDetailScreenPreview() {
+    HomeDetailScreen(
+        data = HomeTempData(
+            image = "https://image.dongascience.com/Photo/2019/12/fb4f7da04758d289a466f81478f5f488.jpg",
+            started_at = "09-01",
+            ended_at = "09-30",
+            title = "2024 AI 광주 미래교육",
+            content = "2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육"
+        ),
+        scrollState = ScrollState(0),
+        onBackClick = {}
+    )
+}

--- a/feature/home/src/main/java/com/school_of_company/home/view/HomeScreen.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/HomeScreen.kt
@@ -102,7 +102,8 @@ internal fun HomeScreen(
 
             HomeList(
                 item = arrayItems,
-                modifier = Modifier.expoClickable { navigationToDetail() }
+                emptyList = false,
+                navigateToHomeDetail = navigationToDetail
             )
         }
     }

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/HomeKakaoMapComponent.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/HomeKakaoMapComponent.kt
@@ -1,0 +1,67 @@
+package com.school_of_company.home.view.component
+
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.kakao.vectormap.KakaoMap
+import com.kakao.vectormap.KakaoMapReadyCallback
+import com.kakao.vectormap.LatLng
+import com.kakao.vectormap.MapLifeCycleCallback
+import com.kakao.vectormap.MapView
+import com.kakao.vectormap.camera.CameraUpdateFactory
+import com.kakao.vectormap.label.LabelOptions
+import com.kakao.vectormap.label.LabelStyle
+import com.kakao.vectormap.label.LabelStyles
+import com.school_of_company.ui.toast.makeToast
+import com.school_of_company.design_system.R
+
+@Composable
+fun HomeKakaoMap(
+    modifier: Modifier = Modifier,
+    locationX: Double,
+    locationY: Double,
+) {
+    val context = LocalContext.current
+    val mapView = remember { MapView(context) }
+
+    AndroidView(
+        modifier = modifier.height(200.dp),
+        factory = { context ->
+            mapView.apply {
+                mapView.start(
+                    object : MapLifeCycleCallback() {
+                        override fun onMapDestroy() {
+                            makeToast(context = context, toastMessage = "지도를 불러오는데 실패했습니다.")
+                        }
+
+                        override fun onMapError(exception: Exception?) {
+                            makeToast(context = context, toastMessage = "지도를 불러오는 중 알 수 없는 에러가 발생했습니다.\n onMapError: $exception")
+                        }
+                    },
+
+                    object : KakaoMapReadyCallback() {
+                        override fun onMapReady(kakaoMap: KakaoMap) {
+                            val cameraUpdate = CameraUpdateFactory.newCenterPosition(LatLng.from(locationX, locationY))
+                            kakaoMap.moveCamera(cameraUpdate)
+                        }
+
+                        override fun getPosition(): LatLng {
+                            return LatLng.from(locationX, locationY)
+                        }
+                    },
+                )
+            }
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun HomeKakaoComponentPreview() {
+    HomeKakaoMap(locationX = 35.14308063423194, locationY = 126.80042860412009)
+}

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/HomeList.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/HomeList.kt
@@ -1,14 +1,20 @@
 package com.school_of_company.home.view.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
+import com.school_of_company.design_system.icon.ExpoIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -16,17 +22,39 @@ import kotlinx.collections.immutable.persistentListOf
 @Composable
 fun HomeList(
     modifier: Modifier = Modifier,
-    item: ImmutableList<HomeTempData> = persistentListOf()
+    emptyList: Boolean = false,
+    item: ImmutableList<HomeTempData> = persistentListOf(),
+    navigateToHomeDetail: () -> Unit
 ) {
-    ExpoAndroidTheme { colors, _ ->
-        LazyColumn(
-            modifier = modifier
-                .fillMaxSize()
-                .background(color = colors.white)
-                .paddingHorizontal(bottom = 8.dp)
-        ) {
-            itemsIndexed(item) {_, item ->
-                HomeListItem(data = item)
+    ExpoAndroidTheme { colors, typography ->
+        if (emptyList) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(28.dp, Alignment.CenterVertically),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(color = colors.white)
+            ) {
+                ExpoIcon(modifier = Modifier.size(100.dp))
+                Text(
+                    text = "아직 박람회가 등장하지 않았아요.",
+                    style = typography.bodyRegular2,
+                    color = colors.gray400
+                )
+            }
+        } else {
+            LazyColumn(
+                modifier = modifier
+                    .fillMaxSize()
+                    .background(color = colors.white)
+                    .paddingHorizontal(bottom = 8.dp)
+            ) {
+                itemsIndexed(item) { _, item ->
+                    HomeListItem(
+                        data = item,
+                        navigateToHomeDetail = navigateToHomeDetail
+                    )
+                }
             }
         }
     }
@@ -39,11 +67,13 @@ private fun HomeListPreview() {
         item = persistentListOf(
             HomeTempData(
                 image = "https://image.dongascience.com/Photo/2019/12/fb4f7da04758d289a466f81478f5f488.jpg",
-                started_at = "2023-09-01",
-                ended_at = "2023-09-30",
+                started_at = "09-01",
+                ended_at = "09-30",
                 title = "2024 AI 광주 미래교육 2024 AI 광주 미래교육",
                 content = "2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육"
             ),
-        )
+        ),
+        emptyList = true,
+        navigateToHomeDetail = {}
     )
 }

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/HomeListItem.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/HomeListItem.kt
@@ -43,6 +43,7 @@ data class HomeTempData(
 fun HomeListItem(
     modifier: Modifier = Modifier,
     data: HomeTempData,
+    navigateToHomeDetail: () -> Unit
 ) {
     ExpoAndroidTheme { colors, typography ->
 
@@ -96,57 +97,62 @@ fun HomeListItem(
                     }
                 }
             } else {
-                Image(
-                    painter = rememberAsyncImagePainter(model = data.image),
-                    contentDescription = stringResource(id = R.string.HomeScreen_Image_description),
-                    contentScale = ContentScale.Crop,
-                    modifier = Modifier
-                        .width(110.dp)
-                        .height(110.dp)
-                        .clip(RoundedCornerShape(6.dp))
-                )
-            }
-
-            Column(
-                verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.Top),
-                horizontalAlignment = Alignment.Start,
-            ) {
-                Row(horizontalArrangement = Arrangement.spacedBy(11.dp, Alignment.Start)) {
-
-                    Text(
-                        text = stringResource(id = R.string.register_temp),
-                        style = typography.captionRegular2,
-                        color = colors.gray600
+                Row (
+                    horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.Start),
+                    modifier = Modifier.expoClickable { navigateToHomeDetail() }
+                ) {
+                    Image(
+                        painter = rememberAsyncImagePainter(model = data.image),
+                        contentDescription = stringResource(id = R.string.HomeScreen_Image_description),
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .width(110.dp)
+                            .height(110.dp)
+                            .clip(RoundedCornerShape(6.dp))
                     )
 
-                    Text(
-                        text = stringResource(
-                            R.string.date_type,
-                            data.started_at.formatServerDate(),
-                            data.ended_at.formatServerDate()
-                        ),
-                        style = typography.captionRegular2,
-                        color = colors.gray600,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.Top),
+                        horizontalAlignment = Alignment.Start,
+                    ) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(11.dp, Alignment.Start)) {
+
+                            Text(
+                                text = stringResource(id = R.string.register_temp),
+                                style = typography.captionRegular2,
+                                color = colors.gray600
+                            )
+
+                            Text(
+                                text = stringResource(
+                                    R.string.date_type,
+                                    data.started_at.formatServerDate(),
+                                    data.ended_at.formatServerDate()
+                                ),
+                                style = typography.captionRegular2,
+                                color = colors.gray600,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
+
+                        Text(
+                            text = data.title,
+                            style = typography.captionBold1,
+                            color = colors.black,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+
+                        Text(
+                            text = data.content,
+                            style = typography.captionRegular2,
+                            color = colors.gray300,
+                            maxLines = 3,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
                 }
-
-                Text(
-                    text = data.title,
-                    style = typography.captionBold1,
-                    color = colors.black,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-
-                Text(
-                    text = data.content,
-                    style = typography.captionRegular2,
-                    color = colors.gray300,
-                    maxLines = 3,
-                    overflow = TextOverflow.Ellipsis
-                )
             }
         }
     }
@@ -163,5 +169,6 @@ private fun HomeListItemPreview() {
             title = "2024 AI 광주 미래교육 2024 AI 광주 미래교육",
             content = "2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육 2024 AI 광주 미래교육2024 AI 광주 미래교육 2024 AI 광주 미래교육"
         ),
+        navigateToHomeDetail = {}
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 #Define Versions
 accompanist = "0.36.0"
+android = "2.12.8"
 androidGradlePlugin = "8.1.4"
 androidxActivity = "1.9.3"
 androidxAppCompat = "1.7.0"
@@ -65,11 +66,13 @@ swiperefresh = "0.27.0"
 turbine = "1.2.0"
 zxing = "3.5.3"
 chuck = "1.1.0"
+identityAndroidLegacy = "202408.1"
 
 
 [libraries]
 #Define Library
 accompanist-permission = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanist" }
+android_kakao_map = { module = "com.kakao.maps.open:android", version.ref = "android" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidxAppCompat" }
 androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "androidxBrowser" }
@@ -164,6 +167,7 @@ ui = { group = "androidx.compose.ui", name = "ui" }
 ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+identity-android-legacy = { group = "com.android.identity", name = "identity-android-legacy", version.ref = "identityAndroidLegacy" }
 
 [plugins]
 #Define Plugins

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven("https://jitpack.io")
+        maven("https://devrepo.kakao.com/nexus/repository/kakaomap-releases/")
     }
 }
 


### PR DESCRIPTION
## 💡 개요
- 박람회 상세보기 화면이 필요해보였습니다.
## 📃 작업내용
- 박람회 상세보기 화면을 퍼블리상 하였습니다.
   - 카카오맵을 사용하여 지도를 띄웠습니다

https://github.com/user-attachments/assets/9d181cfa-43be-4988-93ec-1259bd8269db

## 🔀 변경사항
<img width="680" alt="스크린샷 2024-11-05 오후 4 08 32" src="https://github.com/user-attachments/assets/c89c3882-f2cd-459b-ad03-1a0a24ba13d8">

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이산한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- Kakao SDK 통합을 위한 위치 서비스 권한 추가.
	- 홈 상세 화면 탐색 기능 추가.
	- 새로운 `HomeDetailScreen` 및 `HomeKakaoMap` 컴포넌트 추가.
	- 새로운 `ExpoEnableButton` 및 `LocationIcon` 버튼 추가.
	- 새로운 `app_key` 리소스 추가.
	- 새로운 Maven 저장소 추가로 Kakao 맵 기능 통합.
	- `HomeList`에서 빈 리스트 처리 기능 추가.

- **버그 수정**
	- `HomeList`의 빈 리스트 처리 개선.

- **문서화**
	- 새로운 문자열 리소스 추가: 위치 아이콘 설명.

- **스타일**
	- `ExpoTopBar` 및 `ExpoSubjectTitleText`의 레이아웃 수정.

- **테스트**
	- UI 미리보기 기능 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->