### PR TITLE
🔀 :: (#252) - 바텀 네비게이션바에 대한 디자인 변동 사항이 있어 이를 수정하였습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/TopLevelDestination.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/TopLevelDestination.kt
@@ -11,14 +11,12 @@ enum class TopLevelDestination(
         unSelectedIcon = R.drawable.ic_house,
         iconText = "홈"
     ),
-    ROSTER(
-        unSelectedIcon = R.drawable.ic_append,
-        iconText = "박람회 명단"
-    ),
+
     EXPO(
         unSelectedIcon = R.drawable.ic_expo,
         iconText = "박람회 생성"
     ),
+
     PROFILE(
         unSelectedIcon = R.drawable.ic_user,
         iconText = "프로필"


### PR DESCRIPTION
## 💡 개요
- 바텀 네비게이션바에 대한 디자인 변동 사항이 있어 이를 수정할 필요가 있어보입니다.
## 📃 작업내용
- 바텀 네비게이션바에 대한 디자인 변동 사항이 있어 이를 수정하였습니다.
    - TopLevelDestination에 있는 박람회 명단(ROSTER) 부분을 삭제하였습니다. 

    https://github.com/user-attachments/assets/b6acefb5-b4f4-46b4-9806-bdd8349791bf

## 🔀 변경사항
- chore TopLevelDestination
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x