### PR TITLE
🔀 :: (#286) - 새로 바뀐 baseUrl이 http로 되어있어 안드로이드 스튜디오 자체에서 막는 문제를 전체 HTTP 트래픽을 허용되도록 하였습니다.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <application
         android:name=".ExpoApplication"
         android:allowBackup="true"
+        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
## 💡 개요
- 새로 바뀐 baseUrl이 http로 되어있어 안드로이드 스튜디오 자체에서 막는 문제가 있었습니다.
## 📃 작업내용
- 새로 바뀐 baseUrl이 http로 되어있어 안드로이드 스튜디오 자체에서 막는 문제를 전체 HTTP 트래픽을 허용되도록 하였습니다.
    - app단의 AndroidManifest 파일에 usesCleartextTraffic를 true로 설정하여 트래픽을 허용하였습니다.
## 🔀 변경사항
- chore AndroidManifest(:app)
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **네트워크 설정**
	- 애플리케이션의 클리어텍스트 트래픽 사용을 허용하도록 네트워크 설정을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->