### PR TITLE
🔀 :: (#294) - 백람회 생성, 수정에서의 이미지 크기 제한을 해제하였습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -86,7 +86,6 @@ fun ExpoNavHost(
             onBackClick = navController::popBackStack,
             onMessageClick = navController::navigateToSmsSendMessage,
             onCheckClick = navController::navigateToProgramDetailParticipantManagement,
-            onQrGenerateClick = {},
             onModifyClick = { id ->
                 navController.navigateToExpoModify(id)
             },

--- a/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
@@ -56,7 +56,6 @@ fun NavGraphBuilder.expoDetailScreen(
     onBackClick: () -> Unit,
     onMessageClick: () -> Unit,
     onCheckClick: () -> Unit,
-    onQrGenerateClick: () -> Unit,
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit
 ) {
@@ -67,7 +66,6 @@ fun NavGraphBuilder.expoDetailScreen(
             onBackClick = onBackClick,
             onMessageClick = onMessageClick,
             onCheckClick = onCheckClick,
-            onQrGenerateClick = onQrGenerateClick,
             onModifyClick = onModifyClick,
             onProgramClick = onProgramClick
         )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -349,7 +349,7 @@ internal fun ExpoCreateScreen(
                     )
 
                     Text(
-                        text = "이미지 328 × 178 사이즈로 등록해주세요.",
+                        text = "이미지 328 × 178 사이즈를 권장합니다.",
                         style = typography.captionRegular2,
                         color = colors.gray300
                     )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -106,11 +106,7 @@ internal fun ExpoCreateRoute(
                 val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
                 context.contentResolver.openInputStream(uri)?.use { inputStream ->
                     BitmapFactory.decodeStream(inputStream, null, options)
-                    if (options.outWidth == 328 && options.outHeight == 178) {
-                        selectedImageUri = uri
-                    } else {
-                        onErrorToast(null, R.string.image_size_error)
-                    }
+                    selectedImageUri = uri
                 }
             }
         }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -50,8 +49,6 @@ import com.school_of_company.expo.viewmodel.ExpoViewModel
 import com.school_of_company.expo.viewmodel.uistate.GetExpoInformationUiState
 import com.school_of_company.expo.viewmodel.uistate.GetStandardProgramListUiState
 import com.school_of_company.expo.viewmodel.uistate.GetTrainingProgramListUiState
-import com.school_of_company.model.entity.training.TrainingProgramListResponseEntity
-import com.school_of_company.model.model.expo.ExpoRequestAndResponseModel
 import com.school_of_company.ui.preview.ExpoPreviews
 import com.school_of_company.ui.util.formatServerDate
 
@@ -61,7 +58,6 @@ internal fun ExpoDetailRoute(
     onBackClick: () -> Unit,
     onMessageClick: () -> Unit,
     onCheckClick: () -> Unit,
-    onQrGenerateClick: () -> Unit,
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit,
     viewModel: ExpoViewModel = hiltViewModel()
@@ -75,11 +71,9 @@ internal fun ExpoDetailRoute(
         getExpoInformationUiState = getExpoInformationUiState,
         getTrainingProgramUiState = getTrainingProgramUiState,
         getStandardProgramUiState = getStandardProgramUiState,
-        qrData = QrCode(content = "121231342352"),
         onBackClick = onBackClick,
         onMessageClick = onMessageClick,
         onCheckClick = onCheckClick,
-        onQrGenerateClick = onQrGenerateClick,
         onModifyClick = onModifyClick,
         onProgramClick = onProgramClick
     )
@@ -99,16 +93,13 @@ internal fun ExpoDetailScreen(
     getExpoInformationUiState: GetExpoInformationUiState,
     getTrainingProgramUiState: GetTrainingProgramListUiState,
     getStandardProgramUiState: GetStandardProgramListUiState,
-    qrData: QrCode,
     onBackClick: () -> Unit,
     onMessageClick: () -> Unit,
     onCheckClick: () -> Unit,
-    onQrGenerateClick: () -> Unit,
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit
 ) {
     val (openDialog, isOpenDialog) = rememberSaveable { mutableStateOf(false) }
-    val (openQrDialog, isOpenQrDialog) = rememberSaveable { mutableStateOf(false) }
 
     ExpoAndroidTheme { colors, typography ->
         when {
@@ -423,15 +414,6 @@ internal fun ExpoDetailScreen(
             )
         }
     }
-
-    if (openQrDialog) {
-        Dialog(onDismissRequest = { isOpenQrDialog(false) }) {
-            com.school_of_company.expo.view.component.QrDialog(
-                data = qrData,
-                onCancelClick = { isOpenQrDialog(false) }
-            )
-        }
-    }
 }
 
 @ExpoPreviews
@@ -442,11 +424,9 @@ private fun HomeDetailScreenPreview() {
         onBackClick = {},
         onMessageClick = {},
         onCheckClick = {},
-        onQrGenerateClick = {},
         onModifyClick = {},
         onProgramClick = {},
-        qrData = QrCode(content = "121231342352"),
-        getExpoInformationUiState = GetExpoInformationUiState.Success(ExpoRequestAndResponseModel(title = "asdf", description = "asdfasdf", startedDay = "afsdf", finishedDay = "asdf", location = "adsf", coverImage = "asdf", x = 126.80042860412009f, y = 35.14308063423194f)),
+        getExpoInformationUiState = GetExpoInformationUiState.Loading,
         getTrainingProgramUiState = GetTrainingProgramListUiState.Loading,
         getStandardProgramUiState = GetStandardProgramListUiState.Loading,
         id = ""

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -435,7 +435,7 @@ internal fun ExpoModifyScreen(
                     )
 
                     Text(
-                        text = "이미지 328 × 178 사이즈로 등록해주세요.",
+                        text = "이미지 328 × 178 사이즈를 권장합니다.",
                         style = typography.captionRegular2,
                         color = colors.gray300
                     )


### PR DESCRIPTION
## 💡 개요
- 박람회 생성, 수정에서 이미지 크기를 넣을때 무조건 정해진 크기로만 해야해서 사용자 입장에서 좋지 않는 경험을 제공하고 있어 정해진 크기가 아닌 아무 크기의 이미지를 추가할 수 있도록 수정이 필요해보였습니다.
## 📃 작업내용
- 박람회 생성, 수정에서의 이미지 크기 제한을 해제하였습니다.
   - 박람회 생성, 수정의 디자인 변동사항을 따랐습니다.
   - 이미지 제한을 두는 if .. else문 코드를 삭제하였습니다.
   - 불필요한 코드를 삭제하였습니다.

   - before
   
       https://github.com/user-attachments/assets/c1453525-2c49-409e-9ef0-907ba0b97183

   - after

       https://github.com/user-attachments/assets/d02d54b6-0579-4728-93be-5d11bbe0539f

## 🔀 변경사항
- chore ExpoCreateScreen
- chore ExpoModifyScreen
- chore ExpoDetailScreen
- chore ExpoNavigation
- chore ExpoNavHost
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **기능 변경**
	- QR 생성 기능 제거
	- 이미지 크기 요구사항을 권장 사항으로 변경

- **사용자 경험 업데이트**
	- 이미지 선택 프로세스 간소화
	- 이미지 크기 안내 메시지 수정 (필수 → 권장)

- **탐색 변경**
	- 엑스포 상세 화면의 탐색 매개변수 간소화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->