### PR TITLE
🔀 :: (#289) - 회원가입 스크린 디자인 변동사항을 따릅니다.

### DIFF
--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
@@ -161,7 +161,8 @@ fun ExpoNoneLabelTextField(
     onClicked: (() -> Unit)? = null,
     value: String? = null,
     visualTransformationState: Boolean = false,
-) {
+    trailingIcon: @Composable (() -> Unit)? = null
+    ) {
     var text by remember { mutableStateOf(value ?: "") }
     val isFocused = remember { mutableStateOf(false) }
 
@@ -216,7 +217,8 @@ fun ExpoNoneLabelTextField(
                 singleLine = true,
                 readOnly = isReadOnly,
                 keyboardOptions = keyboardOptions,
-                visualTransformation = if (visualTransformationState) PasswordVisualTransformation() else VisualTransformation.None
+                visualTransformation = if (visualTransformationState) PasswordVisualTransformation() else VisualTransformation.None,
+                trailingIcon = trailingIcon
             )
             if (isError) {
                 Row(horizontalArrangement = if (isError) Arrangement.Start else Arrangement.End) {

--- a/feature/signup/src/main/java/com/school_of_company/signup/view/SignUpScreen.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/view/SignUpScreen.kt
@@ -71,7 +71,6 @@ internal fun SignUpRoute(
     val isPasswordMismatchError by viewModel.isPasswordMismatchError.collectAsStateWithLifecycle()
     val isEmailValidError by viewModel.isEmailValidError.collectAsStateWithLifecycle()
     val isCertificationCodeError by viewModel.isCertificationCodeValid.collectAsStateWithLifecycle()
-    val isCertificationResent by viewModel.isCertificationResent.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
     DisposableEffect(signUpUiState) {
@@ -132,7 +131,6 @@ internal fun SignUpRoute(
         isPasswordMismatchError = isPasswordMismatchError,
         isEmailValidError = isEmailValidError,
         isCertificationCodeError = isCertificationCodeError,
-        isCertificationResent = isCertificationResent,
         certificationCallBack = {
             viewModel.certificationCode(
                 phoneNumber = phoneNumber,
@@ -185,12 +183,12 @@ internal fun SignUpScreen(
     isPasswordMismatchError: Boolean,
     isEmailValidError: Boolean,
     isCertificationCodeError: Boolean,
-    isCertificationResent: Boolean,
     signUpCallBack: () -> Unit,
     certificationCallBack: () -> Unit,
     sendCertificationCodeCallBack: () -> Unit
 ) {
     var isPasswordVisible by remember { mutableStateOf(false) }
+    var isCheckPasswordVisible by remember { mutableStateOf(false) }
 
     ExpoAndroidTheme { colors, typography ->
 
@@ -313,15 +311,16 @@ internal fun SignUpScreen(
                         id = R.string.wrong_password
                     ),
                     onValueChange = onRePasswordChange,
-                    visualTransformationState = if (isPasswordVisible) false else true,
+                    visualTransformationState = if (isCheckPasswordVisible) false else true,
                     trailingIcon = {
                         EyeIcon(
-                            isSelected = isPasswordVisible,
+                            isSelected = isCheckPasswordVisible,
                             modifier = Modifier.expoClickable {
-                                isPasswordVisible = !isPasswordVisible
+                                isCheckPasswordVisible = !isCheckPasswordVisible
                             }
                         )
-                    }                )
+                    }
+                )
 
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.Start),
@@ -422,6 +421,5 @@ private fun SignUpScreenPreview() {
         certificationCallBack = {},
         sendCertificationCodeCallBack = {},
         isCertificationCodeError = false,
-        isCertificationResent = false
     )
 }

--- a/feature/signup/src/main/java/com/school_of_company/signup/view/SignUpScreen.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/view/SignUpScreen.kt
@@ -20,6 +20,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
@@ -40,6 +43,7 @@ import com.school_of_company.design_system.component.modifier.clickable.expoClic
 import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
 import com.school_of_company.design_system.component.textfield.ExpoDefaultTextField
 import com.school_of_company.design_system.component.textfield.ExpoNoneLabelTextField
+import com.school_of_company.design_system.icon.EyeIcon
 import com.school_of_company.design_system.icon.LeftArrowIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.param.auth.AdminSignUpRequestParam
@@ -186,6 +190,8 @@ internal fun SignUpScreen(
     certificationCallBack: () -> Unit,
     sendCertificationCodeCallBack: () -> Unit
 ) {
+    var isPasswordVisible by remember { mutableStateOf(false) }
+
     ExpoAndroidTheme { colors, typography ->
 
         Column(
@@ -284,7 +290,15 @@ internal fun SignUpScreen(
                         id = R.string.wrong_password
                     ),
                     onValueChange = onPasswordChange,
-                    visualTransformationState = true
+                    visualTransformationState = if (isPasswordVisible) false else true,
+                    trailingIcon = {
+                        EyeIcon(
+                            isSelected = isPasswordVisible,
+                            modifier = Modifier.expoClickable {
+                                isPasswordVisible = !isPasswordVisible
+                            }
+                        )
+                    }
                 )
 
                 ExpoNoneLabelTextField(
@@ -299,8 +313,15 @@ internal fun SignUpScreen(
                         id = R.string.wrong_password
                     ),
                     onValueChange = onRePasswordChange,
-                    visualTransformationState = true
-                )
+                    visualTransformationState = if (isPasswordVisible) false else true,
+                    trailingIcon = {
+                        EyeIcon(
+                            isSelected = isPasswordVisible,
+                            modifier = Modifier.expoClickable {
+                                isPasswordVisible = !isPasswordVisible
+                            }
+                        )
+                    }                )
 
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.Start),


### PR DESCRIPTION
## 💡 개요
- 회원가입 스크린에 디자인 변동사항이 있어 이를 수정할 필요가 있었습니다.
## 📃 작업내용
- 회원가입 스크린 디자인 변동사항이 있어 이를 수정합니다.
   - 비밀번호를 입력하는 부분에서 trailingIcon을 추가하여 해당 아이콘의 상태에 따라 비밀번호 암호화의 유무가 변경될 수 있도록하였습니다. 
  
      https://github.com/user-attachments/assets/286960af-a047-4f15-ab70-145fe6746072

## 🔀 변경사항
- chore ExpoTextField(ExpoNoneLabelTextField)
- chore SignUpScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x