### PR TITLE
🔀 :: (#277) -  keyboard UI overlap

### DIFF
--- a/feature/signin/src/main/java/com/school_of_company/view/SignInScreen.kt
+++ b/feature/signin/src/main/java/com/school_of_company/view/SignInScreen.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.view
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -9,8 +10,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -74,34 +78,46 @@ internal fun SignInRoute(
                         onSignInClick()
                         makeToast(context, "로그인 성공")
                     }
+
                     is SaveTokenUiState.Error -> {
                         viewModel.setError(true)
-                        onErrorToast((saveTokenUiState as SaveTokenUiState.Error).exception, R.string.expection_saveToken)
+                        onErrorToast(
+                            (saveTokenUiState as SaveTokenUiState.Error).exception,
+                            R.string.expection_saveToken
+                        )
                     }
                 }
             }
+
             is SignInUiState.NotFound -> {
                 viewModel.setNotFoundError(true)
                 onErrorToast(null, R.string.expection_not_found)
             }
+
             is SignInUiState.EmailNotValid -> {
                 viewModel.setIdError(true)
                 onErrorToast(null, R.string.expection_id_not_valid)
             }
+
             is SignInUiState.PasswordValid -> {
                 viewModel.setPasswordError(true)
                 onErrorToast(null, R.string.expection_password_valid)
             }
+
             is SignInUiState.BadRequest -> {
                 viewModel.setBadRequestError(true)
                 onErrorToast(null, R.string.expection_bad_request)
             }
+
             is SignInUiState.Error -> {
                 viewModel.setError(true)
-                onErrorToast((signInUiState as SignInUiState.Error).exception,  R.string.expection_signIn)
+                onErrorToast(
+                    (signInUiState as SignInUiState.Error).exception,
+                    R.string.expection_signIn
+                )
             }
         }
