### PR TITLE
🔀 :: (#249) - 프로그램, 프로그램 참가자 관리 페이지의 UI 요소인 Box와 리스트 아이템이 horizontalScroll이 될 수 있게 수정하였습니다.

### DIFF
--- a/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailProgramScreen.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailProgramScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
@@ -31,6 +32,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -156,11 +158,11 @@ internal fun HomeDetailProgramScreen(
 
             Box(
                 modifier = Modifier
+                    .fillMaxWidth()
                     .border(
                         width = 1.dp,
                         color = colors.gray200
                     )
-                    .fillMaxWidth()
                     .padding(
                         horizontal = 16.dp,
                         vertical = 16.dp
@@ -238,7 +240,8 @@ internal fun HomeDetailProgramScreen(
                                 is StandardProgramListUiState.Success -> {
                                     StandardProgramList(
                                         standardItem = standardProgramListUiState.data.toImmutableList(),
-                                        navigateToStandardProgramDetail = navigateToStandardProgramDetail
+                                        navigateToStandardProgramDetail = navigateToStandardProgramDetail,
+                                        horizontalScrollState = scrollState
                                     )
                                 }
 
@@ -294,7 +297,8 @@ internal fun HomeDetailProgramScreen(
                                 is TrainingProgramListUiState.Success -> {
                                     ProgramList(
                                         trainingItem = trainingProgramUiState.data.toImmutableList(),
-                                        navigateToTrainingProgramDetail = navigateToTrainingProgramDetail
+                                        navigateToTrainingProgramDetail = navigateToTrainingProgramDetail,
+                                        horizontalScrollState = scrollState
                                     )
                                 }
 

--- a/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailStandardProgramParticipantScreen.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailStandardProgramParticipantScreen.kt
@@ -209,7 +209,7 @@ internal fun HomeDetailStandardProgramParticipantScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(start = 16.dp)
-                        .horizontalScroll(rememberScrollState())
+                        .horizontalScroll(scrollState)
                 ) {
                     Spacer(modifier = Modifier.width(20.dp))
 
@@ -270,7 +270,12 @@ internal fun HomeDetailStandardProgramParticipantScreen(
             ) {
                 when (standardProgramAttendListUiState) {
                     is StandardProgramAttendListUiState.Loading -> Unit
-                    is StandardProgramAttendListUiState.Success -> HomeDetailStandardParticipantList(item = standardProgramAttendListUiState.data.toImmutableList())
+                    is StandardProgramAttendListUiState.Success -> {
+                        HomeDetailStandardParticipantList(
+                            item = standardProgramAttendListUiState.data.toImmutableList(),
+                            horizontalScrollState = scrollState
+                        )
+                    }
                     is StandardProgramAttendListUiState.Error -> {
                         Column(
                             verticalArrangement = Arrangement.spacedBy(

--- a/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailTrainingProgramParticipantScreen.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/HomeDetailTrainingProgramParticipantScreen.kt
@@ -211,7 +211,7 @@ internal fun HomeDetailProgramParticipantScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(start = 16.dp)
-                        .horizontalScroll(rememberScrollState())
+                        .horizontalScroll(scrollState)
                 ) {
                     Spacer(modifier = Modifier.width(20.dp))
 
@@ -272,7 +272,12 @@ internal fun HomeDetailProgramParticipantScreen(
             ) {
                 when (teacherTrainingProgramListUiState) {
                     is TeacherTrainingProgramListUiState.Loading -> Unit
-                    is TeacherTrainingProgramListUiState.Success -> HomeDetailProgramParticipantList(item = teacherTrainingProgramListUiState.data.toImmutableList())
+                    is TeacherTrainingProgramListUiState.Success -> {
+                        HomeDetailProgramParticipantList(
+                            item = teacherTrainingProgramListUiState.data.toImmutableList(),
+                            horizontalScrollState = scrollState
+                        )
+                    }
                     is TeacherTrainingProgramListUiState.Error -> {
                         Column(
                             verticalArrangement = Arrangement.spacedBy(

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/HomeDetailProgramParticipantList.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/HomeDetailProgramParticipantList.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.home.view.component
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -18,7 +19,8 @@ import kotlinx.collections.immutable.persistentListOf
 @Composable
 fun HomeDetailProgramParticipantList(
     modifier: Modifier = Modifier,
-    item: ImmutableList<TeacherTrainingProgramResponseEntity> = persistentListOf()
+    item: ImmutableList<TeacherTrainingProgramResponseEntity> = persistentListOf(),
+    horizontalScrollState: ScrollState
 ) {
     ExpoAndroidTheme { colors, _ ->
         LazyColumn(
@@ -30,7 +32,8 @@ fun HomeDetailProgramParticipantList(
             itemsIndexed(item) { index, item ->
                 HomeDetailProgramParticipantListItem(
                     index = index + 1,
-                    data = item
+                    data = item,
+                    horizontalScrollState = horizontalScrollState
                 )
             }
         }
@@ -40,7 +43,8 @@ fun HomeDetailProgramParticipantList(
 @Composable
 fun HomeDetailStandardParticipantList(
     modifier: Modifier = Modifier,
-    item: ImmutableList<StandardAttendListResponseEntity> = persistentListOf()
+    item: ImmutableList<StandardAttendListResponseEntity> = persistentListOf(),
+    horizontalScrollState: ScrollState
 ) {
     ExpoAndroidTheme { colors, _ ->
         LazyColumn(
@@ -52,7 +56,8 @@ fun HomeDetailStandardParticipantList(
             itemsIndexed(item) { index, item ->
                 HomeDetailStandardProgramParticipantListItem(
                     index = index + 1,
-                    data = item
+                    data = item,
+                    horizontalScrollState = horizontalScrollState
                 )
             }
         }

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/HomeDetailProgramParticipantListItem.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/HomeDetailProgramParticipantListItem.kt
@@ -25,7 +25,7 @@ fun HomeDetailProgramParticipantListItem(
     modifier: Modifier = Modifier,
     index: Int,
     data: TeacherTrainingProgramResponseEntity,
-    horizontalScrollState: ScrollState = rememberScrollState()
+    horizontalScrollState: ScrollState
 ) {
     ExpoAndroidTheme { colors, typography ->
         Spacer(modifier = Modifier.height(20.dp))
@@ -105,6 +105,7 @@ private fun HomeDetailProgramParticipantListItemPreview() {
             status = true,
             entryTime = "2024-09-12 T 08:30",
             leaveTime = "2024-09-12 T 08:30"
-        )
+        ),
+        horizontalScrollState = rememberScrollState()
     )
 }

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/HomeDetailStandardProgramParticipantListItem.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/HomeDetailStandardProgramParticipantListItem.kt
@@ -25,7 +25,7 @@ fun HomeDetailStandardProgramParticipantListItem(
     modifier: Modifier = Modifier,
     index: Int,
     data: StandardAttendListResponseEntity,
-    horizontalScrollState: ScrollState = rememberScrollState()
+    horizontalScrollState: ScrollState
 ) {
     ExpoAndroidTheme { colors, typography ->
         Spacer(modifier = Modifier.height(20.dp))

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramList.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramList.kt
@@ -1,10 +1,12 @@
 package com.school_of_company.home.view.component
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -19,7 +21,8 @@ import kotlinx.collections.immutable.persistentListOf
 fun ProgramList(
     modifier: Modifier = Modifier,
     trainingItem: ImmutableList<TrainingProgramListResponseEntity> = persistentListOf(),
-    navigateToTrainingProgramDetail: (Long) -> Unit
+    navigateToTrainingProgramDetail: (Long) -> Unit,
+    horizontalScrollState: ScrollState
 ) {
     ExpoAndroidTheme { colors, _ ->
 
@@ -33,7 +36,8 @@ fun ProgramList(
                 ProgramListItem(
                     index = index + 1,
                     data = item,
-                    navigateToTrainingProgramDetail = navigateToTrainingProgramDetail
+                    navigateToTrainingProgramDetail = navigateToTrainingProgramDetail,
+                    horizontalScrollState = horizontalScrollState
                 )
             }
         }
@@ -44,7 +48,8 @@ fun ProgramList(
 fun StandardProgramList(
     modifier: Modifier = Modifier,
     standardItem: ImmutableList<StandardProgramListResponseEntity> = persistentListOf(),
-    navigateToStandardProgramDetail: (Long) -> Unit
+    navigateToStandardProgramDetail: (Long) -> Unit,
+    horizontalScrollState: ScrollState
 ) {
     ExpoAndroidTheme { colors, _ ->
 
@@ -58,7 +63,8 @@ fun StandardProgramList(
                 StandardProgramListItem(
                     index = index + 1,
                     data = item,
-                    navigateToStandardProgramDetail = navigateToStandardProgramDetail
+                    navigateToStandardProgramDetail = navigateToStandardProgramDetail,
+                    horizontalScrollState = horizontalScrollState
                 )
             }
         }
@@ -78,6 +84,7 @@ private fun ProgramListPreview() {
                 category = "ESSENTIAL"
             )
         ),
-        navigateToTrainingProgramDetail = {}
+        navigateToTrainingProgramDetail = {},
+        horizontalScrollState = rememberScrollState()
     )
 }

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramListItem.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/ProgramListItem.kt
@@ -31,7 +31,7 @@ fun ProgramListItem(
     index: Int,
     data: TrainingProgramListResponseEntity,
     navigateToTrainingProgramDetail: (Long) -> Unit,
-    horizontalScrollState: ScrollState = rememberScrollState()
+    horizontalScrollState: ScrollState
 ) {
     ExpoAndroidTheme { colors, typography ->
 
@@ -137,6 +137,7 @@ private fun ProgramListItemPreview() {
             endedAt = "2024-09-12 T 08:30",
             category = "ESSENTIAL"
         ),
-        navigateToTrainingProgramDetail = {}
+        navigateToTrainingProgramDetail = {},
+        horizontalScrollState = rememberScrollState()
     )
 }

--- a/feature/home/src/main/java/com/school_of_company/home/view/component/StandardProgramListItem.kt
+++ b/feature/home/src/main/java/com/school_of_company/home/view/component/StandardProgramListItem.kt
@@ -30,7 +30,7 @@ fun StandardProgramListItem(
     index: Int,
     data: StandardProgramListResponseEntity,
     navigateToStandardProgramDetail: (Long) -> Unit,
-    horizontalScrollState: ScrollState = rememberScrollState()
+    horizontalScrollState: ScrollState
 ) {
     ExpoAndroidTheme { colors, typography ->
 
@@ -108,6 +108,7 @@ private fun StandardProgramListItemPreview() {
             startedAt = "2024-09-12 T 08:30",
             endedAt = "2024-09-12 T 08:30",
         ),
-        navigateToStandardProgramDetail = {}
+        navigateToStandardProgramDetail = {},
+        horizontalScrollState = rememberScrollState()
     )
 }


### PR DESCRIPTION
## 💡 개요
- 프로그램, 프로그램 참가자 관리 페이지의 UI 요소인 Box와 리스트 아이템이 horizontalScroll이 될 수 있도록 수정이 필요해보였습니다.
## 📃 작업내용
- 프로그램, 프로그램 참가자 관리 페이지의 UI 요소인 Box와 리스트 아이템이 horizontalScroll이 될 수 있게 수정을 하였습니다.
    - ScrollState를 별도로 생성하지 않고, 상위 컴포저블에서 하나의 ScrollState를 생성하여 하위 컴포저블들에 전달하도록 변경하여 중첩 스크롤 에러를 일으키지 않고 수정할 수 있었습니다.

    https://github.com/user-attachments/assets/71268c66-2cc9-4cf5-98af-1b41b188093f


## 🔀 변경사항
- chore HomeDetailProgramParticipantList
- chore HomeDetailProgramParticipantListItem
- chore ProgramList
- chore ProgramListItem
- chore StandardProgramListItem
- chore HomeDetailStandardProgramParticipantListItem
- chore HomeDetailProgramScreen
- chore HomeDetail(Training and Standard)ProgramParticipantScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- `HomeDetailProgramScreen`, `HomeDetailStandardProgramParticipantScreen`, `HomeDetailTrainingProgramParticipantScreen`에서 수평 스크롤 기능이 향상되었습니다.
	- 프로그램 참가자 목록 및 표준 프로그램 목록에 대한 수평 스크롤 상태 관리가 추가되었습니다.

- **버그 수정**
	- UI 상태 및 오류 처리 로직이 유지되어 데이터가 없거나 로드 실패 시 사용자에게 피드백을 제공합니다.

- **문서화**
	- 함수 시그니처가 업데이트되어 수평 스크롤 상태를 필수 매개변수로 요구합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->