### PR TITLE
🔀 :: (#271) - Standard, Training 부분 수정 기능을 구현합니다.

### DIFF
--- a/core/data/src/main/java/com/school_of_company/data/repository/attendance/AttendanceRepository.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/attendance/AttendanceRepository.kt
@@ -1,8 +1,10 @@
 package com.school_of_company.data.repository.attendance
 
+import com.school_of_company.model.param.attendance.StandardQrCodeRequestParam
 import com.school_of_company.model.param.attendance.TrainingQrCodeRequestParam
 import kotlinx.coroutines.flow.Flow
 
 interface AttendanceRepository {
     fun trainingQrCode(trainingId: Long, body: TrainingQrCodeRequestParam) : Flow<Unit>
+    fun standardQrCode(standardId: Long, body: StandardQrCodeRequestParam) : Flow<Unit>
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/attendance/AttendanceRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/attendance/AttendanceRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.data.repository.attendance
 
+import com.school_of_company.model.param.attendance.StandardQrCodeRequestParam
 import com.school_of_company.model.param.attendance.TrainingQrCodeRequestParam
 import com.school_of_company.network.datasource.attendance.AttendanceDataSource
 import com.school_of_company.network.mapper.attendance.request.toDto
@@ -15,6 +16,16 @@ class AttendanceRepositoryImpl @Inject constructor(
     ): Flow<Unit> {
         return dataSource.trainingQrCode(
             trainingId = trainingId,
+            body = body.toDto()
+        )
+    }
+
+    override fun standardQrCode(
+        standardId: Long,
+        body: StandardQrCodeRequestParam
+    ): Flow<Unit> {
+        return dataSource.standardQrCode(
+            standardId = standardId,
             body = body.toDto()
         )
     }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/bottomsheet/ExpoSettingDialog.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/bottomsheet/ExpoSettingDialog.kt
@@ -1,0 +1,24 @@
+package com.school_of_company.design_system.component.bottomsheet
+
+import android.util.Log
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.Dialog
+
+@Composable
+fun <T> SettingBottomSheet(
+    isOpen: Boolean,
+    onDismiss: () -> Unit,
+    selectedItem: T?,
+    onUpdateItem: (T) -> Unit,
+    content: @Composable (item: T, updateItem: (T) -> Unit) -> Unit
+) {
+    if (isOpen) {
+        Dialog(onDismissRequest = onDismiss) {
+            if (selectedItem != null) {
+                content(selectedItem, onUpdateItem)
+            } else {
+                Log.d("ExpoModifyScreen - SettingBottomSheet", "selectedItem is null")
+            }
+        }
+    }
+}

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/attendance/StandardQrCodeRequestUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/attendance/StandardQrCodeRequestUseCase.kt
@@ -1,0 +1,19 @@
+package com.school_of_company.domain.usecase.attendance
+
+import com.school_of_company.data.repository.attendance.AttendanceRepository
+import com.school_of_company.model.param.attendance.StandardQrCodeRequestParam
+import javax.inject.Inject
+
+class StandardQrCodeRequestUseCase @Inject constructor(
+    private val repository: AttendanceRepository
+) {
+    operator fun invoke(
+        standardId: Long,
+        body: StandardQrCodeRequestParam
+    ) = runCatching {
+        repository.standardQrCode(
+            standardId = standardId,
+            body = body
+        )
+    }
+}

--- a/core/model/src/main/java/com/school_of_company/model/param/attendance/StandardQrCodeRequestParam.kt
+++ b/core/model/src/main/java/com/school_of_company/model/param/attendance/StandardQrCodeRequestParam.kt
@@ -1,0 +1,6 @@
+package com.school_of_company.model.param.attendance
+
+data class StandardQrCodeRequestParam(
+    val participantId: Long,
+    val phoneNumber: String,
+)

--- a/core/network/src/main/java/com/school_of_company/network/api/AttendanceAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/AttendanceAPI.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.network.api
 
+import com.school_of_company.network.dto.attendance.request.StandardQrCodeRequest
 import com.school_of_company.network.dto.attendance.request.TrainingQrCodeRequest
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -11,5 +12,11 @@ interface AttendanceAPI {
     suspend fun trainingQrCode(
         @Path("trainingPro_id") trainingId: Long,
         @Body body: TrainingQrCodeRequest
+    )
+
+    @GET("/attendance/standard/{standardPro_id}")
+    suspend fun standardQrCode(
+        @Path("standardPro_id") standardId: Long,
+        @Body body: StandardQrCodeRequest
     )
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/attendance/AttendanceDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/attendance/AttendanceDataSource.kt
@@ -1,8 +1,11 @@
 package com.school_of_company.network.datasource.attendance
 
+import com.school_of_company.network.dto.attendance.request.StandardQrCodeRequest
 import com.school_of_company.network.dto.attendance.request.TrainingQrCodeRequest
 import kotlinx.coroutines.flow.Flow
 
 interface AttendanceDataSource {
     fun trainingQrCode(trainingId: Long, body: TrainingQrCodeRequest) : Flow<Unit>
+    fun standardQrCode(standardId: Long, body: StandardQrCodeRequest) : Flow<Unit>
+
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/attendance/AttendanceDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/attendance/AttendanceDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.school_of_company.network.datasource.attendance
 
 import com.school_of_company.network.api.AttendanceAPI
+import com.school_of_company.network.dto.attendance.request.StandardQrCodeRequest
 import com.school_of_company.network.dto.attendance.request.TrainingQrCodeRequest
 import com.school_of_company.network.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
@@ -16,5 +17,14 @@ class AttendanceDataSourceImpl @Inject constructor(
         performApiRequest { service.trainingQrCode(
             body = body,
             trainingId = trainingId
+        ) }
+
+    override fun standardQrCode(
+        standardId: Long,
+        body: StandardQrCodeRequest
+    ): Flow<Unit> =
+        performApiRequest { service.standardQrCode(
+            body = body,
+            standardId = standardId
         ) }
 }

--- a/core/network/src/main/java/com/school_of_company/network/dto/attendance/request/StandardQrCodeRequest.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/attendance/request/StandardQrCodeRequest.kt
@@ -1,0 +1,10 @@
+package com.school_of_company.network.dto.attendance.request
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class StandardQrCodeRequest(
+    @Json(name = "participantId") val participantId: Long,
+    @Json(name = "phoneNumber") val phoneNumber: String,
+)

--- a/core/network/src/main/java/com/school_of_company/network/mapper/attendance/request/StandardQrCodeRequestMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/attendance/request/StandardQrCodeRequestMapper.kt
@@ -1,0 +1,10 @@
+package com.school_of_company.network.mapper.attendance.request
+
+import com.school_of_company.model.param.attendance.StandardQrCodeRequestParam
+import com.school_of_company.network.dto.attendance.request.StandardQrCodeRequest
+
+fun StandardQrCodeRequestParam.toDto(): StandardQrCodeRequest =
+    StandardQrCodeRequest(
+        participantId = this.participantId,
+        phoneNumber = this.phoneNumber
+    )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -171,7 +171,7 @@ internal fun ExpoCreateRoute(
             selectedImageUri = null
             makeToast(context, "박람회 등록을 완료하였습니다.")
             viewModel.initRegisterExpo()
-        } else if (registerTrainingProgramListUiState is RegisterTrainingProgramListUiState.Error && registerStandardProgramListUiState is RegisterStandardProgramListUiState.Error) {
+        } else if (registerTrainingProgramListUiState is RegisterTrainingProgramListUiState.Error || registerStandardProgramListUiState is RegisterStandardProgramListUiState.Error) {
             onErrorToast(null, R.string.expo_register_fail)
         }
     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -542,7 +542,7 @@ internal fun ExpoModifyScreen(
                         },
                         onTrainingSetting = { index ->
                             selectedStandardIndex = index
-                            isOpenTrainingSettingBottomSheet(true)
+                            isOpenStandardSettingBottomSheet(true)
                         },
                         placeHolder = "연수 종류를 입력해주세요."
                     )
@@ -629,7 +629,7 @@ internal fun ExpoModifyScreen(
             SettingBottomSheet(
                 isOpen = openTrainingSettingBottomSheet,
                 onDismiss = { isOpenTrainingSettingBottomSheet(false) },
-                selectedItem = selectedTrainingIndex?.let { trainingProgramTextState[it] },
+                selectedItem = selectedTrainingItem,
                 onUpdateItem = { updateItem ->
                     selectedTrainingIndex?.let { index ->
                         updateExistingTrainingProgram(index, updateItem)
@@ -654,7 +654,7 @@ internal fun ExpoModifyScreen(
             SettingBottomSheet(
                 isOpen = openStandardSettingBottomSheet,
                 onDismiss = { isOpenStandardSettingBottomSheet(false) },
-                selectedItem = selectedStandardIndex?.let { standardProgramTextState[it] },
+                selectedItem = selectedStandardItem,
                 onUpdateItem = { updateItem ->
                     selectedStandardIndex?.let { index ->
                         updateExistingStandardProgram(index, updateItem)

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -54,6 +54,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.rememberAsyncImagePainter
 import com.school_of_company.design_system.R
+import com.school_of_company.design_system.component.bottomsheet.SettingBottomSheet
 import com.school_of_company.design_system.component.button.ExpoStateButton
 import com.school_of_company.design_system.component.button.state.ButtonState
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
@@ -625,19 +626,22 @@ internal fun ExpoModifyScreen(
 
             val selectedTrainingItem = selectedTrainingIndex?.let { trainingProgramTextState[it] }
 
-            if (selectedTrainingItem != null) {
+            SettingBottomSheet(
+                isOpen = openTrainingSettingBottomSheet,
+                onDismiss = { isOpenTrainingSettingBottomSheet(false) },
+                selectedItem = selectedTrainingIndex?.let { trainingProgramTextState[it] },
+                onUpdateItem = { updateItem ->
+                    selectedTrainingIndex?.let { index ->
+                        updateExistingTrainingProgram(index, updateItem)
+                    }
+                }
+            ) { item, updateItem ->
                 ExpoSettingBottomSheet(
                     onCancelClick = { isOpenTrainingSettingBottomSheet(false) },
                     onButtonClick = { isOpenTrainingSettingBottomSheet(false) },
-                    trainingSettingItem = selectedTrainingItem,
-                    onTrainingSettingChange = { updateItem ->
-                        selectedTrainingIndex?.let { index ->
-                            updateExistingTrainingProgram(index, updateItem)
-                        }
-                    }
+                    trainingSettingItem = item,
+                    onTrainingSettingChange = updateItem
                 )
-            } else {
-                Log.d("ExpoModifyScreen", "selectedTrainingItem is null")
             }
         }
     }
@@ -647,19 +651,22 @@ internal fun ExpoModifyScreen(
 
             val selectedStandardItem = selectedStandardIndex?.let { standardProgramTextState[it] }
 
-            if (selectedStandardItem != null) {
+            SettingBottomSheet(
+                isOpen = openStandardSettingBottomSheet,
+                onDismiss = { isOpenStandardSettingBottomSheet(false) },
+                selectedItem = selectedStandardIndex?.let { standardProgramTextState[it] },
+                onUpdateItem = { updateItem ->
+                    selectedStandardIndex?.let { index ->
+                        updateExistingStandardProgram(index, updateItem)
+                    }
+                }
+            ) { item, updateItem ->
                 ExpoStandardSettingBottomSheet(
                     onCancelClick = { isOpenStandardSettingBottomSheet(false) },
                     onButtonClick = { isOpenStandardSettingBottomSheet(false) },
-                    trainingSettingItem = selectedStandardItem,
-                    onTrainingSettingChange = { updateItem ->
-                        selectedStandardIndex?.let { index ->
-                            updateExistingStandardProgram(index, updateItem)
-                        }
-                    },
+                    trainingSettingItem = item,
+                    onTrainingSettingChange = updateItem
                 )
-            } else {
-                Log.d("ExpoModifyScreen", "selectedTrainingItem is null")
             }
         }
     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -104,8 +104,8 @@ internal fun ExpoModifyRoute(
     val addressState by viewModel.address.collectAsStateWithLifecycle()
     val locationState by viewModel.location.collectAsStateWithLifecycle()
     val coverImageState by viewModel.cover_image.collectAsStateWithLifecycle()
-    val trainingProgramTextState by rememberSaveable { mutableStateOf(viewModel.trainingProgramTextState.value) }
-    val standardProgramTextState by rememberSaveable { mutableStateOf(viewModel.standardProgramTextState.value) }
+    val trainingProgramTextState by viewModel.trainingProgramTextState.collectAsStateWithLifecycle()
+    val standardProgramTextState by viewModel.standardProgramTextState.collectAsStateWithLifecycle()
 
     var selectedImageUri by remember { mutableStateOf<Uri?>(null) }
 
@@ -292,6 +292,7 @@ internal fun ExpoModifyScreen(
             false
         )
     }
+
     val (openStandardSettingBottomSheet, isOpenStandardSettingBottomSheet) = rememberSaveable {
         mutableStateOf(
             false

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -35,6 +35,7 @@ import com.school_of_company.expo.viewmodel.uistate.RegisterExpoInformationUiSta
 import com.school_of_company.expo.viewmodel.uistate.RegisterStandardProgramListUiState
 import com.school_of_company.expo.viewmodel.uistate.RegisterTrainingProgramListUiState
 import com.school_of_company.expo.viewmodel.uistate.RegisterTrainingProgramUiState
+import com.school_of_company.model.entity.standard.StandardProgramListResponseEntity
 import com.school_of_company.model.model.expo.ExpoRequestAndResponseModel
 import com.school_of_company.model.model.standard.StandardRequestModel
 import com.school_of_company.model.model.training.TrainingDtoModel
@@ -374,7 +375,17 @@ class ExpoViewModel @Inject constructor(
             .collectLatest { result ->
                 when (result) {
                     is Result.Loading -> _getStandardProgramListUiState.value = GetStandardProgramListUiState.Loading
-                    is Result.Success -> _getStandardProgramListUiState.value = GetStandardProgramListUiState.Success(result.data)
+                    is Result.Success -> {
+                        _getStandardProgramListUiState.value = GetStandardProgramListUiState.Success(result.data)
+
+                        _standardProgramTextState.value = result.data.map { program ->
+                            StandardRequestModel(
+                                title = program.title,
+                                startedAt = program.startedAt,
+                                endedAt = program.endedAt
+                            )
+                        }
+                    }
                     is Result.Error -> _getStandardProgramListUiState.value = GetStandardProgramListUiState.Error(result.exception)
                 }
             }
@@ -387,7 +398,18 @@ class ExpoViewModel @Inject constructor(
             .collectLatest { result ->
                 when (result) {
                     is Result.Loading -> _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Loading
-                    is Result.Success -> _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Success(result.data)
+                    is Result.Success -> {
+                        _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Success(result.data)
+
+                        _trainingProgramTextState.value = result.data.map { program ->
+                            TrainingDtoModel(
+                                title = program.title,
+                                startedAt = program.startedAt,
+                                endedAt = program.endedAt,
+                                category = program.category
+                            )
+                        }
+                    }
                     is Result.Error -> _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Error(result.exception)
                 }
             }

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -13,17 +13,23 @@ import com.school_of_company.domain.usecase.expo.GetExpoInformationUseCase
 import com.school_of_company.domain.usecase.expo.GetExpoListUseCase
 import com.school_of_company.domain.usecase.expo.ModifyExpoInformationUseCase
 import com.school_of_company.domain.usecase.expo.RegisterExpoInformationUseCase
+import com.school_of_company.domain.usecase.standard.ModifyStandardProgramUseCase
 import com.school_of_company.domain.usecase.standard.RegisterStandardListProgramUseCase
+import com.school_of_company.domain.usecase.standard.StandardProgramListUseCase
 import com.school_of_company.domain.usecase.training.ModifyTrainingProgramUseCase
 import com.school_of_company.domain.usecase.training.RegisterTrainingProgramListUseCase
 import com.school_of_company.domain.usecase.training.RegisterTrainingProgramUseCase
+import com.school_of_company.domain.usecase.training.TrainingProgramListUseCase
 import com.school_of_company.expo.enum.TrainingCategory
 import com.school_of_company.expo.util.getMultipartFile
 import com.school_of_company.expo.viewmodel.uistate.DeleteExpoInformationUiState
 import com.school_of_company.expo.viewmodel.uistate.GetExpoInformationUiState
 import com.school_of_company.expo.viewmodel.uistate.GetExpoListUiState
+import com.school_of_company.expo.viewmodel.uistate.GetStandardProgramListUiState
+import com.school_of_company.expo.viewmodel.uistate.GetTrainingProgramListUiState
 import com.school_of_company.expo.viewmodel.uistate.ImageUpLoadUiState
 import com.school_of_company.expo.viewmodel.uistate.ModifyExpoInformationUiState
+import com.school_of_company.expo.viewmodel.uistate.ModifyStandardProgramUiState
 import com.school_of_company.expo.viewmodel.uistate.ModifyTrainingProgramUiState
 import com.school_of_company.expo.viewmodel.uistate.RegisterExpoInformationUiState
 import com.school_of_company.expo.viewmodel.uistate.RegisterStandardProgramListUiState
@@ -48,10 +54,12 @@ class ExpoViewModel @Inject constructor(
     private val deleteExpoInformationUseCase: DeleteExpoInformationUseCase,
     private val getExpoListUseCase: GetExpoListUseCase,
     private val imageUpLoadUseCase: ImageUpLoadUseCase,
-    private val registerTrainingProgramUseCase: RegisterTrainingProgramUseCase,
     private val registerTrainingProgramListUseCase: RegisterTrainingProgramListUseCase,
     private val modifyTrainingProgramUseCase: ModifyTrainingProgramUseCase,
+    private val modifyStandardProgramUseCase: ModifyStandardProgramUseCase,
     private val registerStandardProgramListUseCase: RegisterStandardListProgramUseCase,
+    private val standardProgramListUseCase: StandardProgramListUseCase,
+    private val trainingProgramListUseCase: TrainingProgramListUseCase,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     companion object {
@@ -96,17 +104,23 @@ class ExpoViewModel @Inject constructor(
     private val _imageUpLoadUiState = MutableStateFlow<ImageUpLoadUiState>(ImageUpLoadUiState.Loading)
     internal val imageUpLoadUiState = _imageUpLoadUiState.asStateFlow()
 
-    private val _registerTrainingProgramUiState = MutableStateFlow<RegisterTrainingProgramUiState>(RegisterTrainingProgramUiState.Loading)
-    internal val registerTrainingProgramUiState = _registerTrainingProgramUiState.asStateFlow()
-
     private val _registerTrainingProgramListUiState = MutableStateFlow<RegisterTrainingProgramListUiState>(RegisterTrainingProgramListUiState.Loading)
     internal val registerTrainingProgramListUiState = _registerTrainingProgramListUiState.asStateFlow()
 
     private val _modifyTrainingProgramUiState = MutableStateFlow<ModifyTrainingProgramUiState>(ModifyTrainingProgramUiState.Loading)
     internal val modifyTrainingProgramUiState = _modifyTrainingProgramUiState.asStateFlow()
 
+    private val _modifyStandardProgramUiState = MutableStateFlow<ModifyStandardProgramUiState>(ModifyStandardProgramUiState.Loading)
+    internal val modifyStandardProgramUiState = _modifyStandardProgramUiState.asStateFlow()
+
     private val _registerStandardProgramListUiState = MutableStateFlow<RegisterStandardProgramListUiState>(RegisterStandardProgramListUiState.Loading)
     internal val registerStandardProgramListUiState = _registerStandardProgramListUiState.asStateFlow()
+
+    private val _getStandardProgramListUiState = MutableStateFlow<GetStandardProgramListUiState>(GetStandardProgramListUiState.Loading)
+    internal val getStandardProgramListUiState = _getStandardProgramListUiState.asStateFlow()
+
+    private val _getTrainingProgramListUiState = MutableStateFlow<GetTrainingProgramListUiState>(GetTrainingProgramListUiState.Loading)
+    internal val getTrainingProgramListUiState = _getTrainingProgramListUiState.asStateFlow()
 
     internal var modify_title = savedStateHandle.getStateFlow(key = MODIFY_TITLE, initialValue = "")
 
@@ -188,6 +202,8 @@ class ExpoViewModel @Inject constructor(
 
     internal fun initModifyExpo() {
         _modifyExpoInformationUiState.value = ModifyExpoInformationUiState.Loading
+        _modifyTrainingProgramUiState.value = ModifyTrainingProgramUiState.Loading
+        _modifyStandardProgramUiState.value = ModifyStandardProgramUiState.Loading
     }
 
     internal fun resetExpoInformation() {
@@ -267,27 +283,6 @@ class ExpoViewModel @Inject constructor(
             }
     }
 
-    internal fun registerTrainingProgram(
-        expoId: String,
-        body: TrainingDtoModel
-    ) = viewModelScope.launch {
-        _registerTrainingProgramUiState.value = RegisterTrainingProgramUiState.Loading
-        registerTrainingProgramUseCase(
-            expoId = expoId,
-            body = body
-        )
-            .onSuccess {
-                it.catch { remoteError ->
-                    _registerTrainingProgramUiState.value = RegisterTrainingProgramUiState.Error(remoteError)
-                }.collect {
-                    _registerTrainingProgramUiState.value = RegisterTrainingProgramUiState.Success
-                }
-            }
-            .onFailure { error ->
-                _registerTrainingProgramUiState.value = RegisterTrainingProgramUiState.Error(error)
-            }
-    }
-
     internal fun registerTrainingProgramList(
         expoId: String,
         body: List<TrainingDtoModel>
@@ -330,6 +325,27 @@ class ExpoViewModel @Inject constructor(
             }
     }
 
+    internal fun modifyStandardProgram(
+        standardProId: Long,
+        body: StandardRequestModel
+    ) = viewModelScope.launch {
+        _modifyStandardProgramUiState.value = ModifyStandardProgramUiState.Loading
+        modifyStandardProgramUseCase(
+            standardProId = standardProId,
+            body = body
+        )
+            .onSuccess {
+                it.catch { remoteError ->
+                    _modifyStandardProgramUiState.value = ModifyStandardProgramUiState.Error(remoteError)
+                }.collect {
+                    _modifyStandardProgramUiState.value = ModifyStandardProgramUiState.Success
+                }
+            }
+            .onFailure { error ->
+                _modifyStandardProgramUiState.value = ModifyStandardProgramUiState.Error(error)
+            }
+    }
+
     internal fun registerStandardProgramList(
         expoId: String,
         body: List<StandardRequestModel>
@@ -348,6 +364,32 @@ class ExpoViewModel @Inject constructor(
             }
             .onFailure { error ->
                 _registerStandardProgramListUiState.value = RegisterStandardProgramListUiState.Error(error)
+            }
+    }
+
+    internal fun getStandardProgramList(expoId: String) = viewModelScope.launch {
+        _getStandardProgramListUiState.value = GetStandardProgramListUiState.Loading
+        standardProgramListUseCase(expoId = expoId)
+            .asResult()
+            .collectLatest { result ->
+                when (result) {
+                    is Result.Loading -> _getStandardProgramListUiState.value = GetStandardProgramListUiState.Loading
+                    is Result.Success -> _getStandardProgramListUiState.value = GetStandardProgramListUiState.Success(result.data)
+                    is Result.Error -> _getStandardProgramListUiState.value = GetStandardProgramListUiState.Error(result.exception)
+                }
+            }
+    }
+
+    internal fun getTrainingProgramList(expoId: String) = viewModelScope.launch {
+        _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Loading
+        trainingProgramListUseCase(expoId = expoId)
+            .asResult()
+            .collectLatest { result ->
+                when (result) {
+                    is Result.Loading -> _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Loading
+                    is Result.Success -> _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Success(result.data)
+                    is Result.Error -> _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Error(result.exception)
+                }
             }
     }
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -456,6 +456,18 @@ class ExpoViewModel @Inject constructor(
         }
     }
 
+    internal fun updateExistingTrainingProgram(index: Int, updatedItem: TrainingDtoModel) {
+        _trainingProgramTextState.value = _trainingProgramTextState.value.toMutableList().apply {
+            this[index] = updatedItem
+        }
+    }
+
+    internal fun updateExistingStandardProgram(index: Int, updatedItem: StandardRequestModel) {
+        _standardProgramTextState.value = _standardProgramTextState.value.toMutableList().apply {
+            this[index] = updatedItem
+        }
+    }
+
     internal fun onModifyTitleChange(value: String) {
         savedStateHandle[MODIFY_TITLE] = value
     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetStandardProgramListUiState.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetStandardProgramListUiState.kt
@@ -1,0 +1,9 @@
+package com.school_of_company.expo.viewmodel.uistate
+
+import com.school_of_company.model.entity.standard.StandardProgramListResponseEntity
+
+sealed interface GetStandardProgramListUiState {
+    object Loading: GetStandardProgramListUiState
+    data class Success(val data: List<StandardProgramListResponseEntity>): GetStandardProgramListUiState
+    data class Error(val exception: Throwable): GetStandardProgramListUiState
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetTrainingProgramListUiState.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetTrainingProgramListUiState.kt
@@ -1,0 +1,9 @@
+package com.school_of_company.expo.viewmodel.uistate
+
+import com.school_of_company.model.entity.training.TrainingProgramListResponseEntity
+
+sealed interface GetTrainingProgramListUiState {
+    object Loading: GetTrainingProgramListUiState
+    data class Success(val data: List<TrainingProgramListResponseEntity>): GetTrainingProgramListUiState
+    data class Error(val error: Throwable): GetTrainingProgramListUiState
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/ModifyStandardProgramUiState.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/ModifyStandardProgramUiState.kt
@@ -1,0 +1,7 @@
+package com.school_of_company.expo.viewmodel.uistate
+
+sealed interface ModifyStandardProgramUiState {
+    object Loading : ModifyStandardProgramUiState
+    object Success : ModifyStandardProgramUiState
+    data class Error(val exception: Throwable) : ModifyStandardProgramUiState
+}

--- a/feature/standard/build.gradle.kts
+++ b/feature/standard/build.gradle.kts
@@ -9,4 +9,23 @@ android {
 
 dependencies {
     implementation(libs.swiperefresh)
+
+    implementation(libs.coil.kt)
+    implementation(libs.android.kakao.map)
+
+    implementation(libs.mlkit)
+    implementation(libs.zxing.core)
+
+    implementation(libs.swiperefresh)
+
+    implementation(libs.camera.core)
+    implementation(libs.camera.view)
+    implementation(libs.camera.camera2)
+    implementation(libs.camera.lifecycle)
+    implementation(libs.camera.extensions)
+
+    implementation(libs.accompanist.permission)
+
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.play.services)
 }

--- a/feature/standard/src/main/java/com/school_of_company/standard/viewmodel/StandardViewModel.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/viewmodel/StandardViewModel.kt
@@ -4,18 +4,23 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.school_of_company.common.result.Result
 import com.school_of_company.common.result.asResult
+import com.school_of_company.domain.usecase.attendance.StandardQrCodeRequestUseCase
 import com.school_of_company.domain.usecase.standard.StandardProgramAttendListUseCase
+import com.school_of_company.model.param.attendance.StandardQrCodeRequestParam
 import com.school_of_company.standard.viewmodel.uistate.StandardProgramAttendListUiState
+import com.school_of_company.standard.viewmodel.uistate.StandardQrCodeUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class StandardViewModel @Inject constructor(
-    private val standardProgramAttendListUseCase: StandardProgramAttendListUseCase
+    private val standardProgramAttendListUseCase: StandardProgramAttendListUseCase,
+    private val standardQrCodeRequestUseCase: StandardQrCodeRequestUseCase
 ) : ViewModel() {
 
     private val _swipeRefreshLoading = MutableStateFlow(false)
@@ -23,6 +28,9 @@ class StandardViewModel @Inject constructor(
 
     private val _standardProgramAttendListUiState = MutableStateFlow<StandardProgramAttendListUiState>(StandardProgramAttendListUiState.Loading)
     internal val standardProgramAttendListUiState = _standardProgramAttendListUiState.asStateFlow()
+
+    private val _standardQrCodeUiState = MutableStateFlow<StandardQrCodeUiState>(StandardQrCodeUiState.Loading)
+    internal val standardQrCodeUiState = _standardQrCodeUiState.asStateFlow()
 
     internal fun standardProgramList(standardProId: Long) = viewModelScope.launch {
         _swipeRefreshLoading.value = true
@@ -45,6 +53,27 @@ class StandardViewModel @Inject constructor(
                         _swipeRefreshLoading.value = false
                     }
                 }
+            }
+    }
+
+    internal fun standardQrCode(
+        standardProId: Long,
+        body: StandardQrCodeRequestParam
+    ) = viewModelScope.launch {
+        _standardQrCodeUiState.value = StandardQrCodeUiState.Loading
+        standardQrCodeRequestUseCase(
+            standardId = standardProId,
+            body = body
+        )
+            .onSuccess {
+                it.catch { remoteError ->
+                    _standardQrCodeUiState.value = StandardQrCodeUiState.Error(remoteError)
+                }.collect {
+                    _standardQrCodeUiState.value = StandardQrCodeUiState.Success
+                }
+            }
+            .onFailure { error ->
+                _standardQrCodeUiState.value = StandardQrCodeUiState.Error(error)
             }
     }
 }

--- a/feature/standard/src/main/java/com/school_of_company/standard/viewmodel/uistate/StandardQrCodeUiState.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/viewmodel/uistate/StandardQrCodeUiState.kt
@@ -1,0 +1,7 @@
+package com.school_of_company.standard.viewmodel.uistate
+
+sealed interface StandardQrCodeUiState {
+    object Loading : StandardQrCodeUiState
+    object Success : StandardQrCodeUiState
+    data class Error(val exception: Throwable) : StandardQrCodeUiState
+}


### PR DESCRIPTION
## 💡 개요
- Standard, Training 부분 수정 기능을 개발할 필요가 있었습니다.
## 📃 작업내용
- Standard, Training 부분 수정 기능을 구현하였습니다.
   - 마지막 LaunchedEffect 과정에서 성공을 allTasksSuccess, 실패를  anyTaskError로 사용하여 코드를 깔끔하게 처리하였습니다.
   - Training 수정 로직을 viewModel, Screen에서 처리하였습니다.
   - Standard 수정 로직을 viewModel, Screen에서 처리하였습니다.
   - 각각의 상태를 쉽게 처리할 수 있도록 UiState를 추가하였습니다.
## 🔀 변경사항
- add GetTrainingProgramListUiState
- add ModifyStandardProgramUiState
- add GetStandardProgramListUiState
- chore ExpoModifyScreen
- chore ExpoViewModel
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- 추후 PATCH 메서드를 실행할때 body 값에 맞게 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
	- 표준 프로그램에 대한 QR 코드 요청 기능 추가
	- 엑스포 수정 화면에서 표준 및 훈련 프로그램 목록 관리 기능 개선
	- QR 코드 UI 상태 관리 기능 추가
	- 설정 다이얼로그를 위한 새로운 구성 가능 함수 추가

- **버그 수정**
	- 엑스포 생성 및 수정 화면의 오류 처리 로직 개선

- **종속성 업데이트**
	- 표준 기능 모듈에 새로운 라이브러리 추가 (카메라, ML Kit, QR 코드 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->