-        onDispose {  }
+        onDispose { }
     }
 
     SignInScreen(
@@ -112,11 +128,13 @@ internal fun SignInRoute(
         onIdChange = viewModel::onIdChange,
         onPasswordChange = viewModel::onPasswordChange,
         onSignUpClick = onSignUpClick,
-        signInCallBack =  {
-            viewModel.signIn(body = AdminSignInRequestParam(
-                nickname = idState,
-                password = passwordState
-            ))
+        signInCallBack = {
+            viewModel.signIn(
+                body = AdminSignInRequestParam(
+                    nickname = idState,
+                    password = passwordState
+                )
+            )
         },
     )
 }
@@ -125,6 +143,7 @@ internal fun SignInRoute(
 internal fun SignInScreen(
     modifier: Modifier = Modifier,
     focusManager: FocusManager = LocalFocusManager.current,
+    scrollState: ScrollState = rememberScrollState(),
     isEmailError: Boolean,
     isPasswordError: Boolean,
     id: String,
@@ -133,8 +152,7 @@ internal fun SignInScreen(
     onPasswordChange: (String) -> Unit,
     onSignUpClick: () -> Unit,
     signInCallBack: () -> Unit,
-    ) {
-
+) {
     var isPasswordVisible by remember { mutableStateOf(false) }
 
     ExpoAndroidTheme { colors, typography ->
@@ -142,6 +160,8 @@ internal fun SignInScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .fillMaxSize()
+                .imePadding()
+                .verticalScroll(scrollState)
                 .background(color = colors.white)
                 .pointerInput(Unit) {
                     detectTapGestures {
@@ -152,7 +172,7 @@ internal fun SignInScreen(
             Spacer(modifier = modifier.padding(top = 150.dp))
 
             Text(
-                text =  stringResource(id = R.string.main_string),
+                text = stringResource(id = R.string.main_string),
                 style = typography.mainTypo,
                 color = colors.main
             )
@@ -167,7 +187,9 @@ internal fun SignInScreen(
             Spacer(modifier = modifier.padding(40.dp))
 
             Column(
-                modifier = modifier.padding(horizontal = 16.dp),
+                modifier = modifier
+                    .padding(horizontal = 16.dp)
+                    .weight(1f),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 ExpoDefaultTextField(
@@ -198,7 +220,9 @@ internal fun SignInScreen(
                     trailingIcon = {
                         EyeIcon(
                             isSelected = isPasswordVisible,
-                            modifier = Modifier.expoClickable { isPasswordVisible = !isPasswordVisible }
+                            modifier = Modifier.expoClickable {
+                                isPasswordVisible = !isPasswordVisible
+                            }
                         )
                     }
                 )
@@ -216,10 +240,11 @@ internal fun SignInScreen(
                         fontWeight = FontWeight.Normal
                     )
 
-                    Spacer(modifier = Modifier
-                        .width(1.dp)
-                        .height(12.dp)
-                        .background(color = colors.gray400)
+                    Spacer(
+                        modifier = Modifier
+                            .width(1.dp)
+                            .height(12.dp)
+                            .background(color = colors.gray400)
                     )
 
                     Text(

--- a/feature/signup/src/main/java/com/school_of_company/signup/view/SignUpScreen.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/view/SignUpScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
@@ -191,6 +192,7 @@ internal fun SignUpScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = modifier
                 .fillMaxSize()
+                .imePadding()
                 .background(color = colors.white)
                 .verticalScroll(scrollState)
                 .pointerInput(Unit) {
@@ -278,7 +280,9 @@ internal fun SignUpScreen(
                     placeholder = "(8~24자 영어(대소문자)/숫자 특수문자 1개이상)",
                     isError = isPasswordValidError,
                     isDisabled = false,
-                    errorText = if (isPasswordValidError) stringResource(id = R.string.expection_password_validdd) else stringResource(id = R.string.wrong_password),
+                    errorText = if (isPasswordValidError) stringResource(id = R.string.expection_password_validdd) else stringResource(
+                        id = R.string.wrong_password
+                    ),
                     onValueChange = onPasswordChange,
                     visualTransformationState = true
                 )
@@ -291,7 +295,9 @@ internal fun SignUpScreen(
                     placeholder = stringResource(id = R.string.retry_password),
                     isError = isPasswordMismatchError,
                     isDisabled = false,
-                    errorText = if (isPasswordMismatchError) stringResource(id = R.string.mismatch_password) else stringResource(id = R.string.wrong_password),
+                    errorText = if (isPasswordMismatchError) stringResource(id = R.string.mismatch_password) else stringResource(
+                        id = R.string.wrong_password
+                    ),
                     onValueChange = onRePasswordChange,
                     visualTransformationState = true
                 )
@@ -336,7 +342,11 @@ internal fun SignUpScreen(
                         isError = isCertificationCodeError,
                         isDisabled = false,
                         errorText = stringResource(id = R.string.valid_certification),
-                        onValueChange = { if (it.length <= 6 && it.all { char -> char.isDigit() }) onCertificationNumberChange(it) },
+                        onValueChange = {
+                            if (it.length <= 6 && it.all { char -> char.isDigit() }) onCertificationNumberChange(
+                                it
+                            )
+                        },
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
                     )
 


### PR DESCRIPTION
아래는 해당 PR에 대한 설명을 작성할 수 있는 템플릿입니다.

---

## 💡 개요
이번 PR은 `SignInScreen`에서 `IME` (Input Method Editor)로 인한 키보드가 화면을 가릴 때, 사용자가 텍스트 필드에 입력을 할 수 있도록 화면의 하단 여백을 자동으로 조정하는 `imePadding`을 추가한 작업입니다.

## 📃 작업 내용
- `SignInScreen`에서 텍스트 입력란을 포함하는 `Column`에 `imePadding`을 추가하여 키보드가 나타날 때 화면 요소가 가려지지 않도록 처리했습니다.
- `imePadding`을 적용하여 키보드가 올라올 때, 화면의 하단 요소들이 밀려서 올라가도록 했습니다.

## 🔀 변경 사항
- `SignInScreen`에서 `Column`에 `imePadding()`을 추가하여 키보드가 화면의 하단을 가릴 경우 자동으로 UI가 조정되도록 했습니다.

```kotlin
Column(
    horizontalAlignment = Alignment.CenterHorizontally,
    modifier = Modifier
        .fillMaxSize()
        .imePadding()  // imePadding 추가
        .verticalScroll(scrollState)
        .background(color = colors.white)
        .pointerInput(Unit) {
            detectTapGestures {
                focusManager.clearFocus()
            }
        }
) { ... }
```

## 🙋‍♂️ 질문 사항
- `imePadding`이 적용되어 텍스트 필드와 버튼이 키보드 위로 밀려 올라오는 동작을 확인했을 때, 예상대로 작동하지 않는 부분이 있으면 알려주세요.

## 🍴 사용 방법
이 변경사항을 사용하려면 `SignInScreen` 컴포저블이 키보드가 나타날 때 자동으로 하단 여백을 추가하도록 설정되어 있어야 합니다. 별도의 추가 작업 없이도 키보드가 나타나면 화면 요소가 자동으로 올라갑니다.

## 🎸 기타
- `imePadding()`은 기본적으로 하단에 여백을 추가하여 키보드가 올라올 때 UI 요소들이 밀리도록 돕습니다. 이는 `Compose`의 새로운 기능으로 사용자 경험을 개선하는 데 중요한 역할을 합니다.

---

위와 같이 PR을 작성하면 됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **사용자 경험 개선**
	- 로그인 및 회원가입 화면에 스크롤 지원 추가
	- 온스크린 키보드 레이아웃 최적화
	- 오류 처리 기능 강화

- **버그 수정**
	- 다양한 로그인/회원가입 상태에 대한 오류 처리 개선
	- 텍스트 필드 입력 시 레이아웃 안정성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->