### PR TITLE
🔀 :: (#226) - 일반 프로그램 연수 생성 기능을 구현하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -51,7 +51,6 @@ import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.rememberAsyncImagePainter
-import com.google.android.datatransport.cct.StringMerger
 import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.button.ExpoStateButton
 import com.school_of_company.design_system.component.button.state.ButtonState
@@ -65,7 +64,7 @@ import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.expo.enum.TrainingCategory
 import com.school_of_company.expo.view.component.ExpoAddTextField
-import com.school_of_company.expo.view.component.ExpoTrainingSettingBottomSheet
+import com.school_of_company.expo.view.component.ExpoSettingBottomSheet
 import com.school_of_company.expo.viewmodel.ExpoViewModel
 import com.school_of_company.expo.viewmodel.uistate.ImageUpLoadUiState
 import com.school_of_company.expo.viewmodel.uistate.RegisterExpoInformationUiState
@@ -550,7 +549,7 @@ internal fun ExpoCreateScreen(
 
     if (openTrainingSettingBottomSheet) {
         Dialog(onDismissRequest = { isOpenTrainingSettingBottomSheet(false) }) {
-            ExpoTrainingSettingBottomSheet(
+            ExpoSettingBottomSheet(
                 onCancelClick = { isOpenTrainingSettingBottomSheet(false) },
                 startedTextState = startedTextState,
                 endedTextState = endedTextState,
@@ -564,7 +563,7 @@ internal fun ExpoCreateScreen(
 
     if (openStandardSettingBottomSheet) {
         Dialog(onDismissRequest = { isOpenStandardSettingBottomSheet(false) }) {
-            ExpoTrainingSettingBottomSheet(
+            ExpoSettingBottomSheet(
                 onCancelClick = { isOpenStandardSettingBottomSheet(false) },
                 startedTextState = startedStandardTextState,
                 endedTextState = endedStandardTextState,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -66,7 +66,7 @@ import com.school_of_company.design_system.icon.LeftArrowIcon
 import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.expo.view.component.ExpoAddTextField
-import com.school_of_company.expo.view.component.ExpoTrainingSettingBottomSheet
+import com.school_of_company.expo.view.component.ExpoSettingBottomSheet
 import com.school_of_company.expo.viewmodel.ExpoViewModel
 import com.school_of_company.expo.viewmodel.uistate.ImageUpLoadUiState
 import com.school_of_company.expo.viewmodel.uistate.ModifyExpoInformationUiState
@@ -536,7 +536,7 @@ internal fun ExpoModifyScreen(
 
     if (openTrainingSettingBottomSheet) {
         Dialog(onDismissRequest = { isOpenTrainingSettingBottomSheet(false) }) {
-            ExpoTrainingSettingBottomSheet(
+            ExpoSettingBottomSheet(
                 onCancelClick = { isOpenTrainingSettingBottomSheet(false) },
                 startedTextState = "",
                 endedTextState = "",

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoAddTextField.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoAddTextField.kt
@@ -101,8 +101,6 @@ fun ExpoAddTextField(
                         IconButton(onClick = { onRemoveTextField(index) }) {
                             XIcon(tint = colors.black)
                         }
-
-
                     }
                     Spacer(modifier = Modifier.height(8.dp))
                 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
@@ -41,7 +40,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.component.button.ExpoStateButton
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
-import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
 import com.school_of_company.design_system.icon.CheckIcon
 import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
@@ -50,7 +48,7 @@ import com.school_of_company.expo.enum.TrainingCategory
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ExpoTrainingSettingBottomSheet(
+fun ExpoSettingBottomSheet(
     modifier: Modifier = Modifier,
     onCancelClick: () -> Unit,
     startedTextState: String,
@@ -232,7 +230,7 @@ fun CustomCheckBox(
 @Preview
 @Composable
 private fun ExpoTrainingSettingBottomSheetPreview() {
-    ExpoTrainingSettingBottomSheet(
+    ExpoSettingBottomSheet(
         onCancelClick = {},
         startedTextState = "",
         endedTextState = "",

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoTrainingSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoTrainingSettingBottomSheet.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -59,7 +60,8 @@ fun ExpoTrainingSettingBottomSheet(
     onButtonClick: () -> Unit,
     categoryState: TrainingCategory = TrainingCategory.CHOICE,
     onCategoryChange: (TrainingCategory) -> Unit,
-    focusManager: FocusManager = LocalFocusManager.current
+    focusManager: FocusManager = LocalFocusManager.current,
+    isTraining: Boolean = true
 ) {
     val sheetState = rememberModalBottomSheetState()
 
@@ -149,20 +151,24 @@ fun ExpoTrainingSettingBottomSheet(
                         )
                     }
 
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.Start),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Text(
-                            text = "필수",
-                            style = typography.bodyRegular2,
-                            color = colors.gray500
-                        )
+                    if (isTraining) {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.Start),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "필수",
+                                style = typography.bodyRegular2,
+                                color = colors.gray500
+                            )
 
-                        CustomCheckBox(
-                            categoryState = categoryState,
-                            onCategoryChange = onCategoryChange
-                        )
+                            CustomCheckBox(
+                                categoryState = categoryState,
+                                onCategoryChange = onCategoryChange
+                            )
+                        }
+                    } else {
+                        Spacer(modifier = Modifier.size(1.dp))
                     }
                 }
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -65,20 +65,21 @@ class ExpoViewModel @Inject constructor(
         private const val COVER_IMAGE = "cover_image"
         private const val STARTED = "started"
         private const val ENDED = "ended"
+        private const val STANDARD_STARTED = "standard_started"
+        private const val STANDARD_ENDED = "standard_ended"
     }
 
     private val _swipeRefreshLoading = MutableStateFlow(false)
     val swipeRefreshLoading = _swipeRefreshLoading.asStateFlow()
 
-    private val _trainingProgramTextState = MutableStateFlow<List<String>>(emptyList())
+    private val _trainingProgramTextState = MutableStateFlow(listOf(""))
     internal val trainingProgramTextState = _trainingProgramTextState.asStateFlow()
 
-    private val _standardProgramTextState = MutableStateFlow<List<String>>(emptyList())
+    private val _standardProgramTextState = MutableStateFlow(listOf(""))
     internal val standardProgramTextState = _standardProgramTextState.asStateFlow()
 
     private val _categoryState = MutableStateFlow(TrainingCategory.CHOICE)
     val categoryState = _categoryState.asStateFlow()
-
 
     private val _getExpoInformationUiState = MutableStateFlow<GetExpoInformationUiState>(GetExpoInformationUiState.Loading)
     internal val getExpoInformationUiState = _getExpoInformationUiState.asStateFlow()
@@ -127,6 +128,10 @@ class ExpoViewModel @Inject constructor(
     internal var started = savedStateHandle.getStateFlow(key = STARTED, initialValue = "")
 
     internal var ended = savedStateHandle.getStateFlow(key = ENDED, initialValue = "")
+
+    internal var standardStarted = savedStateHandle.getStateFlow(key = STANDARD_STARTED, initialValue = "")
+
+    internal var standardEnded = savedStateHandle.getStateFlow(key = STANDARD_ENDED, initialValue = "")
 
     internal fun getExpoInformation(expoId: String) = viewModelScope.launch {
         getExpoInformationUseCase(expoId = expoId)
@@ -207,8 +212,8 @@ class ExpoViewModel @Inject constructor(
             onModifyTitleChange("")
             onStartedChange("")
             onEndedChange("")
-            updateTrainingProgramText(-1, "")
-            updateStandardProgramText(-1, "")
+            updateTrainingProgramText(0, "")
+            updateStandardProgramText(0, "")
         }
     }
 
@@ -431,5 +436,13 @@ class ExpoViewModel @Inject constructor(
 
     internal fun onEndedChange(value: String) {
         savedStateHandle[ENDED] = value
+    }
+
+    internal fun onStandardStartedChange(value: String) {
+        savedStateHandle[STANDARD_STARTED] = value
+    }
+
+    internal fun onStandardEndedChange(value: String) {
+        savedStateHandle[STANDARD_ENDED] = value
     }
 }


### PR DESCRIPTION
## 💡 개요
- 일반 프로그램 연수 생성 기능 구현이 필요해보였습니다.
## 📃 작업내용
- 일반 프로그램 연수 생성 기능을 구현하였습니다.
- ExpoViewModel에 리팩터링이 필요한 부분이 있어 수정을 하였습니다.
- 바텀시트의 네이밍을 변경하고, 컴포넌트 재사용성을 높였습니다.

   https://github.com/user-attachments/assets/af6d567d-f20d-4c0e-80e6-b46649b8b34b


## 🔀 변경사항
<img width="664" alt="스크린샷 2024-12-01 오전 3 49 14" src="https://github.com/user-attachments/assets/c21fbbb4-a661-4250-8825-251e46c9304f">

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- Expo 생성 화면에서 표준 프로그램 관리 기능이 추가되었습니다.
	- 표준 설정 다이얼로그가 추가되어 교육 및 표준 프로그램 입력을 통합적으로 처리할 수 있습니다.

- **버그 수정**
	- 컴포넌트 이름 변경으로 인해 UI 요소의 일관성이 유지되었습니다.

- **문서화**
	- 코드 내 불필요한 공백 제거로 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->