### PR TITLE
🔀 :: (#268) - 바텀 네비게이션바의 디자인 변동 사항을 수용하여 수정하였습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/TopLevelDestination.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/TopLevelDestination.kt
@@ -13,8 +13,13 @@ enum class TopLevelDestination(
     ),
 
     EXPO(
-        unSelectedIcon = R.drawable.ic_expo,
+        unSelectedIcon = R.drawable.ic_plus,
         iconText = "박람회 생성"
+    ),
+
+    EXPO_CREATED(
+        unSelectedIcon = R.drawable.ic_expo,
+        iconText = "등록된 박람회"
     ),
 
     PROFILE(

--- a/app/src/main/java/com/school_of_company/expo_android/ui/ExpoApp.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/ui/ExpoApp.kt
@@ -46,6 +46,7 @@ fun ExpoApp(
     val topLevelDestinationRoute = arrayOf(
         homeRoute,
         expoCreateRoute,
+        // todo : Expo Created Route
         profileRoute
     )
 

--- a/app/src/main/java/com/school_of_company/expo_android/ui/ExpoAppState.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/ui/ExpoAppState.kt
@@ -76,6 +76,7 @@ class ExpoAppState(
             when (topLevelDestination) {
                 TopLevelDestination.HOME -> navController.navigateToHome(topLevelNavOptions)
                 TopLevelDestination.EXPO -> navController.navigateToExpoCreate(topLevelNavOptions)
+                TopLevelDestination.EXPO_CREATED, // todo : Add Navigation Code
                 TopLevelDestination.PROFILE -> navController.navigateToProfile(topLevelNavOptions)
             }
         }


### PR DESCRIPTION
## 💡 개요
- 바텀 네비게이션바에 디자인 변동 사항이 있어 수정할 필요가 있었습니다.
## 📃 작업내용
- 바텀 네비게이션바의 디자인 변동 사항을 수용하여 수정하였습니다.
   - topLevelDestination에 EXPO_CREATED를 추가하였습니다.
   - ExpoApp, ExpoAppState에 추후에 있을 변동 사항에 대한 todo를 작성하였습니다.

       https://github.com/user-attachments/assets/79310e5d-6fb4-4175-9fae-333673540aa5

## 🔀 변경사항
- chore topLevelDestination
- chore ExpoApp
- chore ExpoAppState
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- 추후 해당 화면 퍼블리싱 후 네비게이션 연결 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 박람회 관련 새로운 탐색 옵션 추가
	- 프로필 경로를 최상위 목적지에 포함

- **탐색 변경 사항**
	- "박람회 생성" 및 "등록된 박람회" 아이콘 및 텍스트 업데이트
	- 앱 내비게이션 흐름에 새로운 목적지 통합

<!-- end of auto-generated comment: release notes by coderabbit.ai -->