### PR TITLE
🔀 :: (#267) - Standard 부분 QR 스캔을 하기 위한 네트워크 세팅 및 ViewModel 로직 작성을 하였습니다. 

### DIFF
--- a/core/data/src/main/java/com/school_of_company/data/repository/attendance/AttendanceRepository.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/attendance/AttendanceRepository.kt
@@ -1,8 +1,10 @@
 package com.school_of_company.data.repository.attendance
 
+import com.school_of_company.model.param.attendance.StandardQrCodeRequestParam
 import com.school_of_company.model.param.attendance.TrainingQrCodeRequestParam
 import kotlinx.coroutines.flow.Flow
 
 interface AttendanceRepository {
     fun trainingQrCode(trainingId: Long, body: TrainingQrCodeRequestParam) : Flow<Unit>
+    fun standardQrCode(standardId: Long, body: StandardQrCodeRequestParam) : Flow<Unit>
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/attendance/AttendanceRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/attendance/AttendanceRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.data.repository.attendance
 
+import com.school_of_company.model.param.attendance.StandardQrCodeRequestParam
 import com.school_of_company.model.param.attendance.TrainingQrCodeRequestParam
 import com.school_of_company.network.datasource.attendance.AttendanceDataSource
 import com.school_of_company.network.mapper.attendance.request.toDto
@@ -15,6 +16,16 @@ class AttendanceRepositoryImpl @Inject constructor(
     ): Flow<Unit> {
         return dataSource.trainingQrCode(
             trainingId = trainingId,
+            body = body.toDto()
+        )
+    }
+
+    override fun standardQrCode(
+        standardId: Long,
+        body: StandardQrCodeRequestParam
+    ): Flow<Unit> {
+        return dataSource.standardQrCode(
+            standardId = standardId,
             body = body.toDto()
         )
     }

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/attendance/StandardQrCodeRequestUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/attendance/StandardQrCodeRequestUseCase.kt
@@ -1,0 +1,19 @@
+package com.school_of_company.domain.usecase.attendance
+
+import com.school_of_company.data.repository.attendance.AttendanceRepository
+import com.school_of_company.model.param.attendance.StandardQrCodeRequestParam
+import javax.inject.Inject
+
+class StandardQrCodeRequestUseCase @Inject constructor(
+    private val repository: AttendanceRepository
+) {
+    operator fun invoke(
+        standardId: Long,
+        body: StandardQrCodeRequestParam
+    ) = runCatching {
+        repository.standardQrCode(
+            standardId = standardId,
+            body = body
+        )
+    }
+}

--- a/core/model/src/main/java/com/school_of_company/model/param/attendance/StandardQrCodeRequestParam.kt
+++ b/core/model/src/main/java/com/school_of_company/model/param/attendance/StandardQrCodeRequestParam.kt
@@ -1,0 +1,6 @@
+package com.school_of_company.model.param.attendance
+
+data class StandardQrCodeRequestParam(
+    val participantId: Long,
+    val phoneNumber: String,
+)

--- a/core/network/src/main/java/com/school_of_company/network/api/AttendanceAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/AttendanceAPI.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.network.api
 
+import com.school_of_company.network.dto.attendance.request.StandardQrCodeRequest
 import com.school_of_company.network.dto.attendance.request.TrainingQrCodeRequest
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -11,5 +12,11 @@ interface AttendanceAPI {
     suspend fun trainingQrCode(
         @Path("trainingPro_id") trainingId: Long,
         @Body body: TrainingQrCodeRequest
+    )
+
+    @GET("/attendance/standard/{standardPro_id}")
+    suspend fun standardQrCode(
+        @Path("standardPro_id") standardId: Long,
+        @Body body: StandardQrCodeRequest
     )
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/attendance/AttendanceDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/attendance/AttendanceDataSource.kt
@@ -1,8 +1,11 @@
 package com.school_of_company.network.datasource.attendance
 
+import com.school_of_company.network.dto.attendance.request.StandardQrCodeRequest
 import com.school_of_company.network.dto.attendance.request.TrainingQrCodeRequest
 import kotlinx.coroutines.flow.Flow
 
 interface AttendanceDataSource {
     fun trainingQrCode(trainingId: Long, body: TrainingQrCodeRequest) : Flow<Unit>
+    fun standardQrCode(standardId: Long, body: StandardQrCodeRequest) : Flow<Unit>
+
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/attendance/AttendanceDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/attendance/AttendanceDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.school_of_company.network.datasource.attendance
 
 import com.school_of_company.network.api.AttendanceAPI
+import com.school_of_company.network.dto.attendance.request.StandardQrCodeRequest
 import com.school_of_company.network.dto.attendance.request.TrainingQrCodeRequest
 import com.school_of_company.network.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
@@ -16,5 +17,14 @@ class AttendanceDataSourceImpl @Inject constructor(
         performApiRequest { service.trainingQrCode(
             body = body,
             trainingId = trainingId
+        ) }
+
+    override fun standardQrCode(
+        standardId: Long,
+        body: StandardQrCodeRequest
+    ): Flow<Unit> =
+        performApiRequest { service.standardQrCode(
+            body = body,
+            standardId = standardId
         ) }
 }

--- a/core/network/src/main/java/com/school_of_company/network/dto/attendance/request/StandardQrCodeRequest.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/attendance/request/StandardQrCodeRequest.kt
@@ -1,0 +1,10 @@
+package com.school_of_company.network.dto.attendance.request
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class StandardQrCodeRequest(
+    @Json(name = "participantId") val participantId: Long,
+    @Json(name = "phoneNumber") val phoneNumber: String,
+)

--- a/core/network/src/main/java/com/school_of_company/network/mapper/attendance/request/StandardQrCodeRequestMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/attendance/request/StandardQrCodeRequestMapper.kt
@@ -1,0 +1,10 @@
+package com.school_of_company.network.mapper.attendance.request
+
+import com.school_of_company.model.param.attendance.StandardQrCodeRequestParam
+import com.school_of_company.network.dto.attendance.request.StandardQrCodeRequest
+
+fun StandardQrCodeRequestParam.toDto(): StandardQrCodeRequest =
+    StandardQrCodeRequest(
+        participantId = this.participantId,
+        phoneNumber = this.phoneNumber
+    )

--- a/feature/standard/build.gradle.kts
+++ b/feature/standard/build.gradle.kts
@@ -9,4 +9,23 @@ android {
 
 dependencies {
     implementation(libs.swiperefresh)
+
+    implementation(libs.coil.kt)
+    implementation(libs.android.kakao.map)
+
+    implementation(libs.mlkit)
+    implementation(libs.zxing.core)
+
+    implementation(libs.swiperefresh)
+
+    implementation(libs.camera.core)
+    implementation(libs.camera.view)
+    implementation(libs.camera.camera2)
+    implementation(libs.camera.lifecycle)
+    implementation(libs.camera.extensions)
+
+    implementation(libs.accompanist.permission)
+
+    implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.play.services)
 }

--- a/feature/standard/src/main/java/com/school_of_company/standard/viewmodel/StandardViewModel.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/viewmodel/StandardViewModel.kt
@@ -4,18 +4,23 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.school_of_company.common.result.Result
 import com.school_of_company.common.result.asResult
+import com.school_of_company.domain.usecase.attendance.StandardQrCodeRequestUseCase
 import com.school_of_company.domain.usecase.standard.StandardProgramAttendListUseCase
+import com.school_of_company.model.param.attendance.StandardQrCodeRequestParam
 import com.school_of_company.standard.viewmodel.uistate.StandardProgramAttendListUiState
+import com.school_of_company.standard.viewmodel.uistate.StandardQrCodeUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class StandardViewModel @Inject constructor(
-    private val standardProgramAttendListUseCase: StandardProgramAttendListUseCase
+    private val standardProgramAttendListUseCase: StandardProgramAttendListUseCase,
+    private val standardQrCodeRequestUseCase: StandardQrCodeRequestUseCase
 ) : ViewModel() {
 
     private val _swipeRefreshLoading = MutableStateFlow(false)
@@ -23,6 +28,9 @@ class StandardViewModel @Inject constructor(
 
     private val _standardProgramAttendListUiState = MutableStateFlow<StandardProgramAttendListUiState>(StandardProgramAttendListUiState.Loading)
     internal val standardProgramAttendListUiState = _standardProgramAttendListUiState.asStateFlow()
+
+    private val _standardQrCodeUiState = MutableStateFlow<StandardQrCodeUiState>(StandardQrCodeUiState.Loading)
+    internal val standardQrCodeUiState = _standardQrCodeUiState.asStateFlow()
 
     internal fun standardProgramList(standardProId: Long) = viewModelScope.launch {
         _swipeRefreshLoading.value = true
@@ -45,6 +53,27 @@ class StandardViewModel @Inject constructor(
                         _swipeRefreshLoading.value = false
                     }
                 }
+            }
+    }
+
+    internal fun standardQrCode(
+        standardProId: Long,
+        body: StandardQrCodeRequestParam
+    ) = viewModelScope.launch {
+        _standardQrCodeUiState.value = StandardQrCodeUiState.Loading
+        standardQrCodeRequestUseCase(
+            standardId = standardProId,
+            body = body
+        )
+            .onSuccess {
+                it.catch { remoteError ->
+                    _standardQrCodeUiState.value = StandardQrCodeUiState.Error(remoteError)
+                }.collect {
+                    _standardQrCodeUiState.value = StandardQrCodeUiState.Success
+                }
+            }
+            .onFailure { error ->
+                _standardQrCodeUiState.value = StandardQrCodeUiState.Error(error)
             }
     }
 }

--- a/feature/standard/src/main/java/com/school_of_company/standard/viewmodel/uistate/StandardQrCodeUiState.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/viewmodel/uistate/StandardQrCodeUiState.kt
@@ -1,0 +1,7 @@
+package com.school_of_company.standard.viewmodel.uistate
+
+sealed interface StandardQrCodeUiState {
+    object Loading : StandardQrCodeUiState
+    object Success : StandardQrCodeUiState
+    data class Error(val exception: Throwable) : StandardQrCodeUiState
+}


### PR DESCRIPTION
## 💡 개요
- Standard 부분 QR 스캔을 하기 위한 네트워크 세팅 및 ViewModel 로직 작성이 필요해보였습니다.
## 📃 작업내용
- Standard 부분 QR 스캔을 하기 위한 네트워크 세팅 및 ViewModel 로직 작성을 하였습니다.
   - DTO, Param 추가
   - Mapper 추가
   - DataSource(Impl) 추가
   - Repository(Impl) 추가
   - UseCase 추가
   - UiState 추가
   - ViewModel에 통신 로직 추가
## 🔀 변경사항
<img width="1242" alt="스크린샷 2025-01-02 오전 10 17 04" src="https://github.com/user-attachments/assets/a1819700-0d63-42e1-a4b5-24063ae0dc95" />

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x