### PR TITLE
🔀 :: (#292) -  created expo screen

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.NavHost
 import com.school_of_company.common.exception.*
 import com.school_of_company.design_system.R
 import com.school_of_company.expo.navigation.expoCreateScreen
+import com.school_of_company.expo.navigation.expoCreatedScreen
 import com.school_of_company.expo.navigation.expoDetailScreen
 import com.school_of_company.expo.navigation.expoModifyScreen
 import com.school_of_company.expo.navigation.expoScreen
@@ -139,6 +140,10 @@ fun ExpoNavHost(
         )
 
         expoCreateScreen(
+            onErrorToast = makeErrorToast
+        )
+
+        expoCreatedScreen(
             onErrorToast = makeErrorToast
         )
 

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/button/OutlinedIconTextButton.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/button/OutlinedIconTextButton.kt
@@ -1,0 +1,70 @@
+package com.school_of_company.design_system.component.button
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.component.modifier.clickable.expoClickable
+import com.school_of_company.design_system.icon.TrashIcon
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.design_system.theme.color.ExpoColor
+
+@Composable
+fun OutlinedIconTextButton(
+    modifier: Modifier = Modifier,
+    textValue: String,
+    enabled: Boolean = true,
+    outlineColor: Color = ExpoColor.gray200,
+    contentColor: Color = ExpoColor.gray400,
+    leadingIcon: @Composable (Color) -> @Composable Unit,
+    onClick: () -> Unit,
+) {
+    ExpoAndroidTheme { colors, typography ->
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .expoClickable(enabled = enabled) { onClick() }
+                .background(
+                    color = colors.white,
+                    shape = RoundedCornerShape(size = 6.dp)
+                )
+                .border(
+                    width = 1.dp,
+                    color = outlineColor,
+                    shape = RoundedCornerShape(size = 6.dp)
+                )
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        ) {
+            leadingIcon(contentColor)
+            Text(
+                text = textValue,
+                style = typography.titleBold3,
+                fontWeight = FontWeight.W600,
+                color = contentColor,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun OutlinedIconTextButtonPreview() {
+    OutlinedIconTextButton(
+        leadingIcon = { color -> TrashIcon(tint = color) },
+        onClick = { },
+        textValue = "삭제하기",
+    )
+}

--- a/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
@@ -150,11 +150,15 @@ fun PlusIcon(
 }
 
 @Composable
-fun TrashIcon(modifier: Modifier = Modifier) {
+fun TrashIcon(
+    modifier: Modifier = Modifier,
+    tint: Color = Color.Unspecified,
+) {
     Icon(
         painter = painterResource(id = R.drawable.ic_trash),
         contentDescription = stringResource(id = R.string.trash_description),
-        modifier = modifier
+        modifier = modifier,
+        tint = tint
     )
 }
 
@@ -334,7 +338,9 @@ fun EyeIcon(
     tint: Color = Color.Unspecified
 ) {
     Icon(
-        painter = if (isSelected) painterResource(id = R.drawable.ic_open_eye) else painterResource(id = R.drawable.ic_eye_close),
+        painter = if (isSelected) painterResource(id = R.drawable.ic_open_eye) else painterResource(
+            id = R.drawable.ic_eye_close
+        ),
         contentDescription = "눈 아이콘",
         modifier = modifier,
         tint = tint

--- a/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.school_of_company.expo.view.ExpoCreateRoute
+import com.school_of_company.expo.view.ExpoCreatedRoute
 import com.school_of_company.expo.view.ExpoDetailRoute
 import com.school_of_company.expo.view.ExpoModifyRoute
 import com.school_of_company.expo.view.ExpoRoute
@@ -13,6 +14,7 @@ const val homeRoute = "home_route"
 const val expoDetailRoute=  "expo_detail_route"
 const val expoModifyRoute = "expo_modify_route"
 const val expoCreateRoute = "expo_create_route"
+const val expoCreatedRoute = "expo_created_route"
 
 fun NavController.navigateToHome(navOptions: NavOptions? = null) {
     this.navigate(homeRoute, navOptions)
@@ -40,6 +42,9 @@ fun NavController.navigateToExpoModify(
 
 fun NavController.navigateToExpoCreate(navOptions: NavOptions? = null) {
     this.navigate(expoCreateRoute, navOptions)
+}
+fun NavController.navigateToExpoCreated(navOptions: NavOptions? = null) {
+    this.navigate(expoCreatedRoute, navOptions)
 }
 
 fun NavGraphBuilder.expoScreen(
@@ -95,5 +100,13 @@ fun NavGraphBuilder.expoCreateScreen(
         ExpoCreateRoute(
             onErrorToast = onErrorToast
         )
+    }
+}
+
+fun NavGraphBuilder.expoCreatedScreen(
+    onErrorToast: (throwable: Throwable?, message: Int?) -> Unit
+) {
+    composable(route = expoCreatedRoute) {
+        ExpoCreatedRoute()
     }
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
@@ -43,6 +43,7 @@ fun NavController.navigateToExpoModify(
 fun NavController.navigateToExpoCreate(navOptions: NavOptions? = null) {
     this.navigate(expoCreateRoute, navOptions)
 }
+
 fun NavController.navigateToExpoCreated(navOptions: NavOptions? = null) {
     this.navigate(expoCreatedRoute, navOptions)
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -36,7 +36,7 @@ import com.school_of_company.expo.viewmodel.uistate.GetExpoListUiState
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 
 @Composable
-fun ExpoCreatedRoute(
+internal fun ExpoCreatedRoute(
     modifier: Modifier = Modifier,
     expoViewModel: ExpoViewModel = hiltViewModel(),
 ) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -27,13 +25,14 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.design_system.theme.ExpoTypography
 import com.school_of_company.design_system.theme.color.ColorTheme
-import com.school_of_company.expo.view.component.CreatedExpoListItem
+import com.school_of_company.expo.view.component.CreatedExpoList
 import com.school_of_company.expo.view.component.ExpoCreatedDeleteButton
 import com.school_of_company.expo.view.component.ExpoCreatedTable
 import com.school_of_company.expo.view.component.ExpoCreatedTopCard
 import com.school_of_company.expo.viewmodel.ExpoViewModel
 import com.school_of_company.expo.viewmodel.uistate.GetExpoListUiState
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
+import kotlinx.collections.immutable.immutableListOf
 
 @Composable
 internal fun ExpoCreatedRoute(
@@ -88,22 +87,13 @@ private fun ExpoCreatedScreen(
                     is GetExpoListUiState.Error -> TODO()
                     GetExpoListUiState.Loading -> TODO()
                     is GetExpoListUiState.Success -> {
-                        LazyColumn(
-                            modifier = Modifier.padding(horizontal = 8.dp),
-                            verticalArrangement = Arrangement.spacedBy(20.dp),
-                        ) {
-                            items(getExpoListUiState.data) {
-                                with(it) {
-                                    CreatedExpoListItem(
-                                        selectedIndex = selectedId,
-                                        item = it,
-                                        onClick = { isSelected ->
-                                            setSelectedId(if (isSelected) 0L else id.toLong())
-                                        },
-                                    )
-                                }
-                            }
-                        }
+                        CreatedExpoList(
+                            expoList = getExpoListUiState.data,
+                            onItemClick = { isSelected, id ->
+                                setSelectedId(if (isSelected) 0L else id)
+                            },
+                            selectedIndex = selectedId,
+                        )
                     }
                 }
             }
@@ -120,7 +110,7 @@ private fun ExpoCreatedScreen(
 private fun ExpoCreatedScreenPreview() {
     ExpoCreatedScreen(
         getExpoListUiState = GetExpoListUiState.Success(
-            listOf(
+            immutableListOf(
                 ExpoListResponseEntity(
                     id = "2",
                     title = "제목",

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -33,6 +33,7 @@ import com.school_of_company.expo.viewmodel.ExpoViewModel
 import com.school_of_company.expo.viewmodel.uistate.GetExpoListUiState
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 import kotlinx.collections.immutable.immutableListOf
+import kotlinx.collections.immutable.toPersistentList
 
 @Composable
 internal fun ExpoCreatedRoute(
@@ -88,7 +89,7 @@ private fun ExpoCreatedScreen(
                     GetExpoListUiState.Loading -> TODO()
                     is GetExpoListUiState.Success -> {
                         CreatedExpoList(
-                            expoList = getExpoListUiState.data,
+                            expoList = getExpoListUiState.data.toPersistentList(),
                             onItemClick = { isSelected, id ->
                                 setSelectedId(if (isSelected) 0L else id)
                             },

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.design_system.theme.ExpoTypography
 import com.school_of_company.design_system.theme.color.ColorTheme
+import com.school_of_company.expo.view.component.CreatedExpoListItem
 import com.school_of_company.expo.view.component.ExpoCreatedDeleteButton
 import com.school_of_company.expo.view.component.ExpoCreatedTable
 import com.school_of_company.expo.view.component.ExpoCreatedTopCard

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -1,0 +1,149 @@
+package com.school_of_company.expo.view
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.design_system.theme.ExpoTypography
+import com.school_of_company.design_system.theme.color.ColorTheme
+import com.school_of_company.expo.view.component.CreatedExpoListItem
+import com.school_of_company.expo.view.component.ExpoCreatedDeleteButton
+import com.school_of_company.expo.view.component.ExpoCreatedTable
+import com.school_of_company.expo.view.component.ExpoCreatedTopCard
+import com.school_of_company.expo.viewmodel.ExpoViewModel
+import com.school_of_company.expo.viewmodel.uistate.GetExpoListUiState
+import com.school_of_company.model.entity.expo.ExpoListResponseEntity
+
+@Composable
+fun ExpoCreatedRoute(
+    modifier: Modifier = Modifier,
+    expoViewModel: ExpoViewModel = hiltViewModel(),
+) {
+    val getExpoListUiState by expoViewModel.getExpoListUiState.collectAsStateWithLifecycle()
+
+    ExpoCreatedScreen(
+        modifier = modifier,
+        participantCount = 0,
+        getExpoListUiState = getExpoListUiState,
+        deleteExpoInformation = expoViewModel::deleteExpoInformation,
+    )
+}
+
+@Composable
+fun ExpoCreatedScreen(
+    modifier: Modifier = Modifier,
+    participantCount: Int,
+    getExpoListUiState: GetExpoListUiState,
+    scrollState: ScrollState = rememberScrollState(),
+    deleteExpoInformation: (String) -> Unit,
+) {
+    val (selectedIndex, setSelectedIndex) = rememberSaveable { mutableLongStateOf(0L) }
+
+    ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = modifier
+                .background(color = colors.white)
+                .padding(top = 40.dp)
+                .fillMaxSize(),
+        ) {
+            ExpoCreatedTopCard(
+                modifier = Modifier.fillMaxWidth(),
+                participantCount = participantCount,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Column(
+                verticalArrangement = Arrangement.spacedBy(14.dp, Alignment.CenterVertically),
+                horizontalAlignment = Alignment.Start,
+                modifier = Modifier
+                    .border(width = 1.dp, color = colors.gray200)
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+                    .horizontalScroll(scrollState),
+            ) {
+                ExpoCreatedTable()
+                when (getExpoListUiState) {
+                    GetExpoListUiState.Empty -> TODO()
+                    is GetExpoListUiState.Error -> TODO()
+                    GetExpoListUiState.Loading -> TODO()
+                    is GetExpoListUiState.Success -> {
+                        LazyColumn(
+                            modifier = Modifier.padding(horizontal = 8.dp),
+                            verticalArrangement = Arrangement.spacedBy(20.dp),
+                        ) {
+                            items(getExpoListUiState.data) {
+                                with(it) {
+                                    CreatedExpoListItem(
+                                        selectedIndex = selectedIndex,
+                                        id = id.toLong(),
+                                        title = title,
+                                        startedDay = startedDay,
+                                        finishedDay = finishedDay,
+                                        coverImage = coverImage,
+                                        onClick = { isSelected ->
+                                            setSelectedIndex(if (isSelected) 0L else id.toLong())
+                                        },
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Spacer(modifier = Modifier.height(32.dp))
+            ExpoCreatedDeleteButton(
+                enabled = selectedIndex != 0L,
+                onClick = { deleteExpoInformation("") })
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ExpoCreatedScreenPreview() {
+    ExpoCreatedScreen(
+        getExpoListUiState = GetExpoListUiState.Success(
+            listOf(
+                ExpoListResponseEntity(
+                    id = "2",
+                    title = "제목",
+                    description = "묘사",
+                    startedDay = "어제",
+                    finishedDay = "오늘",
+                    coverImage = null,
+                ),
+                ExpoListResponseEntity(
+                    id = "2",
+                    title = "제목",
+                    description = "묘사",
+                    startedDay = "어제",
+                    finishedDay = "오늘",
+                    coverImage = null,
+                )
+            )
+        ),
+        participantCount = 100,
+        deleteExpoInformation = { _ -> }
+    )
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -27,7 +27,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.design_system.theme.ExpoTypography
 import com.school_of_company.design_system.theme.color.ColorTheme
-import com.school_of_company.expo.view.component.CreatedExpoListItem
 import com.school_of_company.expo.view.component.ExpoCreatedDeleteButton
 import com.school_of_company.expo.view.component.ExpoCreatedTable
 import com.school_of_company.expo.view.component.ExpoCreatedTopCard
@@ -58,7 +57,7 @@ fun ExpoCreatedScreen(
     scrollState: ScrollState = rememberScrollState(),
     deleteExpoInformation: (String) -> Unit,
 ) {
-    val (selectedIndex, setSelectedIndex) = rememberSaveable { mutableLongStateOf(0L) }
+    val (selectedId, setSelectedId) = rememberSaveable { mutableLongStateOf(0L) }
 
     ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
         Column(
@@ -95,14 +94,14 @@ fun ExpoCreatedScreen(
                             items(getExpoListUiState.data) {
                                 with(it) {
                                     CreatedExpoListItem(
-                                        selectedIndex = selectedIndex,
+                                        selectedIndex = selectedId,
                                         id = id.toLong(),
                                         title = title,
                                         startedDay = startedDay,
                                         finishedDay = finishedDay,
                                         coverImage = coverImage,
                                         onClick = { isSelected ->
-                                            setSelectedIndex(if (isSelected) 0L else id.toLong())
+                                            setSelectedId(if (isSelected) 0L else id.toLong())
                                         },
                                     )
                                 }
@@ -113,8 +112,8 @@ fun ExpoCreatedScreen(
             }
             Spacer(modifier = Modifier.height(32.dp))
             ExpoCreatedDeleteButton(
-                enabled = selectedIndex != 0L,
-                onClick = { deleteExpoInformation("") })
+                enabled = selectedId != 0L,
+                onClick = { deleteExpoInformation(selectedId.toString()) })
         }
     }
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -51,7 +51,7 @@ internal fun ExpoCreatedRoute(
 }
 
 @Composable
-fun ExpoCreatedScreen(
+private fun ExpoCreatedScreen(
     modifier: Modifier = Modifier,
     participantCount: Int,
     getExpoListUiState: GetExpoListUiState,
@@ -96,11 +96,7 @@ fun ExpoCreatedScreen(
                                 with(it) {
                                     CreatedExpoListItem(
                                         selectedIndex = selectedId,
-                                        id = id.toLong(),
-                                        title = title,
-                                        startedDay = startedDay,
-                                        finishedDay = finishedDay,
-                                        coverImage = coverImage,
+                                        item = it,
                                         onClick = { isSelected ->
                                             setSelectedId(if (isSelected) 0L else id.toLong())
                                         },
@@ -121,7 +117,7 @@ fun ExpoCreatedScreen(
 
 @Preview
 @Composable
-fun ExpoCreatedScreenPreview() {
+private fun ExpoCreatedScreenPreview() {
     ExpoCreatedScreen(
         getExpoListUiState = GetExpoListUiState.Success(
             listOf(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.expo.view
 
+import CreatedExpoList
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -22,10 +23,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.google.accompanist.swiperefresh.SwipeRefreshState
+import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
-import com.school_of_company.design_system.theme.ExpoTypography
-import com.school_of_company.design_system.theme.color.ColorTheme
-import com.school_of_company.expo.view.component.CreatedExpoList
 import com.school_of_company.expo.view.component.ExpoCreatedDeleteButton
 import com.school_of_company.expo.view.component.ExpoCreatedTable
 import com.school_of_company.expo.view.component.ExpoCreatedTopCard
@@ -41,11 +41,15 @@ internal fun ExpoCreatedRoute(
     expoViewModel: ExpoViewModel = hiltViewModel(),
 ) {
     val getExpoListUiState by expoViewModel.getExpoListUiState.collectAsStateWithLifecycle()
+    val swipeRefreshLoading by expoViewModel.swipeRefreshLoading.collectAsStateWithLifecycle()
+    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing = swipeRefreshLoading)
 
     ExpoCreatedScreen(
         modifier = modifier,
         participantCount = 0,
         getExpoListUiState = getExpoListUiState,
+        swipeRefreshState = swipeRefreshState,
+        initCreatedExpoList = expoViewModel::getExpoList,
         deleteExpoInformation = expoViewModel::deleteExpoInformation,
     )
 }
@@ -56,11 +60,13 @@ private fun ExpoCreatedScreen(
     participantCount: Int,
     getExpoListUiState: GetExpoListUiState,
     scrollState: ScrollState = rememberScrollState(),
+    swipeRefreshState: SwipeRefreshState,
+    initCreatedExpoList: () -> Unit,
     deleteExpoInformation: (String) -> Unit,
 ) {
     val (selectedId, setSelectedId) = rememberSaveable { mutableLongStateOf(0L) }
 
-    ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
+    ExpoAndroidTheme { colors, _ ->
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = modifier
@@ -94,6 +100,8 @@ private fun ExpoCreatedScreen(
                                 setSelectedId(if (isSelected) 0L else id)
                             },
                             selectedIndex = selectedId,
+                            swipeRefreshState = swipeRefreshState,
+                            onRefresh = initCreatedExpoList
                         )
                     }
                 }
@@ -131,6 +139,8 @@ private fun ExpoCreatedScreenPreview() {
             )
         ),
         participantCount = 100,
-        deleteExpoInformation = { _ -> }
+        deleteExpoInformation = { _ -> },
+        swipeRefreshState = SwipeRefreshState(isRefreshing = true),
+        initCreatedExpoList = {}
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoScreen.kt
@@ -58,12 +58,12 @@ internal fun ExpoRoute(
     ExpoScreen(
         swipeRefreshState = swipeRefreshState,
         getExpoListData = getExpoListUiState,
-        getExpoList = { viewModel.expoList() },
+        getExpoList = { viewModel.getExpoList() },
         navigationToDetail = navigationToDetail
     )
 
     LaunchedEffect(Unit) {
-        viewModel.expoList()
+        viewModel.getExpoList()
     }
 }
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
@@ -1,12 +1,14 @@
-package com.school_of_company.expo.view.component
-
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.SwipeRefreshState
+import com.school_of_company.expo.view.component.CreatedExpoListItem
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -14,22 +16,29 @@ import kotlinx.collections.immutable.persistentListOf
 @Composable
 internal fun CreatedExpoList(
     modifier: Modifier = Modifier,
-    expoList: ImmutableList<ExpoListResponseEntity>, // getExpoListUiState.data 대신 데이터 리스트
-    selectedIndex: Long, // 선택된 ID를 전달받음
-    onItemClick: (Boolean, Long) -> Unit, // 클릭 이벤트 콜백
+    expoList: ImmutableList<ExpoListResponseEntity>,
+    selectedIndex: Long,
+    swipeRefreshState: SwipeRefreshState, // 상위에서 전달받은 SwipeRefreshState
+    onItemClick: (Boolean, Long) -> Unit,
+    onRefresh: () -> Unit, // 새로고침 콜백
 ) {
-    LazyColumn(
-        modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(20.dp)
+    SwipeRefresh(
+        state = swipeRefreshState,
+        onRefresh = onRefresh // 새로고침 시 호출되는 함수
     ) {
-        items(expoList) { item ->
-            CreatedExpoListItem(
-                selectedIndex = selectedIndex,
-                item = item,
-                onClick = { isSelected ->
-                    onItemClick(isSelected, item.id.toLong())
-                }
-            )
+        LazyColumn(
+            modifier = modifier,
+            verticalArrangement = Arrangement.spacedBy(20.dp)
+        ) {
+            items(expoList) { item ->
+                CreatedExpoListItem(
+                    selectedIndex = selectedIndex,
+                    item = item,
+                    onClick = { isSelected ->
+                        onItemClick(isSelected, item.id.toLong())
+                    }
+                )
+            }
         }
     }
 }
@@ -37,6 +46,8 @@ internal fun CreatedExpoList(
 @Preview
 @Composable
 fun CreatedExpoListPreview() {
+    val swipeRefreshState = remember { SwipeRefreshState(false) }
+
     CreatedExpoList(
         expoList = persistentListOf(
             ExpoListResponseEntity(
@@ -49,6 +60,8 @@ fun CreatedExpoListPreview() {
             ),
         ),
         onItemClick = { _, _ -> },
-        selectedIndex = 1
+        selectedIndex = 1,
+        onRefresh = { /* 새로고침 시 동작할 함수 */ },
+        swipeRefreshState = swipeRefreshState // 상위에서 전달한 상태
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
@@ -7,7 +7,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
 import com.google.accompanist.swiperefresh.SwipeRefreshState
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.expo.view.component.CreatedExpoListItem
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 import kotlinx.collections.immutable.ImmutableList
@@ -22,22 +24,31 @@ internal fun CreatedExpoList(
     onItemClick: (Boolean, Long) -> Unit,
     onRefresh: () -> Unit, // 새로고침 콜백
 ) {
-    SwipeRefresh(
-        state = swipeRefreshState,
-        onRefresh = onRefresh // 새로고침 시 호출되는 함수
-    ) {
-        LazyColumn(
-            modifier = modifier,
-            verticalArrangement = Arrangement.spacedBy(20.dp)
-        ) {
-            items(expoList) { item ->
-                CreatedExpoListItem(
-                    selectedIndex = selectedIndex,
-                    item = item,
-                    onClick = { isSelected ->
-                        onItemClick(isSelected, item.id.toLong())
-                    }
+    ExpoAndroidTheme { colors, _ ->
+        SwipeRefresh(
+            state = swipeRefreshState,
+            onRefresh = onRefresh,// 새로고침 시 호출되는 함수
+            indicator = { state, refreshTrigger ->
+                SwipeRefreshIndicator(
+                    state = state,
+                    refreshTriggerDistance = refreshTrigger,
+                    contentColor = colors.main
                 )
+            }
+        ) {
+            LazyColumn(
+                modifier = modifier,
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                items(expoList) { item ->
+                    CreatedExpoListItem(
+                        selectedIndex = selectedIndex,
+                        item = item,
+                        onClick = { isSelected ->
+                            onItemClick(isSelected, item.id.toLong())
+                        }
+                    )
+                }
             }
         }
     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
@@ -1,0 +1,54 @@
+package com.school_of_company.expo.view.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.model.entity.expo.ExpoListResponseEntity
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+internal fun CreatedExpoList(
+    modifier: Modifier = Modifier,
+    expoList: ImmutableList<ExpoListResponseEntity>, // getExpoListUiState.data 대신 데이터 리스트
+    selectedIndex: Long, // 선택된 ID를 전달받음
+    onItemClick: (Boolean, Long) -> Unit, // 클릭 이벤트 콜백
+) {
+    LazyColumn(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        items(expoList) { item ->
+            CreatedExpoListItem(
+                selectedIndex = selectedIndex,
+                item = item,
+                onClick = { isSelected ->
+                    onItemClick(isSelected, item.id.toLong())
+                }
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun CreatedExpoListPreview() {
+    CreatedExpoList(
+        expoList = persistentListOf(
+            ExpoListResponseEntity(
+                id = "1",
+                title = "2024 AI광주미래교육박람회",
+                description = "",
+                startedDay = "09.10",
+                finishedDay = "09.20",
+                coverImage = null
+            ),
+        ),
+        onItemClick = { _, _ -> },
+        selectedIndex = 1
+    )
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -55,9 +55,9 @@ fun CreatedExpoListItem(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 if (coverImage == null) {
-                    XIcon()
+                    XIcon(tint = colors.error)
                 } else {
-                    CircleIcon()
+                    CircleIcon(tint = colors.black)
                 }
                 Text(
                     text = title,
@@ -82,12 +82,12 @@ fun CreatedExpoListItem(
 @Composable
 fun CreatedExpoListItemNotSelectedPreview() {
     CreatedExpoListItem(
-        id = 2,
+        id = 0,
         coverImage = null,
         startedDay = "시작날",
         finishedDay = "끝날",
         title = "제목입니다",
-        selectedIndex = 0,
+        selectedIndex = 1,
         onClick = { _ -> },
     )
 }
@@ -96,12 +96,12 @@ fun CreatedExpoListItemNotSelectedPreview() {
 @Composable
 fun CreatedExpoListItemSelectedPreview() {
     CreatedExpoListItem(
-        id = 2,
+        id = 1,
         coverImage = null,
         startedDay = "시작날",
         finishedDay = "끝날",
         title = "제목입니다",
-        selectedIndex = 0,
+        selectedIndex = 1,
         onClick = { _ -> },
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -89,7 +89,7 @@ private fun CreatedExpoListItemNotSelectedPreview() {
             finishedDay = "09.20",
             coverImage = null
         ),
-        selectedIndex = 1,
+        selectedIndex = 0,
         onClick = { _ -> },
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -82,11 +82,11 @@ internal fun CreatedExpoListItem(
 private fun CreatedExpoListItemNotSelectedPreview() {
     CreatedExpoListItem(
         item = ExpoListResponseEntity(
-            id = "",
-            title = "",
+            id = "1",
+            title = "2024 AI광주미래교육박람회",
             description = "",
-            startedDay = "",
-            finishedDay = "",
+            startedDay = "09.10",
+            finishedDay = "09.20",
             coverImage = null
         ),
         selectedIndex = 1,
@@ -100,10 +100,10 @@ private fun CreatedExpoListItemSelectedPreview() {
     CreatedExpoListItem(
         item = ExpoListResponseEntity(
             id = "1",
-            title = "",
+            title = "2024 AI광주미래교육박람회",
             description = "",
-            startedDay = "",
-            finishedDay = "",
+            startedDay = "09.10",
+            finishedDay = "09.20",
             coverImage = null
         ),
         selectedIndex = 1,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -64,14 +64,7 @@ fun CreatedExpoListItem(
                     textAlign = TextAlign.Center,
                 )
                 Text(
-                    text = startedDay,
-                    style = typography.captionRegular2,
-                    fontWeight = FontWeight.W400,
-                    color = colors.black,
-                    textAlign = TextAlign.Center,
-                )
-                Text(
-                    text = finishedDay,
+                    text = "$startedDay ~ $finishedDay",
                     style = typography.captionRegular2,
                     fontWeight = FontWeight.W400,
                     color = colors.black,
@@ -94,6 +87,7 @@ fun CreatedExpoListItemNotSelectedPreview() {
         isSelected = false,
     )
 }
+
 @Preview
 @Composable
 fun CreatedExpoListItemSelectedPreview() {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.icon.CircleIcon
 import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
@@ -28,6 +29,7 @@ fun CreatedExpoListItem(
     startedDay: String,
     finishedDay: String,
     coverImage: String?,
+    onClick: (Boolean) -> Unit,
 ) {
     ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
         Row(
@@ -86,6 +88,7 @@ fun CreatedExpoListItemNotSelectedPreview() {
         finishedDay = "끝날",
         title = "제목입니다",
         selectedIndex = 0,
+        onClick = { _ -> },
     )
 }
 
@@ -99,5 +102,6 @@ fun CreatedExpoListItemSelectedPreview() {
         finishedDay = "끝날",
         title = "제목입니다",
         selectedIndex = 0,
+        onClick = { _ -> },
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -19,60 +19,59 @@ import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.design_system.theme.ExpoTypography
 import com.school_of_company.design_system.theme.color.ColorTheme
+import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 
 @Composable
 internal fun CreatedExpoListItem(
     modifier: Modifier = Modifier,
     selectedIndex: Long,
-    id: Long,
-    title: String,
-    startedDay: String,
-    finishedDay: String,
-    coverImage: String?,
+    item: ExpoListResponseEntity,
     onClick: (Boolean) -> Unit,
 ) {
-    ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(38.dp, Alignment.Start),
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = modifier
-                .background(
-                    color = if (selectedIndex == id) colors.main100 else colors.white,
-                    shape = RoundedCornerShape(size = 4.dp)
-                )
-                .expoClickable { onClick(selectedIndex == id) }
-                .padding(8.dp),
-        ) {
-            Text(
-                text = id.toString(),
-                style = typography.captionBold1,
-                fontWeight = FontWeight.W600,
-                color = colors.black,
-                textAlign = TextAlign.Center,
-            )
+    with(item) {
+        ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
             Row(
-                horizontalArrangement = Arrangement.spacedBy(48.dp, Alignment.Start),
+                horizontalArrangement = Arrangement.spacedBy(38.dp, Alignment.Start),
                 verticalAlignment = Alignment.CenterVertically,
+                modifier = modifier
+                    .background(
+                        color = if (selectedIndex == id.toLong()) colors.main100 else colors.white,
+                        shape = RoundedCornerShape(size = 4.dp)
+                    )
+                    .expoClickable { onClick(selectedIndex == id.toLong()) }
+                    .padding(8.dp),
             ) {
-                if (coverImage == null) {
-                    XIcon(tint = colors.error)
-                } else {
-                    CircleIcon(tint = colors.black)
+                Text(
+                    text = id.toString(),
+                    style = typography.captionBold1,
+                    fontWeight = FontWeight.W600,
+                    color = colors.black,
+                    textAlign = TextAlign.Center,
+                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(48.dp, Alignment.Start),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    if (coverImage == null) {
+                        XIcon(tint = colors.error)
+                    } else {
+                        CircleIcon(tint = colors.black)
+                    }
+                    Text(
+                        text = title,
+                        style = typography.captionRegular2,
+                        fontWeight = FontWeight.W400,
+                        color = colors.black,
+                        textAlign = TextAlign.Center,
+                    )
+                    Text(
+                        text = "$startedDay ~ $finishedDay",
+                        style = typography.captionRegular2,
+                        fontWeight = FontWeight.W400,
+                        color = colors.black,
+                        textAlign = TextAlign.Center,
+                    )
                 }
-                Text(
-                    text = title,
-                    style = typography.captionRegular2,
-                    fontWeight = FontWeight.W400,
-                    color = colors.black,
-                    textAlign = TextAlign.Center,
-                )
-                Text(
-                    text = "$startedDay ~ $finishedDay",
-                    style = typography.captionRegular2,
-                    fontWeight = FontWeight.W400,
-                    color = colors.black,
-                    textAlign = TextAlign.Center,
-                )
             }
         }
     }
@@ -82,11 +81,14 @@ internal fun CreatedExpoListItem(
 @Composable
 private fun CreatedExpoListItemNotSelectedPreview() {
     CreatedExpoListItem(
-        id = 0,
-        coverImage = null,
-        startedDay = "시작날",
-        finishedDay = "끝날",
-        title = "제목입니다",
+        item = ExpoListResponseEntity(
+            id = "",
+            title = "",
+            description = "",
+            startedDay = "",
+            finishedDay = "",
+            coverImage = null
+        ),
         selectedIndex = 1,
         onClick = { _ -> },
     )
@@ -96,11 +98,14 @@ private fun CreatedExpoListItemNotSelectedPreview() {
 @Composable
 private fun CreatedExpoListItemSelectedPreview() {
     CreatedExpoListItem(
-        id = 1,
-        coverImage = null,
-        startedDay = "시작날",
-        finishedDay = "끝날",
-        title = "제목입니다",
+        item = ExpoListResponseEntity(
+            id = "1",
+            title = "",
+            description = "",
+            startedDay = "",
+            finishedDay = "",
+            coverImage = null
+        ),
         selectedIndex = 1,
         onClick = { _ -> },
     )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -21,7 +21,7 @@ import com.school_of_company.design_system.theme.ExpoTypography
 import com.school_of_company.design_system.theme.color.ColorTheme
 
 @Composable
-fun CreatedExpoListItem(
+internal fun CreatedExpoListItem(
     modifier: Modifier = Modifier,
     selectedIndex: Long,
     id: Long,
@@ -80,7 +80,7 @@ fun CreatedExpoListItem(
 
 @Preview
 @Composable
-fun CreatedExpoListItemNotSelectedPreview() {
+private fun CreatedExpoListItemNotSelectedPreview() {
     CreatedExpoListItem(
         id = 0,
         coverImage = null,
@@ -94,7 +94,7 @@ fun CreatedExpoListItemNotSelectedPreview() {
 
 @Preview
 @Composable
-fun CreatedExpoListItemSelectedPreview() {
+private fun CreatedExpoListItemSelectedPreview() {
     CreatedExpoListItem(
         id = 1,
         coverImage = null,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -1,0 +1,108 @@
+package com.school_of_company.expo.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.icon.CircleIcon
+import com.school_of_company.design_system.icon.XIcon
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.design_system.theme.ExpoTypography
+import com.school_of_company.design_system.theme.color.ColorTheme
+
+@Composable
+fun CreatedExpoListItem(
+    modifier: Modifier = Modifier,
+    isSelected: Boolean,
+    id: Long,
+    title: String,
+    startedDay: String,
+    finishedDay: String,
+    coverImage: String?
+) {
+    ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(38.dp, Alignment.Start),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .background(
+                    color = if (isSelected) colors.main100 else colors.white,
+                    shape = RoundedCornerShape(size = 4.dp)
+                )
+                .padding(8.dp),
+        ) {
+            Text(
+                text = id.toString(),
+                style = typography.captionBold1,
+                fontWeight = FontWeight.W600,
+                color = colors.black,
+                textAlign = TextAlign.Center,
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(48.dp, Alignment.Start),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                if (coverImage == null) {
+                    XIcon()
+                } else {
+                    CircleIcon()
+                }
+                Text(
+                    text = title,
+                    style = typography.captionRegular2,
+                    fontWeight = FontWeight.W400,
+                    color = colors.black,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = startedDay,
+                    style = typography.captionRegular2,
+                    fontWeight = FontWeight.W400,
+                    color = colors.black,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = finishedDay,
+                    style = typography.captionRegular2,
+                    fontWeight = FontWeight.W400,
+                    color = colors.black,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun CreatedExpoListItemNotSelectedPreview() {
+    CreatedExpoListItem(
+        id = 2,
+        coverImage = null,
+        startedDay = "시작날",
+        finishedDay = "끝날",
+        title = "제목입니다",
+        isSelected = false,
+    )
+}
+@Preview
+@Composable
+fun CreatedExpoListItemSelectedPreview() {
+    CreatedExpoListItem(
+        id = 2,
+        coverImage = null,
+        startedDay = "시작날",
+        finishedDay = "끝날",
+        title = "제목입니다",
+        isSelected = true,
+    )
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -22,12 +22,12 @@ import com.school_of_company.design_system.theme.color.ColorTheme
 @Composable
 fun CreatedExpoListItem(
     modifier: Modifier = Modifier,
-    isSelected: Boolean,
+    selectedIndex: Long,
     id: Long,
     title: String,
     startedDay: String,
     finishedDay: String,
-    coverImage: String?
+    coverImage: String?,
 ) {
     ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
         Row(
@@ -35,9 +35,10 @@ fun CreatedExpoListItem(
             verticalAlignment = Alignment.CenterVertically,
             modifier = modifier
                 .background(
-                    color = if (isSelected) colors.main100 else colors.white,
+                    color = if (selectedIndex == id) colors.main100 else colors.white,
                     shape = RoundedCornerShape(size = 4.dp)
                 )
+                .expoClickable { onClick(selectedIndex == id) }
                 .padding(8.dp),
         ) {
             Text(
@@ -84,7 +85,7 @@ fun CreatedExpoListItemNotSelectedPreview() {
         startedDay = "시작날",
         finishedDay = "끝날",
         title = "제목입니다",
-        isSelected = false,
+        selectedIndex = 0,
     )
 }
 
@@ -97,6 +98,6 @@ fun CreatedExpoListItemSelectedPreview() {
         startedDay = "시작날",
         finishedDay = "끝날",
         title = "제목입니다",
-        isSelected = true,
+        selectedIndex = 0,
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedDeleteButton.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedDeleteButton.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.icon.TrashIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.design_system.theme.ExpoTypography
@@ -22,12 +23,14 @@ import com.school_of_company.design_system.theme.color.ColorTheme
 fun ExpoCreatedDeleteButton(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    onClick: () -> Unit,
 ) {
     ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
         Row(
             horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
             verticalAlignment = Alignment.CenterVertically,
             modifier = modifier
+                .expoClickable { onClick() }
                 .background(
                     color = if (enabled) colors.error
                     else colors.white,
@@ -54,11 +57,11 @@ fun ExpoCreatedDeleteButton(
 @Preview
 @Composable
 fun ExpoCreatedDeleteButtonEnabled() {
-    ExpoCreatedDeleteButton(enabled = true)
+    ExpoCreatedDeleteButton(enabled = true) {}
 }
 
 @Preview
 @Composable
 fun ExpoCreatedDeleteButtonDisabled() {
-    ExpoCreatedDeleteButton(enabled = false)
+    ExpoCreatedDeleteButton(enabled = false) {}
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedDeleteButton.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedDeleteButton.kt
@@ -1,6 +1,7 @@
 package com.school_of_company.expo.view.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
@@ -35,6 +36,14 @@ fun ExpoCreatedDeleteButton(
                     color = if (enabled) colors.error
                     else colors.white,
                     shape = RoundedCornerShape(size = 6.dp)
+                )
+                .then(
+                    if (enabled) Modifier
+                    else Modifier.border(
+                        width = 1.dp,
+                        color = colors.gray200,
+                        shape = RoundedCornerShape(size = 6.dp)
+                    )
                 )
                 .padding(horizontal = 16.dp, vertical = 12.dp),
         ) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedDeleteButton.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedDeleteButton.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.component.button.OutlinedIconTextButton
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.icon.TrashIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
@@ -27,37 +28,34 @@ fun ExpoCreatedDeleteButton(
     onClick: () -> Unit,
 ) {
     ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = modifier
-                .expoClickable { onClick() }
-                .background(
-                    color = if (enabled) colors.error
-                    else colors.white,
-                    shape = RoundedCornerShape(size = 6.dp)
-                )
-                .then(
-                    if (enabled) Modifier
-                    else Modifier.border(
-                        width = 1.dp,
-                        color = colors.gray200,
+        if (enabled) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = modifier
+                    .expoClickable { onClick() }
+                    .background(
+                        color = colors.error,
                         shape = RoundedCornerShape(size = 6.dp)
                     )
+                    .padding(horizontal = 16.dp, vertical = 12.dp),
+            ) {
+                TrashIcon(
+                    tint = colors.white
                 )
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-        ) {
-            TrashIcon(
-                tint = if (enabled) colors.white
-                else colors.gray400,
-            )
-            Text(
-                text = "삭제하기",
-                style = typography.titleBold3,
-                fontWeight = FontWeight.W600,
-                color = if (enabled) colors.white
-                else colors.gray400,
-                textAlign = TextAlign.Center,
+                Text(
+                    text = "삭제하기",
+                    style = typography.titleBold3,
+                    fontWeight = FontWeight.W600,
+                    color = colors.white,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        } else {
+            OutlinedIconTextButton(
+                textValue = "삭제하기",
+                leadingIcon = { color -> TrashIcon(tint = color) },
+                onClick = { onClick() }
             )
         }
     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedDeleteButton.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedDeleteButton.kt
@@ -1,0 +1,64 @@
+package com.school_of_company.expo.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.icon.TrashIcon
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.design_system.theme.ExpoTypography
+import com.school_of_company.design_system.theme.color.ColorTheme
+
+@Composable
+fun ExpoCreatedDeleteButton(
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+) {
+    ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .background(
+                    color = if (enabled) colors.error
+                    else colors.white,
+                    shape = RoundedCornerShape(size = 6.dp)
+                )
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        ) {
+            TrashIcon(
+                tint = if (enabled) colors.white
+                else colors.gray400,
+            )
+            Text(
+                text = "삭제하기",
+                style = typography.titleBold3,
+                fontWeight = FontWeight.W600,
+                color = if (enabled) colors.white
+                else colors.gray400,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ExpoCreatedDeleteButtonEnabled() {
+    ExpoCreatedDeleteButton(enabled = true)
+}
+
+@Preview
+@Composable
+fun ExpoCreatedDeleteButtonDisabled() {
+    ExpoCreatedDeleteButton(enabled = false)
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTable.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTable.kt
@@ -1,0 +1,75 @@
+package com.school_of_company.expo.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.design_system.theme.ExpoTypography
+import com.school_of_company.design_system.theme.color.ColorTheme
+
+@Composable
+fun ExpoCreatedTable(modifier: Modifier = Modifier) {
+    ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(73.dp, Alignment.Start),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .background(color = colors.white)
+                .drawBehind {
+                    // 아래쪽 Border 그리기
+                    val strokeWidth = 1.dp.toPx()
+                    val y = size.height - strokeWidth / 2
+                    drawLine(
+                        color = colors.gray100, // Border 색상
+                        start = Offset(0f, y),
+                        end = Offset(size.width, y),
+                        strokeWidth = strokeWidth
+                    )
+                }
+                .padding(
+                    horizontal = 54.dp,
+                    vertical = 14.dp,
+                )
+        ) {
+            Text(
+                text = "이미지",
+                style = typography.captionBold1,
+                fontWeight = FontWeight.W600,
+                color = colors.gray600,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = "박람회 이름",
+                style = typography.captionBold1,
+                fontWeight = FontWeight.W600,
+                color = colors.gray600,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = "모집 기간",
+                style = typography.captionBold1,
+                fontWeight = FontWeight.W600,
+                color = colors.gray600,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+
+@Preview
+@Composable
+fun ExpoCreatedTablePreview() {
+    ExpoCreatedTable()
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTopCard.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTopCard.kt
@@ -30,9 +30,7 @@ fun ExpoCreatedTopCard(
         Column(
             verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.Top),
             horizontalAlignment = Alignment.Start,
-            modifier = modifier
-                .fillMaxWidth()
-                .padding(horizontal = 22.dp, vertical = 10.dp),
+            modifier = modifier.padding(horizontal = 22.dp, vertical = 10.dp),
         ) {
             Text(
                 text = "등록된 박람회",

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTopCard.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTopCard.kt
@@ -1,0 +1,95 @@
+package com.school_of_company.expo.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.icon.WarnIcon
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.design_system.theme.ExpoTypography
+import com.school_of_company.design_system.theme.color.ColorTheme
+
+@Composable
+fun ExpoCreatedTopCard(
+    modifier: Modifier = Modifier,
+    participantCount: Int,
+) {
+    ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
+        Column(
+            verticalArrangement = Arrangement.spacedBy(12.dp, Alignment.Top),
+            horizontalAlignment = Alignment.Start,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 22.dp, vertical = 10.dp),
+        ) {
+            Text(
+                text = "등록된 박람회",
+                style = typography.bodyBold2,
+                fontWeight = FontWeight.W600,
+                color = colors.black,
+            )
+
+            Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.Start),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    WarnIcon(tint = colors.gray300)
+                    Text(
+                        text = "옆으로 넘겨서 확인해보세요",
+                        style = typography.captionRegular2,
+                        fontWeight = FontWeight.W400,
+                        color = colors.gray300,
+                    )
+                }
+                VerticalDivider(
+                    modifier = Modifier
+                        .width(1.dp)
+                        .height(14.dp)
+                        .background(color = colors.gray100)
+                )
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.Start),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = "참가자 전체 인원",
+                        style = typography.captionRegular2,
+                        fontWeight = FontWeight.W400,
+                        color = colors.gray500,
+                    )
+                    Text(
+                        text = "${participantCount}명",
+                        style = typography.captionRegular2,
+                        fontWeight = FontWeight.W400,
+                        color = colors.main,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ExpoCreatedTopCardPreview(){
+    ExpoCreatedTopCard(
+        participantCount = 30
+    )
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -18,7 +18,6 @@ import com.school_of_company.domain.usecase.standard.RegisterStandardListProgram
 import com.school_of_company.domain.usecase.standard.StandardProgramListUseCase
 import com.school_of_company.domain.usecase.training.ModifyTrainingProgramUseCase
 import com.school_of_company.domain.usecase.training.RegisterTrainingProgramListUseCase
-import com.school_of_company.domain.usecase.training.RegisterTrainingProgramUseCase
 import com.school_of_company.domain.usecase.training.TrainingProgramListUseCase
 import com.school_of_company.expo.enum.TrainingCategory
 import com.school_of_company.expo.util.getMultipartFile
@@ -34,8 +33,6 @@ import com.school_of_company.expo.viewmodel.uistate.ModifyTrainingProgramUiState
 import com.school_of_company.expo.viewmodel.uistate.RegisterExpoInformationUiState
 import com.school_of_company.expo.viewmodel.uistate.RegisterStandardProgramListUiState
 import com.school_of_company.expo.viewmodel.uistate.RegisterTrainingProgramListUiState
-import com.school_of_company.expo.viewmodel.uistate.RegisterTrainingProgramUiState
-import com.school_of_company.model.entity.standard.StandardProgramListResponseEntity
 import com.school_of_company.model.model.expo.ExpoRequestAndResponseModel
 import com.school_of_company.model.model.standard.StandardRequestModel
 import com.school_of_company.model.model.training.TrainingDtoModel
@@ -238,7 +235,7 @@ class ExpoViewModel @Inject constructor(
             }
     }
 
-    internal fun expoList() = viewModelScope.launch {
+    internal fun getExpoList() = viewModelScope.launch {
         _swipeRefreshLoading.value = true
         getExpoListUseCase()
             .asResult()

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetExpoListUiState.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetExpoListUiState.kt
@@ -1,11 +1,10 @@
 package com.school_of_company.expo.viewmodel.uistate
 
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
-import kotlinx.collections.immutable.ImmutableList
 
 sealed interface GetExpoListUiState {
     object Loading : GetExpoListUiState
     object Empty : GetExpoListUiState
-    data class Success(val data: ImmutableList<ExpoListResponseEntity>) : GetExpoListUiState
+    data class Success(val data: List<ExpoListResponseEntity>) : GetExpoListUiState
     data class Error(val exception: Throwable) : GetExpoListUiState
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetExpoListUiState.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetExpoListUiState.kt
@@ -1,10 +1,11 @@
 package com.school_of_company.expo.viewmodel.uistate
 
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
+import kotlinx.collections.immutable.ImmutableList
 
 sealed interface GetExpoListUiState {
     object Loading : GetExpoListUiState
     object Empty : GetExpoListUiState
-    data class Success(val data: List<ExpoListResponseEntity>) : GetExpoListUiState
+    data class Success(val data: ImmutableList<ExpoListResponseEntity>) : GetExpoListUiState
     data class Error(val exception: Throwable) : GetExpoListUiState
 }


### PR DESCRIPTION
### 💡 개요  
등록된 박람회 화면 관련 퍼블리싱 작업 및 기능 개선 작업을 진행했습니다.  

---

### 📃 작업내용  
1. **퍼블리싱 작업**  
   - `ExpoCreatedTopCard` 퍼블리싱 작업 추가.  
   - `CreatedExpoListItem` 퍼블리싱 작업 추가.  
   - `ExpoCreatedTable` 퍼블리싱 작업 추가.  
   - `ExpoCreatedDeleteButton` 퍼블리싱 작업 추가.  
   - 등록된 박람회 전체 화면 퍼블리싱 작업 추가.  

2. **기능 개선**  
   - `startedDay`와 `finishedDay`를 연결해서 날짜를 보여주도록 수정.  
   - `fillMaxWidth`를 상위 Composable 함수에서 적용하도록 변경.  
   - 함수명을 동사 형태로 변경하여 가독성 및 일관성 개선.  
   - `isSelected` 상태를 구하는 방식을 변경하고 관련 함수 추가.  
   - `TrashIcon`에 tint 추가.  
   - `ExpoCreatedDeleteButton`에 `onClick` 이벤트와 border 추가.  

---

### 🔀 변경사항  
- 화면 구성 및 퍼블리싱 관련 변경사항.  
- UI 동작 개선 및 함수 구조 변경.  

---

### 🙋‍♂️ 질문사항  
- `TrashIcon`의 tint 색상이나 `ExpoCreatedDeleteButton`의 border 스타일에 대한 추가 의견이 필요합니다.  
- 개선할 점, 오타, 또는 코드에 이상한 부분이 있다면 Comment 부탁드립니다.  

---

### 🍴 사용방법  
- 등록된 박람회 화면에서 리스트 항목과 삭제 버튼이 정상적으로 동작하는지 확인해주세요.  

---

### 🎸 기타  
- 코드의 일관성 유지를 위해 함수명 변경 및 구조 개선을 진행했습니다.  
- 퍼블리싱 작업에서 빠진 부분이 있다면 알려주세요.  

--- 

**PR 포함 Commit**  
1. ✨ `ExpoCreatedTopCard` 퍼블리싱  
2. ✨ `CreatedExpoListItem` 퍼블리싱  
3. ♻️ `startedDay`와 `finishedDay` 연결  
4. ♻️ `fillMaxWidth` 상위 적용  
5. ♻️ 함수명 동사형 변경  
6. ♻️ `isSelected` 상태 변경 및 함수 추가  
7. ♻️ `TrashIcon` tint 추가  
8. ✨ `ExpoCreatedTable` 퍼블리싱  
9. ✨ `ExpoCreatedDeleteButton` 퍼블리싱  
10. ♻️ `onClick` 추가  
11. ♻️ `ExpoCreatedDeleteButton` border 추가  
12. ✨ 등록된 박람회 화면 퍼블리싱  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
  - 박람회 생성 및 관리를 위한 새로운 화면 추가
  - 박람회 목록 조회 및 삭제 기능 구현
  - 사용자 인터페이스 컴포넌트 개선
  - 새로운 아이콘 및 버튼 컴포넌트 추가
  - 박람회 목록 항목을 위한 새로운 리스트 아이템 구성 요소 추가
  - 새로운 테이블 및 카드 UI 구성 요소 추가
  - 새로운 네비게이션 기능 추가로 화면 전환 개선
  - 아이콘의 색상 조정 기능 추가
  - 스와이프 새로 고침 기능이 포함된 동적 목록 표시 추가
  - 아웃라인 아이콘 텍스트 버튼 컴포넌트 추가

- **버그 수정**
  - 데이터 조회 메서드 이름 변경으로 일관성 개선

- **사용자 경험**
  - 박람회 목록 항목에 대한 선택 및 상호작용 기능 추가
  - 삭제 버튼 상태에 따른 시각적 피드백 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->