### PR TITLE
🔀 :: (#224) - standard 부분 네트워크 세팅을 했습니다.

### DIFF
--- a/core/data/src/main/java/com/school_of_company/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/school_of_company/data/di/RepositoryModule.kt
@@ -8,6 +8,8 @@ import com.school_of_company.data.repository.image.ImageRepository
 import com.school_of_company.data.repository.image.ImageRepositoryImpl
 import com.school_of_company.data.repository.sms.SmsRepository
 import com.school_of_company.data.repository.sms.SmsRepositoryImpl
+import com.school_of_company.data.repository.standard.StandardRepository
+import com.school_of_company.data.repository.standard.StandardRepositoryImpl
 import com.school_of_company.data.repository.training.TrainingRepository
 import com.school_of_company.data.repository.training.TrainingRepositoryImpl
 import dagger.Binds
@@ -43,4 +45,9 @@ abstract class RepositoryModule {
     abstract fun bindTrainingRepository(
         trainingRepositoryImpl: TrainingRepositoryImpl
     ) : TrainingRepository
+
+    @Binds
+    abstract fun bindStandardRepository(
+        standardRepositoryImpl: StandardRepositoryImpl
+    ) : StandardRepository
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/standard/StandardRepository.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/standard/StandardRepository.kt
@@ -1,0 +1,15 @@
+package com.school_of_company.data.repository.standard
+
+import com.school_of_company.model.entity.standard.StandardAttendListResponseEntity
+import com.school_of_company.model.entity.standard.StandardProgramListResponseEntity
+import com.school_of_company.model.model.standard.StandardRequestModel
+import kotlinx.coroutines.flow.Flow
+
+interface StandardRepository {
+    fun registerStandardProgram(expoId: String, body: StandardRequestModel): Flow<Unit>
+    fun registerStandardListProgram(expoId: String, body: List<StandardRequestModel>): Flow<Unit>
+    fun modifyStandardProgram(standardProId: Long, body: StandardRequestModel): Flow<Unit>
+    fun deleteStandardProgram(standardProId: Long): Flow<Unit>
+    fun standardProgramList(expoId: String): Flow<List<StandardProgramListResponseEntity>>
+    fun standardProgramAttendList(standardProId: Long): Flow<List<StandardAttendListResponseEntity>>
+}

--- a/core/data/src/main/java/com/school_of_company/data/repository/standard/StandardRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/standard/StandardRepositoryImpl.kt
@@ -1,0 +1,54 @@
+package com.school_of_company.data.repository.standard
+
+import com.school_of_company.model.entity.standard.StandardAttendListResponseEntity
+import com.school_of_company.model.entity.standard.StandardProgramListResponseEntity
+import com.school_of_company.model.model.standard.StandardRequestModel
+import com.school_of_company.network.datasource.standard.StandardDataSource
+import com.school_of_company.network.mapper.standard.request.toDto
+import com.school_of_company.network.mapper.standard.response.toModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.transform
+import javax.inject.Inject
+
+class StandardRepositoryImpl @Inject constructor(
+    private val dataSource: StandardDataSource
+) : StandardRepository {
+    override fun registerStandardProgram(expoId: String, body: StandardRequestModel): Flow<Unit> {
+        return dataSource.registerStandardProgram(
+            expoId = expoId,
+            body = body.toDto()
+        )
+    }
+
+    override fun registerStandardListProgram(
+        expoId: String,
+        body: List<StandardRequestModel>
+    ): Flow<Unit> {
+        return dataSource.registerStandardListProgram(
+            expoId = expoId,
+            body = body.map { it.toDto() }
+        )
+    }
+
+    override fun modifyStandardProgram(
+        standardProId: Long,
+        body: StandardRequestModel
+    ): Flow<Unit> {
+        return dataSource.modifyStandardProgram(
+            standardProId = standardProId,
+            body = body.toDto()
+        )
+    }
+
+    override fun deleteStandardProgram(standardProId: Long): Flow<Unit> {
+        return dataSource.deleteStandardProgram(standardProId = standardProId)
+    }
+
+    override fun standardProgramList(expoId: String): Flow<List<StandardProgramListResponseEntity>> {
+        return dataSource.standardProgramList(expoId = expoId).transform { list -> emit(list.map { it.toModel() }) }
+    }
+
+    override fun standardProgramAttendList(standardProId: Long): Flow<List<StandardAttendListResponseEntity>> {
+        return dataSource.standardProgramAttendList(standardProId = standardProId).transform { list -> emit(list.map { it.toModel() }) }
+    }
+}

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/standard/DeleteStandardProgramListUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/standard/DeleteStandardProgramListUseCase.kt
@@ -1,0 +1,12 @@
+package com.school_of_company.domain.usecase.standard
+
+import com.school_of_company.data.repository.standard.StandardRepository
+import javax.inject.Inject
+
+class DeleteStandardProgramListUseCase @Inject constructor(
+    private val repository: StandardRepository
+) {
+    operator fun invoke(standardProId: Long) = runCatching {
+        repository.deleteStandardProgram(standardProId = standardProId)
+    }
+}

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/standard/ModifyStandardProgramUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/standard/ModifyStandardProgramUseCase.kt
@@ -1,0 +1,20 @@
+package com.school_of_company.domain.usecase.standard
+
+import com.school_of_company.data.repository.standard.StandardRepository
+import com.school_of_company.model.model.standard.StandardRequestModel
+import javax.inject.Inject
+
+class ModifyStandardProgramUseCase @Inject constructor(
+    private val repository: StandardRepository
+) {
+    operator fun invoke(
+        standardProId: Long,
+        body: StandardRequestModel
+    ) = runCatching {
+        repository.modifyStandardProgram(
+            standardProId = standardProId,
+            body = body
+        )
+
+    }
+}

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/standard/RegisterStandardListProgramUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/standard/RegisterStandardListProgramUseCase.kt
@@ -1,0 +1,19 @@
+package com.school_of_company.domain.usecase.standard
+
+import com.school_of_company.data.repository.standard.StandardRepository
+import com.school_of_company.model.model.standard.StandardRequestModel
+import javax.inject.Inject
+
+class RegisterStandardListProgramUseCase @Inject constructor(
+    private val repository: StandardRepository
+) {
+    operator fun invoke(
+        expoId: String,
+        body: List<StandardRequestModel>
+    ) = runCatching {
+        repository.registerStandardListProgram(
+            expoId = expoId,
+            body = body
+        )
+    }
+}

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/standard/RegisterStandardProgramUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/standard/RegisterStandardProgramUseCase.kt
@@ -1,0 +1,19 @@
+package com.school_of_company.domain.usecase.standard
+
+import com.school_of_company.data.repository.standard.StandardRepository
+import com.school_of_company.model.model.standard.StandardRequestModel
+import javax.inject.Inject
+
+class RegisterStandardProgramUseCase @Inject constructor(
+    private val repository: StandardRepository
+) {
+    operator fun invoke(
+        expoId: String,
+        body: StandardRequestModel
+    ) = runCatching {
+        repository.registerStandardProgram(
+            expoId = expoId,
+            body = body
+        )
+    }
+}

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/standard/StandardProgramAttendListUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/standard/StandardProgramAttendListUseCase.kt
@@ -1,0 +1,13 @@
+package com.school_of_company.domain.usecase.standard
+
+import com.school_of_company.data.repository.standard.StandardRepository
+import com.school_of_company.model.entity.standard.StandardAttendListResponseEntity
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class StandardProgramAttendListUseCase @Inject constructor(
+    private val repository: StandardRepository
+) {
+    operator fun invoke(standardProId: Long) : Flow<List<StandardAttendListResponseEntity>> =
+        repository.standardProgramAttendList(standardProId = standardProId)
+}

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/standard/StandardProgramListUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/standard/StandardProgramListUseCase.kt
@@ -1,0 +1,13 @@
+package com.school_of_company.domain.usecase.standard
+
+import com.school_of_company.data.repository.standard.StandardRepository
+import com.school_of_company.model.entity.standard.StandardProgramListResponseEntity
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class StandardProgramListUseCase @Inject constructor(
+    private val repository: StandardRepository
+) {
+    operator fun invoke(expoId: String) : Flow<List<StandardProgramListResponseEntity>> =
+        repository.standardProgramList(expoId = expoId)
+}

--- a/core/model/src/main/java/com/school_of_company/model/entity/standard/StandardAttendListResponseEntity.kt
+++ b/core/model/src/main/java/com/school_of_company/model/entity/standard/StandardAttendListResponseEntity.kt
@@ -1,0 +1,11 @@
+package com.school_of_company.model.entity.standard
+
+data class StandardAttendListResponseEntity(
+    val name: String,
+    val affiliation: String,
+    val position: String,
+    val programName: String,
+    val status: Boolean,
+    val entryTime: String,
+    val leaveTime: String
+)

--- a/core/model/src/main/java/com/school_of_company/model/entity/standard/StandardProgramListResponseEntity.kt
+++ b/core/model/src/main/java/com/school_of_company/model/entity/standard/StandardProgramListResponseEntity.kt
@@ -1,0 +1,8 @@
+package com.school_of_company.model.entity.standard
+
+data class StandardProgramListResponseEntity(
+    val id: Long,
+    val title: String,
+    val startedAt: String,
+    val endedAt: String,
+)

--- a/core/model/src/main/java/com/school_of_company/model/model/standard/StandardRequestModel.kt
+++ b/core/model/src/main/java/com/school_of_company/model/model/standard/StandardRequestModel.kt
@@ -1,0 +1,7 @@
+package com.school_of_company.model.model.standard
+
+data class StandardRequestModel(
+    val title: String,
+    val startedAt: String,
+    val endedAt: String,
+)

--- a/core/network/src/main/java/com/school_of_company/network/api/StandardAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/StandardAPI.kt
@@ -1,0 +1,46 @@
+package com.school_of_company.network.api
+
+import com.school_of_company.network.dto.standard.request.StandardRequest
+import com.school_of_company.network.dto.standard.response.StandardAttendListResponse
+import com.school_of_company.network.dto.standard.response.StandardProgramListResponse
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface StandardAPI {
+
+    @POST("/standard/{expo_id}")
+    suspend fun registerStandardProgram(
+        @Path("expo_id") expoId: String,
+        @Body body: StandardRequest
+    )
+
+    @POST("/standard/list/{expo_id}")
+    suspend fun registerStandardListProgram(
+        @Path("expo_id") expoId: String,
+        @Body body: List<StandardRequest>
+    )
+
+    @POST("/standard/{standardPro_id}")
+    suspend fun modifyStandardProgram(
+        @Path("standardPro_id") standardProId: Long,
+        @Body body: StandardRequest
+    )
+
+    @DELETE("/standard/{standardPro_id}")
+    suspend fun deleteStandardProgram(
+        @Path("standardPro_id") standardProId: Long
+    )
+
+    @GET("/standard/program/{expo_id}")
+    suspend fun standardProgramList(
+        @Path("expo_id") expoId: String
+    ) : List<StandardProgramListResponse>
+
+    @GET("/standard/{standardPro_id}")
+    suspend fun standardProgramAttendList(
+        @Path("standardPro_id") standardProId: Long
+    ) : List<StandardAttendListResponse>
+}

--- a/core/network/src/main/java/com/school_of_company/network/datasource/standard/StandardDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/standard/StandardDataSource.kt
@@ -1,0 +1,15 @@
+package com.school_of_company.network.datasource.standard
+
+import com.school_of_company.network.dto.standard.request.StandardRequest
+import com.school_of_company.network.dto.standard.response.StandardAttendListResponse
+import com.school_of_company.network.dto.standard.response.StandardProgramListResponse
+import kotlinx.coroutines.flow.Flow
+
+interface StandardDataSource {
+    fun registerStandardProgram(expoId: String, body: StandardRequest) : Flow<Unit>
+    fun registerStandardListProgram(expoId: String, body: List<StandardRequest>) : Flow<Unit>
+    fun modifyStandardProgram(standardProId: Long, body: StandardRequest) : Flow<Unit>
+    fun deleteStandardProgram(standardProId: Long) : Flow<Unit>
+    fun standardProgramList(expoId: String) : Flow<List<StandardProgramListResponse>>
+    fun standardProgramAttendList(standardProId: Long) : Flow<List<StandardAttendListResponse>>
+}

--- a/core/network/src/main/java/com/school_of_company/network/datasource/standard/StandardDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/standard/StandardDataSourceImpl.kt
@@ -1,0 +1,43 @@
+package com.school_of_company.network.datasource.standard
+
+import com.school_of_company.network.api.StandardAPI
+import com.school_of_company.network.dto.standard.request.StandardRequest
+import com.school_of_company.network.dto.standard.response.StandardAttendListResponse
+import com.school_of_company.network.dto.standard.response.StandardProgramListResponse
+import com.school_of_company.network.util.performApiRequest
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class StandardDataSourceImpl @Inject constructor(
+    private val service: StandardAPI
+) : StandardDataSource {
+    override fun registerStandardProgram(expoId: String, body: StandardRequest): Flow<Unit> =
+        performApiRequest { service.registerStandardProgram(
+            expoId = expoId,
+            body = body
+        ) }
+
+    override fun registerStandardListProgram(
+        expoId: String,
+        body: List<StandardRequest>
+    ): Flow<Unit> =
+        performApiRequest { service.registerStandardListProgram(
+            expoId = expoId,
+            body = body
+        ) }
+
+    override fun modifyStandardProgram(standardProId: Long, body: StandardRequest): Flow<Unit> =
+        performApiRequest { service.modifyStandardProgram(
+            standardProId = standardProId,
+            body = body
+        ) }
+
+    override fun deleteStandardProgram(standardProId: Long): Flow<Unit> =
+        performApiRequest { service.deleteStandardProgram(standardProId = standardProId) }
+
+    override fun standardProgramList(expoId: String): Flow<List<StandardProgramListResponse>> =
+        performApiRequest { service.standardProgramList(expoId = expoId) }
+
+    override fun standardProgramAttendList(standardProId: Long): Flow<List<StandardAttendListResponse>> =
+        performApiRequest { service.standardProgramAttendList(standardProId = standardProId) }
+}

--- a/core/network/src/main/java/com/school_of_company/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/school_of_company/network/di/NetworkModule.kt
@@ -8,6 +8,7 @@ import com.school_of_company.network.api.AuthAPI
 import com.school_of_company.network.api.ExpoAPI
 import com.school_of_company.network.api.ImageAPI
 import com.school_of_company.network.api.SmsAPI
+import com.school_of_company.network.api.StandardAPI
 import com.school_of_company.network.api.TrainingAPI
 import com.school_of_company.network.util.AuthInterceptor
 import com.school_of_company.network.util.TokenAuthenticator
@@ -108,4 +109,9 @@ object NetworkModule {
     @Provides
     fun provideTrainingAPI(retrofit: Retrofit) : TrainingAPI =
         retrofit.create(TrainingAPI::class.java)
+
+    @Provides
+    fun provideStandardAPI(retrofit: Retrofit) : StandardAPI =
+        retrofit.create(StandardAPI::class.java)
+
 }

--- a/core/network/src/main/java/com/school_of_company/network/di/RemoteDataSourceModule.kt
+++ b/core/network/src/main/java/com/school_of_company/network/di/RemoteDataSourceModule.kt
@@ -8,6 +8,8 @@ import com.school_of_company.network.datasource.image.ImageDataSource
 import com.school_of_company.network.datasource.image.ImageDataSourceImpl
 import com.school_of_company.network.datasource.sms.SmsDataSource
 import com.school_of_company.network.datasource.sms.SmsDataSourceImpl
+import com.school_of_company.network.datasource.standard.StandardDataSource
+import com.school_of_company.network.datasource.standard.StandardDataSourceImpl
 import com.school_of_company.network.datasource.training.TrainingDataSource
 import com.school_of_company.network.datasource.training.TrainingDataSourceImpl
 import dagger.Binds
@@ -43,4 +45,9 @@ abstract class RemoteDataSourceModule {
     abstract fun bindTrainingRemoteDataSource(
         trainingDataSourceImpl: TrainingDataSourceImpl
     ) : TrainingDataSource
+
+    @Binds
+    abstract fun bindStandardRemoteDataSource(
+        standardDataSourceImpl: StandardDataSourceImpl
+    ) : StandardDataSource
 }

--- a/core/network/src/main/java/com/school_of_company/network/dto/standard/request/StandardRequest.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/standard/request/StandardRequest.kt
@@ -1,0 +1,11 @@
+package com.school_of_company.network.dto.standard.request
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class StandardRequest(
+    @Json(name = "title") val title: String,
+    @Json(name = "startedAt") val startedAt: String,
+    @Json(name = "endedAt") val endedAt: String,
+)

--- a/core/network/src/main/java/com/school_of_company/network/dto/standard/response/StandardAttendListResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/standard/response/StandardAttendListResponse.kt
@@ -1,0 +1,15 @@
+package com.school_of_company.network.dto.standard.response
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class StandardAttendListResponse(
+    @Json(name = "name") val name: String,
+    @Json(name = "affiliation") val affiliation: String,
+    @Json(name = "position") val position: String,
+    @Json(name = "programName") val programName: String,
+    @Json(name = "status") val status: Boolean,
+    @Json(name = "entryTime") val entryTime: String,
+    @Json(name = "leaveTime") val leaveTime: String
+)

--- a/core/network/src/main/java/com/school_of_company/network/dto/standard/response/StandardProgramListResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/standard/response/StandardProgramListResponse.kt
@@ -1,0 +1,12 @@
+package com.school_of_company.network.dto.standard.response
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class StandardProgramListResponse(
+    @Json(name = "id") val id: Long,
+    @Json(name = "title") val title: String,
+    @Json(name = "startedAt") val startedAt: String,
+    @Json(name = "endedAt") val endedAt: String,
+)

--- a/core/network/src/main/java/com/school_of_company/network/mapper/standard/request/StandardRequestMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/standard/request/StandardRequestMapper.kt
@@ -1,0 +1,11 @@
+package com.school_of_company.network.mapper.standard.request
+
+import com.school_of_company.model.model.standard.StandardRequestModel
+import com.school_of_company.network.dto.standard.request.StandardRequest
+
+fun StandardRequestModel.toDto(): StandardRequest =
+    StandardRequest(
+        title = this.title,
+        startedAt = this.startedAt,
+        endedAt = this.endedAt,
+    )

--- a/core/network/src/main/java/com/school_of_company/network/mapper/standard/response/StandardAttendListResponseMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/standard/response/StandardAttendListResponseMapper.kt
@@ -1,0 +1,15 @@
+package com.school_of_company.network.mapper.standard.response
+
+import com.school_of_company.model.entity.standard.StandardAttendListResponseEntity
+import com.school_of_company.network.dto.standard.response.StandardAttendListResponse
+
+fun StandardAttendListResponse.toModel(): StandardAttendListResponseEntity =
+    StandardAttendListResponseEntity(
+        name = this.name,
+        affiliation = this.affiliation,
+        position = this.position,
+        programName = this.programName,
+        status = this.status,
+        entryTime = this.entryTime,
+        leaveTime = this.leaveTime
+    )

--- a/core/network/src/main/java/com/school_of_company/network/mapper/standard/response/StandardProgramListResponseMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/standard/response/StandardProgramListResponseMapper.kt
@@ -1,0 +1,12 @@
+package com.school_of_company.network.mapper.standard.response
+
+import com.school_of_company.model.entity.standard.StandardProgramListResponseEntity
+import com.school_of_company.network.dto.standard.response.StandardProgramListResponse
+
+fun StandardProgramListResponse.toModel(): StandardProgramListResponseEntity =
+    StandardProgramListResponseEntity(
+        id = this.id,
+        title = this.title,
+        startedAt = this.startedAt,
+        endedAt = this.endedAt,
+    )

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -13,6 +13,7 @@ import com.school_of_company.domain.usecase.expo.GetExpoInformationUseCase
 import com.school_of_company.domain.usecase.expo.GetExpoListUseCase
 import com.school_of_company.domain.usecase.expo.ModifyExpoInformationUseCase
 import com.school_of_company.domain.usecase.expo.RegisterExpoInformationUseCase
+import com.school_of_company.domain.usecase.standard.RegisterStandardListProgramUseCase
 import com.school_of_company.domain.usecase.training.ModifyTrainingProgramUseCase
 import com.school_of_company.domain.usecase.training.RegisterTrainingProgramListUseCase
 import com.school_of_company.domain.usecase.training.RegisterTrainingProgramUseCase
@@ -25,9 +26,11 @@ import com.school_of_company.expo.viewmodel.uistate.ImageUpLoadUiState
 import com.school_of_company.expo.viewmodel.uistate.ModifyExpoInformationUiState
 import com.school_of_company.expo.viewmodel.uistate.ModifyTrainingProgramUiState
 import com.school_of_company.expo.viewmodel.uistate.RegisterExpoInformationUiState
+import com.school_of_company.expo.viewmodel.uistate.RegisterStandardProgramListUiState
 import com.school_of_company.expo.viewmodel.uistate.RegisterTrainingProgramListUiState
 import com.school_of_company.expo.viewmodel.uistate.RegisterTrainingProgramUiState
 import com.school_of_company.model.model.expo.ExpoRequestAndResponseModel
+import com.school_of_company.model.model.standard.StandardRequestModel
 import com.school_of_company.model.model.training.TrainingDtoModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -49,6 +52,7 @@ class ExpoViewModel @Inject constructor(
     private val registerTrainingProgramUseCase: RegisterTrainingProgramUseCase,
     private val registerTrainingProgramListUseCase: RegisterTrainingProgramListUseCase,
     private val modifyTrainingProgramUseCase: ModifyTrainingProgramUseCase,
+    private val registerStandardProgramListUseCase: RegisterStandardListProgramUseCase,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     companion object {
@@ -102,6 +106,9 @@ class ExpoViewModel @Inject constructor(
 
     private val _modifyTrainingProgramUiState = MutableStateFlow<ModifyTrainingProgramUiState>(ModifyTrainingProgramUiState.Loading)
     internal val modifyTrainingProgramUiState = _modifyTrainingProgramUiState.asStateFlow()
+
+    private val _registerStandardProgramListUiState = MutableStateFlow<RegisterStandardProgramListUiState>(RegisterStandardProgramListUiState.Loading)
+    internal val registerStandardProgramListUiState = _registerStandardProgramListUiState.asStateFlow()
 
     internal var modify_title = savedStateHandle.getStateFlow(key = MODIFY_TITLE, initialValue = "")
 
@@ -326,6 +333,27 @@ class ExpoViewModel @Inject constructor(
             }
             .onFailure { error ->
                 _modifyTrainingProgramUiState.value = ModifyTrainingProgramUiState.Error(error)
+            }
+    }
+
+    internal fun registerStandardProgramList(
+        expoId: String,
+        body: List<StandardRequestModel>
+    ) = viewModelScope.launch {
+        _registerStandardProgramListUiState.value = RegisterStandardProgramListUiState.Loading
+        registerStandardProgramListUseCase(
+            expoId = expoId,
+            body = body
+        )
+            .onSuccess {
+                it.catch { remoteError ->
+                    _registerStandardProgramListUiState.value = RegisterStandardProgramListUiState.Error(remoteError)
+                }.collect {
+                    _registerStandardProgramListUiState.value = RegisterStandardProgramListUiState.Success
+                }
+            }
+            .onFailure { error ->
+                _registerStandardProgramListUiState.value = RegisterStandardProgramListUiState.Error(error)
             }
     }
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/RegisterStandardProgramListUiState.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/RegisterStandardProgramListUiState.kt
@@ -1,0 +1,7 @@
+package com.school_of_company.expo.viewmodel.uistate
+
+interface RegisterStandardProgramListUiState {
+    object Loading: RegisterStandardProgramListUiState
+    object Success: RegisterStandardProgramListUiState
+    data class Error(val exception: Throwable): RegisterStandardProgramListUiState
+}


### PR DESCRIPTION
## 💡 개요
- 기능 개발을 하기 위해서는 standard 부분 네트워크 세팅이 필요해보였습니다.
## 📃 작업내용
- standard 부분 네트워크 세팅을 했습니다.
  - add Standard DTO
  - add Standard Model, Entity
  - add Standard Mapper
  - chore NetworkModule
  - add StandardDataSource(Impl)
  - chore RemoteDataSourceModule
  - add StandardRepository(Impl)
  - chore RepositoryModule
  - add StandardUseCase
  - add StandardUiState
  - chore ExpoViewModel 
## 🔀 변경사항
<img width="701" alt="스크린샷 2024-12-01 오전 12 48 34" src="https://github.com/user-attachments/assets/2cf2f1b0-6c07-496a-be1b-12c7debf74d0">

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 표준 프로그램 등록 및 관리 기능을 위한 새로운 인터페이스 및 데이터 모델 추가.
	- 표준 프로그램 목록을 등록하는 기능을 지원하는 새로운 UI 상태 관리 추가.
- **버그 수정**
	- UI 상태 관리 개선으로 인한 사용자 경험 향상.
- **문서화**
	- 새로운 API 및 데이터 모델에 대한 문서화 업데이트.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->