### PR TITLE
🔀 :: (#193) - 박람회 -> 프로그램 버튼 클릭시 나와야하는 화면을 퍼블리싱하였습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -11,17 +11,20 @@ import androidx.navigation.compose.NavHost
 import com.school_of_company.common.exception.*
 import com.school_of_company.design_system.R
 import com.school_of_company.expo_android.ui.ExpoAppState
+import com.school_of_company.home.navigation.homeDetailProgramParticipantScreen
+import com.school_of_company.home.navigation.homeDetailProgramScreen
 import com.school_of_company.home.navigation.homeDetailScreen
 import com.school_of_company.home.navigation.homeScreen
 import com.school_of_company.home.navigation.homeSendMessageScreen
 import com.school_of_company.home.navigation.navigateToHome
 import com.school_of_company.home.navigation.navigateToHomeDetail
+import com.school_of_company.home.navigation.navigateToHomeDetailProgram
+import com.school_of_company.home.navigation.navigateToHomeDetailProgramParticipant
 import com.school_of_company.home.navigation.navigateToHomeSendMessage
 import com.school_of_company.navigation.navigateToSignIn
 import com.school_of_company.navigation.sigInRoute
 import com.school_of_company.navigation.signInScreen
 import com.school_of_company.signup.navigation.navigationToSignUp
-import com.school_of_company.signup.navigation.signUpRoute
 import com.school_of_company.signup.navigation.signUpScreen
 import com.school_of_company.ui.toast.makeToast
 
@@ -116,12 +119,21 @@ fun ExpoNavHost(
             onCheckClick = {},
             onQrGenerateClick = {},
             onModifyClick = {},
-            onProgramClick = {}
+            onProgramClick = navController::navigateToHomeDetailProgram
         )
 
         homeSendMessageScreen(
             onBackClick = navController::popBackStack,
             onSendClick = navController::navigateToHomeDetail
+        )
+
+        homeDetailProgramScreen(
+            onBackClick = navController::popBackStack,
+            navigateToProgramDetail = navController::navigateToHomeDetailProgramParticipant
+        )
+
+        homeDetailProgramParticipantScreen(
+            onBackClick = navController::popBackStack
         )
     }
 }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
@@ -143,10 +143,14 @@ fun UserIcon(modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun WarnIcon(modifier: Modifier = Modifier) {
+fun WarnIcon(
+    modifier: Modifier = Modifier,
+    tint: Color = Color.Unspecified
+) {
     Icon(
         painter = painterResource(id = R.drawable.ic_warn),
         contentDescription = stringResource(id = R.string.warn_description),
+        tint = tint,
         modifier = modifier
     )
 }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
@@ -170,10 +170,14 @@ fun CopyIcon(modifier: Modifier = Modifier) {
 }
 
 @Composable
-fun CircleIcon(modifier: Modifier = Modifier) {
+fun CircleIcon(
+    modifier: Modifier = Modifier,
+    tint: Color = Color.Unspecified
+) {
     Icon(
         painter = painterResource(id = R.drawable.ic_circle),
         contentDescription = stringResource(id = R.string.circle_description),
+        tint = tint,
         modifier = modifier
     )
 }

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -96,4 +96,6 @@
     <string name="id">아이디</string>
 
     <string name="slash">/</string>
+
+    <string name="string_type">%s</string>
 </resources>

--- a/feature/home/src/main/java/com/school_of_company/home/enum/ProgramEnum.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/enum/ProgramEnum.kt
@@ -1,0 +1,6 @@
+package com.school_of_company.home.enum
+
+enum class ProgramEnum {
+    NORMAL,
+    TRAINING
+}

--- a/feature/home/src/main/java/com/school_of_company/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/navigation/HomeNavigation.kt
@@ -4,7 +4,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import com.school_of_company.home.view.HomeDetailProgramParticipantScreen
+import com.school_of_company.home.view.HomeDetailProgramParticipantRoute
 import com.school_of_company.home.view.HomeDetailProgramRoute
 import com.school_of_company.home.view.HomeDetailRoute
 import com.school_of_company.home.view.HomeRoute
@@ -94,7 +94,7 @@ fun NavGraphBuilder.homeDetailProgramParticipantScreen(
     onBackClick: () -> Unit
 ) {
     composable(route = homeDetailProgramParticipantRoute) {
-        HomeDetailProgramParticipantScreen(
+        HomeDetailProgramParticipantRoute(
             onBackClick = onBackClick
         )
     }

--- a/feature/home/src/main/java/com/school_of_company/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/navigation/HomeNavigation.kt
@@ -4,6 +4,8 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.school_of_company.home.view.HomeDetailProgramParticipantScreen
+import com.school_of_company.home.view.HomeDetailProgramRoute
 import com.school_of_company.home.view.HomeDetailRoute
 import com.school_of_company.home.view.HomeRoute
 import com.school_of_company.home.view.SendMessageRoute
@@ -11,6 +13,8 @@ import com.school_of_company.home.view.SendMessageRoute
 const val homeRoute = "home_route"
 const val homeDetailRoute=  "home_detail_route"
 const val homeSendMessageRoute = "home_send_message_route"
+const val homeDetailProgramRoute = "home_detail_program_route"
+const val homeDetailProgramParticipantRoute = "home_detail_program_participant_route"
 
 fun NavController.navigateToHome(navOptions: NavOptions? = null) {
     this.navigate(homeRoute, navOptions)
@@ -22,6 +26,14 @@ fun NavController.navigateToHomeDetail(navOptions: NavOptions? = null) {
 
 fun NavController.navigateToHomeSendMessage(navOptions: NavOptions? = null) {
     this.navigate(homeSendMessageRoute, navOptions)
+}
+
+fun NavController.navigateToHomeDetailProgram(navOptions: NavOptions? = null) {
+    this.navigate(homeDetailProgramRoute, navOptions)
+}
+
+fun NavController.navigateToHomeDetailProgramParticipant(navOptions: NavOptions? = null) {
+    this.navigate(homeDetailProgramParticipantRoute, navOptions)
 }
 
 fun NavGraphBuilder.homeScreen(
@@ -61,6 +73,28 @@ fun NavGraphBuilder.homeSendMessageScreen(
     composable(route = homeSendMessageRoute) {
         SendMessageRoute(
             onSendClick = onSendClick,
+            onBackClick = onBackClick
+        )
+    }
+}
+
+fun NavGraphBuilder.homeDetailProgramScreen(
+    onBackClick: () -> Unit,
+    navigateToProgramDetail: () -> Unit
+) {
+    composable(route = homeDetailProgramRoute) {
+        HomeDetailProgramRoute(
+            onBackClick = onBackClick,
+            navigateToProgramDetail = navigateToProgramDetail
+        )
+    }
+}
+
+fun NavGraphBuilder.homeDetailProgramParticipantScreen(
+    onBackClick: () -> Unit
+) {
+    composable(route = homeDetailProgramParticipantRoute) {
+        HomeDetailProgramParticipantScreen(
             onBackClick = onBackClick
         )
     }

--- a/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailProgramParticipantScreen.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailProgramParticipantScreen.kt
@@ -14,26 +14,20 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
-import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
 import com.school_of_company.design_system.icon.LeftArrowIcon
 import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.home.view.component.HomeDetailProgramParticipantData
 import com.school_of_company.home.view.component.HomeDetailProgramParticipantList
-import com.school_of_company.home.view.component.ProgramTempList
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 
@@ -128,7 +122,7 @@ internal fun HomeDetailProgramParticipantScreen(
                     )
 
                     Text(
-                        text = stringResource(id = R.string.string_type),
+                        text = "${participantData.size}명",
                         style = typography.captionRegular2,
                         color = colors.main
                     )

--- a/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailProgramParticipantScreen.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailProgramParticipantScreen.kt
@@ -1,0 +1,205 @@
+package com.school_of_company.home.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.R
+import com.school_of_company.design_system.component.modifier.clickable.expoClickable
+import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
+import com.school_of_company.design_system.component.topbar.ExpoTopBar
+import com.school_of_company.design_system.icon.LeftArrowIcon
+import com.school_of_company.design_system.icon.WarnIcon
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.home.view.component.HomeDetailProgramParticipantData
+import com.school_of_company.home.view.component.HomeDetailProgramParticipantList
+import com.school_of_company.home.view.component.ProgramTempList
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toPersistentList
+
+fun generateParticipantSampleData(): ImmutableList<HomeDetailProgramParticipantData> {
+    return List(20) {
+        HomeDetailProgramParticipantData(
+            name = "이명훈",
+            company = "초등학교",
+            position = "교사",
+            schoolSubject = "컴퓨터공학",
+            phone = "010-1234-5678"
+        )
+    }.toPersistentList()
+}
+
+@Composable
+internal fun HomeDetailProgramParticipantRoute(
+    onBackClick: () -> Unit
+) {
+    HomeDetailProgramParticipantScreen(
+        onBackClick = onBackClick,
+        participantData = generateParticipantSampleData()
+    )
+}
+
+@Composable
+internal fun HomeDetailProgramParticipantScreen(
+    modifier: Modifier = Modifier,
+    participantData: ImmutableList<HomeDetailProgramParticipantData>,
+    onBackClick: () -> Unit
+) {
+    ExpoAndroidTheme { colors, typography ->
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .background(color = colors.white)
+                .padding(top = 68.dp)
+        ) {
+            ExpoTopBar(
+                startIcon = {
+                    LeftArrowIcon(
+                        tint = colors.black,
+                        modifier = Modifier.expoClickable { onBackClick() }
+                    )
+                },
+                betweenText = "참가자 관리",
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+
+            Spacer(modifier = Modifier.height(28.dp))
+
+            Text(
+                text = "프로그램",
+                style = typography.bodyBold2,
+                color = colors.black,
+                modifier = Modifier.padding(start = 16.dp)
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(modifier = Modifier.padding(horizontal = 16.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.Start),) {
+                    WarnIcon(
+                        tint = colors.gray300,
+                        modifier = Modifier.size(16.dp)
+                    )
+
+                    Text(
+                        text = "옆으로 넘겨서 확인해보세요",
+                        style = typography.captionRegular2,
+                        color = colors.gray300
+                    )
+                }
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                Spacer(
+                    modifier = Modifier
+                        .padding(0.dp)
+                        .width(1.dp)
+                        .height(14.dp)
+                        .background(color = colors.gray100)
+                )
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                Row(horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.Start)) {
+                    Text(
+                        text = "참가자 전체 인원",
+                        style = typography.captionRegular2,
+                        color = colors.gray500
+                    )
+
+                    Text(
+                        text = stringResource(id = R.string.string_type),
+                        style = typography.captionRegular2,
+                        color = colors.main
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Box(
+                modifier = Modifier
+                    .border(
+                        width = 1.dp,
+                        color = colors.gray200
+                    )
+                    .fillMaxWidth()
+                    .padding(
+                        vertical = 16.dp
+                    )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 16.dp)
+                        .horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(20.dp)
+                ) {
+                    Spacer(modifier = Modifier.width(20.dp))
+                    
+                    Text(
+                        text = "성명",
+                        style = typography.captionBold1,
+                        color = colors.gray600,
+                        modifier = Modifier.width(80.dp)
+                    )
+                    Text(
+                        text = "소속",
+                        style = typography.captionBold1,
+                        color = colors.gray600,
+                        modifier = Modifier.width(100.dp)
+                    )
+                    Text(
+                        text = "직급",
+                        style = typography.captionBold1,
+                        color = colors.gray600,
+                        modifier = Modifier.width(80.dp)
+                    )
+                    Text(
+                        text = "교과명",
+                        style = typography.captionBold1,
+                        color = colors.gray600,
+                        modifier = Modifier.width(120.dp)
+                    )
+                    Text(
+                        text = "연락처",
+                        style = typography.captionBold1,
+                        color = colors.gray600,
+                        modifier = Modifier.width(100.dp)
+                    )
+                }
+            }
+
+            HomeDetailProgramParticipantList(item = participantData)
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun HomeDetailProgramParticipantScreenPreview() {
+    HomeDetailProgramParticipantScreen(
+        onBackClick = {},
+        participantData = generateParticipantSampleData()
+    )
+}

--- a/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailProgramScreen.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailProgramScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.TabRow
+import androidx.compose.material3.TabRowDefaults
+import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
@@ -91,7 +93,12 @@ internal fun HomeDetailProgramScreen(
             TabRow(
                 selectedTabIndex = pagerState.currentPage,
                 containerColor = Color.Transparent,
-                indicator = { Color.Transparent },
+                indicator = { tabPositions ->
+                    TabRowDefaults.Indicator(
+                        color = colors.main,
+                        modifier = modifier.tabIndicatorOffset(tabPositions[pagerState.currentPage]),
+                    )
+                },
                 modifier = Modifier.width(230.dp)
             ) {
                 persistentListOf(

--- a/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailProgramScreen.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailProgramScreen.kt
@@ -1,0 +1,198 @@
+package com.school_of_company.home.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.TabRow
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.component.modifier.clickable.expoClickable
+import com.school_of_company.design_system.component.topbar.ExpoTopBar
+import com.school_of_company.design_system.icon.LeftArrowIcon
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.home.view.component.ProgramList
+import com.school_of_company.home.view.component.ProgramTabRowItem
+import com.school_of_company.home.view.component.ProgramTempList
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+fun generateProgramSampleData(): ImmutableList<ProgramTempList> {
+    return List(20) {
+        ProgramTempList(
+            programName = "프로그램 이름",
+            check = true,
+            must = false
+        )
+    }.toPersistentList()
+}
+
+@Composable
+internal fun HomeDetailProgramRoute(
+    onBackClick: () -> Unit,
+    navigateToProgramDetail: () -> Unit
+) {
+    HomeDetailProgramScreen(
+        programItem = generateProgramSampleData(),
+        onBackClick = onBackClick,
+        navigateToProgramDetail = navigateToProgramDetail
+    )
+}
+
+@Composable
+internal fun HomeDetailProgramScreen(
+    modifier: Modifier = Modifier,
+    pagerState: PagerState = rememberPagerState(pageCount = { 2 }),
+    coroutineScope: CoroutineScope = rememberCoroutineScope(),
+    programItem: ImmutableList<ProgramTempList>,
+    onBackClick: () -> Unit,
+    navigateToProgramDetail: () -> Unit,
+) {
+    ExpoAndroidTheme { colors, typography ->
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = modifier
+                .fillMaxSize()
+                .background(color = colors.white)
+                .padding(top = 68.dp)
+        ) {
+
+            ExpoTopBar(
+                startIcon = { LeftArrowIcon(
+                        tint = colors.black,
+                        modifier = Modifier.expoClickable { onBackClick() }
+                    ) },
+                betweenText = "프로그램",
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+
+            Spacer(modifier = Modifier.padding(top = 28.dp))
+
+            TabRow(
+                selectedTabIndex = pagerState.currentPage,
+                containerColor = Color.Transparent,
+                indicator = { Color.Transparent },
+                modifier = Modifier.width(230.dp)
+            ) {
+                persistentListOf(
+                    "일반 프로그램",
+                    "연수 프로그램"
+                ).forEachIndexed { index, title ->
+                    ProgramTabRowItem(
+                        isCurrentIndex = index == pagerState.currentPage,
+                        title = title,
+                        onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(index)
+                            }
+                        },
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Box(
+                modifier = Modifier
+                    .border(
+                        width = 1.dp,
+                        color = colors.gray200
+                    )
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = 16.dp,
+                        vertical = 16.dp
+                    )
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+
+                    Spacer(modifier = Modifier.weight(0.5f))
+
+                    Text(
+                        text = "프로그램",
+                        style = typography.captionBold1,
+                        color = colors.gray600,
+                        modifier = Modifier.weight(2f)
+                    )
+
+                    Text(
+                        text = "선택",
+                        style = typography.captionBold1,
+                        color = colors.gray600,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.weight(1f)
+                    )
+
+                    Text(
+                        text = "필수",
+                        style = typography.captionBold1,
+                        color = colors.gray600,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(14.dp))
+            
+            HorizontalPager(state = pagerState) { page ->
+                when (page) {
+                    0 -> {
+                        ProgramList(
+                            item = programItem,
+                            navigateToProgramDetail = navigateToProgramDetail
+                        )
+                    }
+
+                    1 -> {
+                        ProgramList(
+                            item = programItem,
+                            navigateToProgramDetail = navigateToProgramDetail
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun HomeDetailProgramScreenPreview() {
+    HomeDetailProgramScreen(
+        programItem = persistentListOf(
+            ProgramTempList(
+                programName = "adsfasfas",
+                check = true,
+                must = true
+            ),
+            ProgramTempList(
+                programName = "adsfasfas",
+                check = true,
+                must = true
+            ),
+        ),
+        onBackClick = {},
+        navigateToProgramDetail = {}
+    )
+}

--- a/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailProgramScreen.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailProgramScreen.kt
@@ -160,8 +160,6 @@ internal fun HomeDetailProgramScreen(
                 }
             }
 
-            Spacer(modifier = Modifier.height(14.dp))
-            
             HorizontalPager(state = pagerState) { page ->
                 when (page) {
                     0 -> {

--- a/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailScreen.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailScreen.kt
@@ -104,7 +104,7 @@ internal fun HomeDetailScreen(
                     )
                 },
                 betweenText = data.title,
-                modifier = Modifier.padding(top = 50.dp)
+                modifier = Modifier.padding(top = 68.dp)
             )
 
             Spacer(modifier = Modifier.height(28.dp))

--- a/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailScreen.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailScreen.kt
@@ -34,7 +34,6 @@ import com.school_of_company.design_system.component.button.ExpoButton
 import com.school_of_company.design_system.component.button.ExpoEnableButton
 import com.school_of_company.design_system.component.button.ExpoEnableDetailButton
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
-import com.school_of_company.design_system.component.modifier.padding.paddingVertical
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
 import com.school_of_company.design_system.icon.LeftArrowIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
@@ -43,7 +42,6 @@ import com.school_of_company.home.view.component.HomeTempData
 import com.school_of_company.home.view.component.MessageDialog
 import com.school_of_company.home.view.component.QrCode
 import com.school_of_company.home.view.component.QrDialog
-import com.school_of_company.ui.preview.ExpoPreviews
 import com.school_of_company.ui.util.formatServerDate
 
 @Composable

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/HomeBottomSheet.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/HomeBottomSheet.kt
@@ -35,7 +35,7 @@ fun HomeBottomSheet(
 ) {
     val sheetState = rememberModalBottomSheetState()
 
-    ExpoAndroidTheme { colors, typography ->
+    ExpoAndroidTheme { colors, _ ->
 
         ModalBottomSheet(
             onDismissRequest = { onCancelClick() },

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/HomeDetailProgramParticipantList.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/HomeDetailProgramParticipantList.kt
@@ -1,0 +1,59 @@
+package com.school_of_company.home.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+fun HomeDetailProgramParticipantList(
+    modifier: Modifier = Modifier,
+    item: ImmutableList<HomeDetailProgramParticipantData> = persistentListOf()
+) {
+    ExpoAndroidTheme { colors, _ ->
+        LazyColumn(
+            modifier = modifier
+                .fillMaxSize()
+                .background(color = colors.white)
+                .padding(start = 16.dp)
+        ) {
+            itemsIndexed(item) { index, item ->
+                HomeDetailProgramParticipantListItem(
+                    index = index + 1,
+                    data = item
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun HomeDetailProgramParticipantListPreview() {
+    HomeDetailProgramParticipantList(
+        item = persistentListOf(
+            HomeDetailProgramParticipantData(
+                name = "이명훈",
+                company = "초등학교",
+                position = "교사",
+                schoolSubject = "컴퓨터공학",
+                phone = "010-1234-5678"
+            ),
+            HomeDetailProgramParticipantData(
+                name = "이명훈",
+                company = "초등학교",
+                position = "교사",
+                schoolSubject = "컴퓨터공학",
+                phone = "010-1234-5678"
+            ),
+        )
+    )
+}

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/HomeDetailProgramParticipantListItem.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/HomeDetailProgramParticipantListItem.kt
@@ -1,0 +1,102 @@
+package com.school_of_company.home.view.component
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+data class HomeDetailProgramParticipantData(
+    val name: String,
+    val company: String,
+    val position: String,
+    val schoolSubject: String,
+    val phone: String
+)
+
+@Composable
+fun HomeDetailProgramParticipantListItem(
+    modifier: Modifier = Modifier,
+    index: Int,
+    data: HomeDetailProgramParticipantData,
+    horizontalScrollState: ScrollState = rememberScrollState()
+) {
+    ExpoAndroidTheme { colors, typography ->
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+                .horizontalScroll(rememberScrollState()), // 수평 스크롤 가능
+            horizontalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            Text(
+                text = index.toString(),
+                style = typography.captionRegular2,
+                color = colors.black,
+                modifier = Modifier.width(20.dp) // 제목과 동일한 너비
+            )
+
+            Text(
+                text = data.name,
+                style = typography.captionRegular2,
+                color = colors.black,
+                modifier = Modifier.width(80.dp) // 제목과 동일한 너비 설정
+            )
+            Text(
+                text = data.company,
+                style = typography.captionRegular2,
+                color = colors.black,
+                modifier = Modifier.width(100.dp) // 제목과 동일한 너비 설정
+            )
+            Text(
+                text = data.position,
+                style = typography.captionRegular2,
+                color = colors.black,
+                modifier = Modifier.width(80.dp) // 제목과 동일한 너비 설정
+            )
+            Text(
+                text = data.schoolSubject,
+                style = typography.captionRegular2,
+                color = colors.black,
+                modifier = Modifier.width(120.dp) // 제목과 동일한 너비 설정
+            )
+            Text(
+                text = data.phone,
+                style = typography.captionRegular2,
+                color = colors.black,
+                modifier = Modifier.width(100.dp) // 제목과 동일한 너비 설정
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun HomeDetailProgramParticipantListItemPreview() {
+    HomeDetailProgramParticipantListItem(
+        index = 1,
+        data = HomeDetailProgramParticipantData(
+            name = "이명훈",
+            company = "초등학교",
+            position = "교사",
+            schoolSubject = "컴퓨터공학",
+            phone = "010-1234-5678"
+        )
+    )
+}

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/HomeDetailProgramParticipantListItem.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/HomeDetailProgramParticipantListItem.kt
@@ -1,7 +1,6 @@
 package com.school_of_company.home.view.component
 
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -42,45 +41,45 @@ fun HomeDetailProgramParticipantListItem(
             modifier = modifier
                 .fillMaxWidth()
                 .padding(vertical = 8.dp)
-                .horizontalScroll(rememberScrollState()), // 수평 스크롤 가능
+                .horizontalScroll(horizontalScrollState),
             horizontalArrangement = Arrangement.spacedBy(20.dp)
         ) {
             Text(
                 text = index.toString(),
                 style = typography.captionRegular2,
                 color = colors.black,
-                modifier = Modifier.width(20.dp) // 제목과 동일한 너비
+                modifier = Modifier.width(20.dp)
             )
 
             Text(
                 text = data.name,
                 style = typography.captionRegular2,
                 color = colors.black,
-                modifier = Modifier.width(80.dp) // 제목과 동일한 너비 설정
+                modifier = Modifier.width(80.dp)
             )
             Text(
                 text = data.company,
                 style = typography.captionRegular2,
                 color = colors.black,
-                modifier = Modifier.width(100.dp) // 제목과 동일한 너비 설정
+                modifier = Modifier.width(100.dp)
             )
             Text(
                 text = data.position,
                 style = typography.captionRegular2,
                 color = colors.black,
-                modifier = Modifier.width(80.dp) // 제목과 동일한 너비 설정
+                modifier = Modifier.width(80.dp)
             )
             Text(
                 text = data.schoolSubject,
                 style = typography.captionRegular2,
                 color = colors.black,
-                modifier = Modifier.width(120.dp) // 제목과 동일한 너비 설정
+                modifier = Modifier.width(120.dp)
             )
             Text(
                 text = data.phone,
                 style = typography.captionRegular2,
                 color = colors.black,
-                modifier = Modifier.width(100.dp) // 제목과 동일한 너비 설정
+                modifier = Modifier.width(100.dp)
             )
         }
     }

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/HomeKakaoMapComponent.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/HomeKakaoMapComponent.kt
@@ -14,11 +14,7 @@ import com.kakao.vectormap.LatLng
 import com.kakao.vectormap.MapLifeCycleCallback
 import com.kakao.vectormap.MapView
 import com.kakao.vectormap.camera.CameraUpdateFactory
-import com.kakao.vectormap.label.LabelOptions
-import com.kakao.vectormap.label.LabelStyle
-import com.kakao.vectormap.label.LabelStyles
 import com.school_of_company.ui.toast.makeToast
-import com.school_of_company.design_system.R
 
 @Composable
 fun HomeKakaoMap(
@@ -31,7 +27,7 @@ fun HomeKakaoMap(
 
     AndroidView(
         modifier = modifier.height(200.dp),
-        factory = { context ->
+        factory = { _ ->
             mapView.apply {
                 mapView.start(
                     object : MapLifeCycleCallback() {

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/HomeSendMessageTopBar.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/HomeSendMessageTopBar.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import com.school_of_company.design_system.component.text.ExpoSubjectTitleText
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 
 @Composable

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramList.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramList.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramList.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramList.kt
@@ -1,0 +1,80 @@
+package com.school_of_company.home.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+fun ProgramList(
+    modifier: Modifier = Modifier,
+    item: ImmutableList<ProgramTempList> = persistentListOf(),
+    navigateToProgramDetail: () -> Unit
+) {
+    ExpoAndroidTheme { colors, _ ->
+
+        LazyColumn(
+            modifier = modifier
+                .fillMaxSize()
+                .background(color = colors.white)
+                .padding(horizontal = 16.dp)
+        ) {
+            itemsIndexed(item) { index, item ->
+                ProgramListItem(
+                    index = index + 1,
+                    data = item,
+                    navigateToProgramDetail = navigateToProgramDetail
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ProgramListPreview() {
+    ProgramList(
+        item = persistentListOf(
+            ProgramTempList(
+                programName = "adsfasfas",
+                check = true,
+                must = true
+            ),
+            ProgramTempList(
+                programName = "adsfasdf",
+                check = true,
+                must = false
+            ),
+            ProgramTempList(
+                programName = "adsfasdf",
+                check = false,
+                must = true
+            ),
+            ProgramTempList(
+                programName = "adsfasdf",
+                check = true,
+                must = false
+            ),
+            ProgramTempList(
+                programName = "adsfasdf",
+                check = false,
+                must = false
+            ),
+            ProgramTempList(
+                programName = "adsfasdf",
+                check = false,
+                must = false
+            ),
+        ),
+        navigateToProgramDetail = {}
+    )
+}

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramListItem.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramListItem.kt
@@ -1,0 +1,116 @@
+package com.school_of_company.home.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.component.modifier.clickable.expoClickable
+import com.school_of_company.design_system.icon.CircleIcon
+import com.school_of_company.design_system.icon.XIcon
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+data class ProgramTempList(
+    val programName: String,
+    val check: Boolean,
+    val must: Boolean
+)
+
+@Composable
+fun ProgramListItem(
+    modifier: Modifier = Modifier,
+    index: Int,
+    data: ProgramTempList,
+    navigateToProgramDetail: () -> Unit
+) {
+    ExpoAndroidTheme { colors, typography ->
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .fillMaxWidth()
+                .background(color = colors.white)
+                .padding(vertical = 10.dp)
+                .expoClickable { navigateToProgramDetail() }
+        ) {
+
+            Text(
+                text = index.toString(),
+                style = typography.captionBold1,
+                color = colors.black,
+                modifier = Modifier.weight(0.5f)
+            )
+
+
+            Text(
+                text = data.programName,
+                style = typography.captionRegular2,
+                color = colors.black,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(2f)
+            )
+
+
+            if (data.check) {
+                CircleIcon(
+                    tint = colors.black,
+                    modifier = Modifier
+                        .size(16.dp)
+                        .weight(1f)
+                )
+            } else {
+                XIcon(
+                    tint = colors.error,
+                    modifier = Modifier
+                        .size(16.dp)
+                        .weight(1f)
+                )
+            }
+            
+
+            if (data.must) {
+                CircleIcon(
+                    tint = colors.black,
+                    modifier = Modifier
+                        .size(16.dp)
+                        .weight(1f)
+                )
+            } else {
+                XIcon(
+                    tint = colors.error,
+                    modifier = Modifier
+                        .size(16.dp)
+                        .weight(1f)
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ProgramListItemPreview() {
+    ProgramListItem(
+        index = 1,
+        data = ProgramTempList(
+            programName = "프로그램 이름",
+            check = true,
+            must = false
+        ),
+        navigateToProgramDetail = {}
+    )
+}

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramListItem.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramListItem.kt
@@ -1,14 +1,12 @@
 package com.school_of_company.home.view.component
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramTabRowItem.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramTabRowItem.kt
@@ -1,0 +1,45 @@
+package com.school_of_company.home.view.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.component.modifier.clickable.expoClickable
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+fun ProgramTabRowItem(
+    modifier: Modifier = Modifier,
+    title: String,
+    onClick: () -> Unit,
+    isCurrentIndex: Boolean,
+) {
+    ExpoAndroidTheme { colors, typography ->
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .padding(8.dp)
+                .expoClickable(onClick = onClick)
+        ) {
+            if (isCurrentIndex) {
+                Text(
+                    text = title,
+                    style = typography.bodyBold1,
+                    fontWeight = FontWeight.SemiBold,
+                    color = colors.black,
+                )
+            } else {
+                Text(
+                    text = title,
+                    style = typography.bodyBold1,
+                    fontWeight = FontWeight.Normal,
+                    color = colors.gray500,
+                )
+            }
+        }
+    }
+}

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramTabRowItem.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramTabRowItem.kt
@@ -22,24 +22,15 @@ fun ProgramTabRowItem(
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = modifier
-                .padding(8.dp)
                 .expoClickable(onClick = onClick)
+                .padding(8.dp)
         ) {
-            if (isCurrentIndex) {
-                Text(
-                    text = title,
-                    style = typography.bodyBold1,
-                    fontWeight = FontWeight.SemiBold,
-                    color = colors.black,
-                )
-            } else {
-                Text(
-                    text = title,
-                    style = typography.bodyBold1,
-                    fontWeight = FontWeight.Normal,
-                    color = colors.gray500,
-                )
-            }
+            Text(
+                text = title,
+                style = typography.bodyBold1,
+                fontWeight = if (isCurrentIndex) FontWeight.SemiBold else FontWeight.Normal,
+                color = if (isCurrentIndex) colors.black else colors.gray500,
+            )
         }
     }
 }


### PR DESCRIPTION
## 💡 개요
- 박람회 -> 프로그램 버튼 클릭시 나와야하는 화면이 퍼블리싱이 필요해보였습니다.
## 📃 작업내용
- 박람회 -> 프로그램 버튼 클릭시 나와야하는 화면을 퍼블리싱하였습니다.
   - 화면 퍼블리싱
   - 퍼블리싱에 필요한 컴포넌트 제작

https://github.com/user-attachments/assets/83e5f629-0d69-4893-94e6-6923971e85ca

## 🔀 변경사항
- add ProgramList(Item)
- add ProgramEnum
- add ProgramTabRow
- add HomeDetailProgramScreen
- add HomeDetailProgramparticipantList(Item)
- add HomeDetailProgramParticipantScreen
- chore HomeNavigation
- chore ExpoNavHost
- chore Refactor Code
- remove Fire Unused Code
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이산한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- 새로운 화면으로 프로그램 세부정보 및 참가자 세부정보를 추가하여 내비게이션 흐름을 개선했습니다.
	- 사용자 정의 색상을 지정할 수 있는 아이콘의 틴트 기능을 추가했습니다.
	- 프로그램 목록 및 참가자 목록을 표시하는 새로운 UI 구성 요소를 도입했습니다.
	- 프로그램 유형을 정의하는 새로운 열거형 `ProgramEnum`을 추가했습니다.

- **Bug Fixes**
	- UI 레이아웃 조정으로 상단 바의 패딩을 수정했습니다.

- **Documentation**
	- 새로운 문자열 리소스를 추가했습니다.

- **Chores**
	- 사용하지 않는 임포트를 제거하여 코드 정리를 수행했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->