### PR TITLE
🔀 :: (#304) - access modifiers edit

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/util/ConvertMultipart.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/util/ConvertMultipart.kt
@@ -13,6 +13,12 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.io.OutputStream
 
+internal fun getMultipartFile(context: Context, uri: Uri): MultipartBody.Part? {
+    val jpegFile = uriToJpeg(context, uri) ?: return null
+
+    return fileToMultipartFile(jpegFile)
+}
+
 private fun uriToJpeg(context: Context, uri: Uri): File? {
     val inputStream = context.contentResolver.openInputStream(uri) ?: return null
     val bitmap = getExifData(context = context, uri = uri)?.let { exifData ->
@@ -33,12 +39,6 @@ private fun fileToMultipartFile(file: File): MultipartBody.Part {
     val requestFile = file.asRequestBody("image/jpeg".toMediaTypeOrNull())
 
     return MultipartBody.Part.createFormData("image", file.name, requestFile)
-}
-
-fun getMultipartFile(context: Context, uri: Uri): MultipartBody.Part? {
-    val jpegFile = uriToJpeg(context, uri) ?: return null
-
-    return fileToMultipartFile(jpegFile)
 }
 
 @Throws(IOException::class)

--- a/feature/expo/src/main/java/com/school_of_company/expo/util/ImageRotators.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/util/ImageRotators.kt
@@ -8,7 +8,7 @@ import android.net.Uri
 import android.provider.MediaStore
 import androidx.exifinterface.media.ExifInterface
 
-fun rotateImage(bitmap: Bitmap, exif: String): Bitmap {
+internal fun rotateImage(bitmap: Bitmap, exif: String): Bitmap {
     val matrix = Matrix()
     val angle = when (exif) {
         ExifInterface.ORIENTATION_ROTATE_90.toString() -> 90f
@@ -20,7 +20,7 @@ fun rotateImage(bitmap: Bitmap, exif: String): Bitmap {
     return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
 }
 
-fun getExifData(context: Context, uri: Uri): String? {
+internal fun getExifData(context: Context, uri: Uri): String? {
     var exifData: String? = null
     var cursor: Cursor? = null
     try {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -207,7 +207,7 @@ internal fun ExpoCreateRoute(
 }
 
 @Composable
-internal fun ExpoCreateScreen(
+private fun ExpoCreateScreen(
     modifier: Modifier = Modifier,
     imageUri: String?,
     onImageClick: () -> Unit,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -44,7 +44,6 @@ import com.school_of_company.design_system.icon.LeftArrowIcon
 import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.expo.view.component.HomeKakaoMap
-import com.school_of_company.expo.view.component.QrCode
 import com.school_of_company.expo.viewmodel.ExpoViewModel
 import com.school_of_company.expo.viewmodel.uistate.GetExpoInformationUiState
 import com.school_of_company.expo.viewmodel.uistate.GetStandardProgramListUiState
@@ -86,7 +85,7 @@ internal fun ExpoDetailRoute(
 }
 
 @Composable
-internal fun ExpoDetailScreen(
+private fun ExpoDetailScreen(
     id: String,
     modifier: Modifier = Modifier,
     scrollState: ScrollState = rememberScrollState(),

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -266,7 +266,7 @@ internal fun ExpoModifyRoute(
 }
 
 @Composable
-internal fun ExpoModifyScreen(
+private fun ExpoModifyScreen(
     modifier: Modifier = Modifier,
     focusManager: FocusManager = LocalFocusManager.current,
     scrollState: ScrollState = rememberScrollState(),

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoScreen.kt
@@ -68,7 +68,7 @@ internal fun ExpoRoute(
 }
 
 @Composable
-internal fun ExpoScreen(
+private fun ExpoScreen(
     modifier: Modifier = Modifier,
     scrollState: ScrollState = rememberScrollState(),
     swipeRefreshState: SwipeRefreshState,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoAddTextField.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoAddTextField.kt
@@ -28,7 +28,7 @@ import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.model.training.TrainingDtoModel
 
 @Composable
-fun ExpoAddTextField(
+internal fun ExpoAddTextField(
     modifier: Modifier = Modifier,
     placeHolder: String,
     trainingTextFieldList: List<TrainingDtoModel>,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoBottomSheet.kt
@@ -27,7 +27,7 @@ import com.school_of_company.design_system.theme.ExpoTypography
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HomeBottomSheet(
+internal fun HomeBottomSheet(
     modifier: Modifier = Modifier,
     onRecentClick: () -> Unit,
     onOldClick: () -> Unit,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFilterButton.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFilterButton.kt
@@ -17,7 +17,7 @@ import com.school_of_company.design_system.icon.DownArrowIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 
 @Composable
-fun HomeFilterButton(
+internal fun HomeFilterButton(
     modifier: Modifier = Modifier,
     text: String,
     onClick: () -> Unit

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoKakaoMapComponent.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoKakaoMapComponent.kt
@@ -17,7 +17,7 @@ import com.kakao.vectormap.camera.CameraUpdateFactory
 import com.school_of_company.ui.toast.makeToast
 
 @Composable
-fun HomeKakaoMap(
+internal fun HomeKakaoMap(
     modifier: Modifier = Modifier,
     locationX: Double,
     locationY: Double,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoList.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoList.kt
@@ -24,7 +24,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
-fun ExpoList(
+internal fun ExpoList(
     modifier: Modifier = Modifier,
     emptyList: Boolean = false,
     item: ImmutableList<ExpoListResponseEntity> = persistentListOf(),

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoListItem.kt
@@ -33,7 +33,7 @@ import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 import com.school_of_company.ui.util.formatServerDate
 
 @Composable
-fun ExpoListItem(
+internal fun ExpoListItem(
     modifier: Modifier = Modifier,
     data: ExpoListResponseEntity,
     navigateToExpoDetail: (String) -> Unit

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoNoneLineTextField.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoNoneLineTextField.kt
@@ -24,7 +24,7 @@ import com.school_of_company.design_system.theme.ExpoTypography
 import com.school_of_company.design_system.theme.color.ExpoColor
 
 @Composable
-fun ExpoNoneLineTextField(
+internal fun ExpoNoneLineTextField(
     modifier: Modifier = Modifier,
     textState: String,
     placeHolder: @Composable () -> Unit,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
@@ -49,7 +49,7 @@ import com.school_of_company.model.model.training.TrainingDtoModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ExpoSettingBottomSheet(
+internal fun ExpoSettingBottomSheet(
     modifier: Modifier = Modifier,
     onCancelClick: () -> Unit,
     trainingSettingItem: TrainingDtoModel,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardAddTextField.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardAddTextField.kt
@@ -125,3 +125,22 @@ internal fun ExpoStandardAddTextField(
         }
     }
 }
+
+@Preview
+@Composable
+private fun ExpoStandardAddTextFieldPreview() {
+    ExpoStandardAddTextField(
+        onAddTextField = {},
+        onValueChange = { _, _ -> },
+        onRemoveTextField = {},
+        onTrainingSetting = {},
+        placeHolder = "안녕하세요",
+        trainingTextFieldList = listOf(
+            StandardRequestModel(
+                title = "제목",
+                startedAt = "9:10",
+                endedAt = "11:11"
+            )
+        ),
+    )
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardAddTextField.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardAddTextField.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.icon.PlusIcon
@@ -27,7 +28,7 @@ import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.model.standard.StandardRequestModel
 
 @Composable
-fun ExpoStandardAddTextField(
+internal fun ExpoStandardAddTextField(
     modifier: Modifier = Modifier,
     placeHolder: String,
     trainingTextFieldList: List<StandardRequestModel>,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
@@ -35,7 +35,7 @@ import com.school_of_company.model.model.standard.StandardRequestModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ExpoStandardSettingBottomSheet(
+internal fun ExpoStandardSettingBottomSheet(
     modifier: Modifier = Modifier,
     onCancelClick: () -> Unit,
     trainingSettingItem: StandardRequestModel,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/TrainingSettingButton.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/TrainingSettingButton.kt
@@ -16,7 +16,7 @@ import com.school_of_company.design_system.component.modifier.clickable.expoClic
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 
 @Composable
-fun TrainingSettingButton(
+internal fun TrainingSettingButton(
     modifier: Modifier = Modifier,
     text: String,
     onClick: () -> Unit

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -48,7 +48,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class ExpoViewModel @Inject constructor(
+internal class ExpoViewModel @Inject constructor(
     private val getExpoInformationUseCase: GetExpoInformationUseCase,
     private val registerExpoInformationUseCase: RegisterExpoInformationUseCase,
     private val modifyExpoInformationUseCase: ModifyExpoInformationUseCase,

--- a/feature/program/src/main/java/com/school_of_company/program/util/QrcodeAnalyzer.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/util/QrcodeAnalyzer.kt
@@ -8,7 +8,7 @@ import com.google.mlkit.vision.barcode.BarcodeScanning
 import com.google.mlkit.vision.barcode.common.Barcode
 import com.google.mlkit.vision.common.InputImage
 
-class QrcodeAnalyzer(
+internal class QrcodeAnalyzer(
     private val qrcodeData: (String) -> Unit
 ) : ImageAnalysis.Analyzer {
 

--- a/feature/program/src/main/java/com/school_of_company/program/util/parseQrScanModel.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/util/parseQrScanModel.kt
@@ -7,12 +7,12 @@ data class QrScanModel(
     val phoneNumber: String
 )
 
-fun String.parseStandardQrScanModel(): QrScanModel {
+internal fun String.parseStandardQrScanModel(): QrScanModel {
     val jsonObject = JSONObject(this)
     val participantId = jsonObject.optLong("participantId")
     val phoneNumber = jsonObject.optString("phoneNumber")
 
     return QrScanModel(participantId, phoneNumber)
 }
-fun String.parseTrainingQr(): String = JSONObject(this).optString("traineeId")
+internal fun String.parseTrainingQr(): String = JSONObject(this).optString("traineeId")
 

--- a/feature/program/src/main/java/com/school_of_company/program/util/setupQrScanCamera.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/util/setupQrScanCamera.kt
@@ -7,7 +7,7 @@ import androidx.camera.view.PreviewView
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.LifecycleOwner
 
-fun setupQrScanCamera(
+internal fun setupQrScanCamera(
     previewView: PreviewView,
     lifecycleOwner: LifecycleOwner,
     onQrcodeScanned: (String) -> Unit

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -31,7 +31,7 @@ import com.school_of_company.program.view.component.ProgramDetailParticipantMana
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 
-fun generateParticipantManagementSampleData(): ImmutableList<HomeDetailParticipantManagementData> {
+internal fun generateParticipantManagementSampleData(): ImmutableList<HomeDetailParticipantManagementData> {
     return List(20) {
         HomeDetailParticipantManagementData(
             name = "이명훈",
@@ -56,7 +56,7 @@ internal fun ProgramDetailParticipantManagementRoute(
 }
 
 @Composable
-internal fun ProgramDetailParticipantManagementScreen(
+private fun ProgramDetailParticipantManagementScreen(
     modifier: Modifier = Modifier,
     participantManagementData: ImmutableList<HomeDetailParticipantManagementData>,
     onBackClick: () -> Unit

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailProgramScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailProgramScreen.kt
@@ -89,7 +89,7 @@ internal fun ProgramDetailProgramRoute(
 }
 
 @Composable
-internal fun ProgramDetailProgramScreen(
+private fun ProgramDetailProgramScreen(
     modifier: Modifier = Modifier,
     swipeRefreshState: SwipeRefreshState,
     trainingProgramUiState: TrainingProgramListUiState,

--- a/feature/program/src/main/java/com/school_of_company/program/view/QrScannerScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/QrScannerScreen.kt
@@ -112,7 +112,7 @@ internal fun QrScannerRoute(
 
 @androidx.annotation.OptIn(androidx.camera.core.ExperimentalGetImage::class)
 @Composable
-internal fun QrScannerScreen(
+private fun QrScannerScreen(
     modifier: Modifier = Modifier,
     lifecycleOwner: LifecycleOwner,
     onBackClick: () -> Unit,

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementList.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementList.kt
@@ -15,7 +15,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
-fun ProgramDetailParticipantManagementList(
+internal fun ProgramDetailParticipantManagementList(
     modifier: Modifier = Modifier,
     item: ImmutableList<HomeDetailParticipantManagementData> = persistentListOf()
 ) {

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementListItem.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementListItem.kt
@@ -29,7 +29,7 @@ data class HomeDetailParticipantManagementData(
 )
 
 @Composable
-fun ProgramDetailParticipantManagementListItem(
+internal fun ProgramDetailParticipantManagementListItem(
     modifier: Modifier = Modifier,
     index: Int,
     data: HomeDetailParticipantManagementData,

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramList.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramList.kt
@@ -18,7 +18,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
-fun ProgramList(
+internal fun ProgramList(
     modifier: Modifier = Modifier,
     trainingItem: ImmutableList<TrainingProgramListResponseEntity> = persistentListOf(),
     navigateToTrainingProgramDetail: (Long) -> Unit,
@@ -45,7 +45,7 @@ fun ProgramList(
 }
 
 @Composable
-fun StandardProgramList(
+internal fun StandardProgramList(
     modifier: Modifier = Modifier,
     standardItem: ImmutableList<StandardProgramListResponseEntity> = persistentListOf(),
     navigateToStandardProgramDetail: (Long) -> Unit,

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramListItem.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramListItem.kt
@@ -26,7 +26,7 @@ import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.entity.training.TrainingProgramListResponseEntity
 
 @Composable
-fun ProgramListItem(
+internal fun ProgramListItem(
     modifier: Modifier = Modifier,
     index: Int,
     data: TrainingProgramListResponseEntity,

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTabRowItem.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTabRowItem.kt
@@ -9,12 +9,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 
 @Composable
-fun ProgramTabRowItem(
+internal fun ProgramTabRowItem(
     modifier: Modifier = Modifier,
     title: String,
     onClick: () -> Unit,

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTabRowItem.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTabRowItem.kt
@@ -38,3 +38,23 @@ fun ProgramTabRowItem(
         }
     }
 }
+
+@Preview
+@Composable
+private fun ProgramTabRowItemNotCurrentIndexPreview() {
+    ProgramTabRowItem(
+        isCurrentIndex = false,
+        onClick = {},
+        title = "제목"
+    )
+}
+
+@Preview
+@Composable
+private fun ProgramTabRowItemCurrentIndexPreview() {
+    ProgramTabRowItem(
+        isCurrentIndex = true,
+        onClick = {},
+        title = "제목"
+    )
+}

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/QrButton.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/QrButton.kt
@@ -10,15 +10,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 
 @Composable
-fun QrButton(
+internal fun QrButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
+    // TODO: 사용 여부 확인하기
     ExpoAndroidTheme { colors, typography ->
 
         Row(

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/QrButton.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/QrButton.kt
@@ -52,3 +52,11 @@ fun QrButton(
         }
     }
 }
+
+@Preview
+@Composable
+private fun QrButtonPreview() {
+    QrButton(
+        onClick = {},
+    )
+}

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/StandardProgramListItem.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/StandardProgramListItem.kt
@@ -25,7 +25,7 @@ import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.entity.standard.StandardProgramListResponseEntity
 
 @Composable
-fun StandardProgramListItem(
+internal fun StandardProgramListItem(
     modifier: Modifier = Modifier,
     index: Int,
     data: StandardProgramListResponseEntity,

--- a/feature/program/src/main/java/com/school_of_company/program/viewmodel/ProgramViewModel.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/viewmodel/ProgramViewModel.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class ProgramViewModel @Inject constructor(
+internal class ProgramViewModel @Inject constructor(
     private val trainingProgramListUseCase: TrainingProgramListUseCase,
     private val standardProgramListUseCase: StandardProgramListUseCase,
     private val trainingQrCodeRequestUseCase: TrainingQrCodeRequestUseCase,

--- a/feature/signin/src/main/java/com/school_of_company/view/SignInScreen.kt
+++ b/feature/signin/src/main/java/com/school_of_company/view/SignInScreen.kt
@@ -140,7 +140,7 @@ internal fun SignInRoute(
 }
 
 @Composable
-internal fun SignInScreen(
+private fun SignInScreen(
     modifier: Modifier = Modifier,
     focusManager: FocusManager = LocalFocusManager.current,
     scrollState: ScrollState = rememberScrollState(),
@@ -274,7 +274,7 @@ internal fun SignInScreen(
 
 @Preview
 @Composable
-fun SignInScreenPreview() {
+private fun SignInScreenPreview() {
     SignInScreen(
         id = "",
         password = "",

--- a/feature/signin/src/main/java/com/school_of_company/viewmodel/SignInViewModel.kt
+++ b/feature/signin/src/main/java/com/school_of_company/viewmodel/SignInViewModel.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class SignInViewModel @Inject constructor(
+internal class SignInViewModel @Inject constructor(
     private val signInUseCase: AdminSignInRequestUseCase,
     private val saveTokenUseCase: SaveTokenUseCase,
     private val savedStateHandle: SavedStateHandle,

--- a/feature/signup/src/main/java/com/school_of_company/signup/view/SignUpScreen.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/view/SignUpScreen.kt
@@ -160,7 +160,7 @@ internal fun SignUpRoute(
 }
 
 @Composable
-internal fun SignUpScreen(
+private fun SignUpScreen(
     modifier: Modifier = Modifier,
     focusManager: FocusManager = LocalFocusManager.current,
     scrollState: ScrollState = rememberScrollState(),

--- a/feature/signup/src/main/java/com/school_of_company/signup/viewmodel/SignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/viewmodel/SignUpViewModel.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class SignUpViewModel @Inject constructor(
+internal class SignUpViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val signUpRequestUseCase: AdminSignUpRequestUseCase,
     private val smsSignUpCertificationNumberSendRequestUseCase: SmsSignUpCertificationNumberSendRequestUseCase,

--- a/feature/sms/src/main/java/com/school_of_company/sms/view/SendMessageScreen.kt
+++ b/feature/sms/src/main/java/com/school_of_company/sms/view/SendMessageScreen.kt
@@ -45,7 +45,7 @@ internal fun SendMessageRoute(
 }
 
 @Composable
-internal fun SendMessageScreen(
+private fun SendMessageScreen(
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit,
     title: String,

--- a/feature/sms/src/main/java/com/school_of_company/sms/view/component/SendMessageTopBar.kt
+++ b/feature/sms/src/main/java/com/school_of_company/sms/view/component/SendMessageTopBar.kt
@@ -10,7 +10,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.icon.CheckIcon
+import com.school_of_company.design_system.icon.TrashIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 
 @Composable
@@ -35,4 +38,14 @@ internal fun HomeSendMessageTopBar(
             endIcon()
         }
     }
+}
+
+@Preview
+@Composable
+private fun HomeSendMessageTopBarPreview() {
+    HomeSendMessageTopBar(
+        startIcon = { TrashIcon() },
+        betweenText = "사이 텍스트 입니다",
+        endIcon = { CheckIcon() },
+    )
 }

--- a/feature/sms/src/main/java/com/school_of_company/sms/viewmodel/SmsViewModel.kt
+++ b/feature/sms/src/main/java/com/school_of_company/sms/viewmodel/SmsViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import javax.inject.Inject
 
-class SmsViewModel @Inject constructor(
+internal class SmsViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     companion object {

--- a/feature/standard/src/main/java/com/school_of_company/standard/view/StandardProgramParticipantScreen.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/view/StandardProgramParticipantScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -322,4 +323,30 @@ internal fun StandardProgramParticipantScreen(
             }
         }
     }
+}
+
+@Preview
+@Composable
+private fun StandardProgramParticipantScreenPreview() {
+    StandardProgramParticipantScreen(
+        id = 1,
+        swipeRefreshState = SwipeRefreshState(false),
+        getTeacherTrainingProgramList = {},
+        navigateToQrScanner = { _ -> },
+        onBackClick = {},
+        standardProgramAttendListUiState = StandardProgramAttendListUiState.Success(
+            listOf(
+                StandardAttendListResponseEntity(
+                    affiliation = "affiliation",
+                    entryTime = "입장시간",
+                    id = 1,
+                    leaveTime = "퇴장시간",
+                    name = "연수자 이름",
+                    position = "직위",
+                    programName = "연수 이름",
+                    status = true
+                )
+            )
+        ),
+    )
 }

--- a/feature/standard/src/main/java/com/school_of_company/standard/view/StandardProgramParticipantScreen.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/view/StandardProgramParticipantScreen.kt
@@ -37,6 +37,7 @@ import com.school_of_company.design_system.icon.ExpoIcon
 import com.school_of_company.design_system.icon.LeftArrowIcon
 import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.model.entity.standard.StandardAttendListResponseEntity
 import com.school_of_company.standard.view.component.QrButton
 import com.school_of_company.standard.view.component.StandardParticipantList
 import com.school_of_company.standard.viewmodel.StandardViewModel
@@ -53,7 +54,8 @@ internal fun StandardProgramParticipantRoute(
     val swipeRefreshLoading by viewModel.swipeRefreshLoading.collectAsStateWithLifecycle()
     val swipeRefreshState = rememberSwipeRefreshState(isRefreshing = swipeRefreshLoading)
 
-    val standardProgramAttendListUiState = viewModel.standardProgramAttendListUiState.collectAsStateWithLifecycle().value
+    val standardProgramAttendListUiState =
+        viewModel.standardProgramAttendListUiState.collectAsStateWithLifecycle().value
 
     StandardProgramParticipantScreen(
         id = id,
@@ -70,7 +72,7 @@ internal fun StandardProgramParticipantRoute(
 }
 
 @Composable
-internal fun StandardProgramParticipantScreen(
+private fun StandardProgramParticipantScreen(
     id: Long,
     modifier: Modifier = Modifier,
     swipeRefreshState: SwipeRefreshState,

--- a/feature/standard/src/main/java/com/school_of_company/standard/view/component/QrButton.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/view/component/QrButton.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
@@ -51,4 +52,12 @@ fun QrButton(
             }
         }
     }
+}
+
+@Preview
+@Composable
+private fun QrButtonPreview() {
+    QrButton(
+        onClick = {},
+    )
 }

--- a/feature/standard/src/main/java/com/school_of_company/standard/view/component/QrButton.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/view/component/QrButton.kt
@@ -16,7 +16,7 @@ import com.school_of_company.design_system.component.modifier.clickable.expoClic
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 
 @Composable
-fun QrButton(
+internal fun QrButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {

--- a/feature/standard/src/main/java/com/school_of_company/standard/view/component/StandardParticipantList.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/view/component/StandardParticipantList.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.entity.standard.StandardAttendListResponseEntity
@@ -36,4 +37,24 @@ fun StandardParticipantList(
             }
         }
     }
+}
+
+@Preview
+@Composable
+private fun StandardParticipantListPreview() {
+    StandardParticipantList(
+        horizontalScrollState = ScrollState(1),
+        item = persistentListOf(
+            StandardAttendListResponseEntity(
+                affiliation = "affiliation",
+                entryTime = "입장시간",
+                id = 1,
+                leaveTime = "퇴장시간",
+                name = "연수자 이름",
+                position = "직위",
+                programName = "연수 이름",
+                status = true
+            )
+        )
+    )
 }

--- a/feature/standard/src/main/java/com/school_of_company/standard/view/component/StandardParticipantList.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/view/component/StandardParticipantList.kt
@@ -16,7 +16,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
-fun StandardParticipantList(
+internal fun StandardParticipantList(
     modifier: Modifier = Modifier,
     item: ImmutableList<StandardAttendListResponseEntity> = persistentListOf(),
     horizontalScrollState: ScrollState

--- a/feature/standard/src/main/java/com/school_of_company/standard/view/component/StandardProgramParticipantListItem.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/view/component/StandardProgramParticipantListItem.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.entity.standard.StandardAttendListResponseEntity
@@ -87,4 +88,23 @@ fun StandardProgramParticipantListItem(
             )
         }
     }
+}
+
+@Preview
+@Composable
+private fun StandardProgramParticipantListItemPreview() {
+    StandardProgramParticipantListItem(
+        data = StandardAttendListResponseEntity(
+            affiliation = "affiliation",
+            entryTime = "입장시간",
+            id = 1,
+            leaveTime = "퇴장시간",
+            name = "연수자 이름",
+            position = "직위",
+            programName = "연수 이름",
+            status = true
+        ),
+        index = 2,
+        horizontalScrollState = ScrollState(1)
+    )
 }

--- a/feature/standard/src/main/java/com/school_of_company/standard/view/component/StandardProgramParticipantListItem.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/view/component/StandardProgramParticipantListItem.kt
@@ -20,7 +20,7 @@ import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.entity.standard.StandardAttendListResponseEntity
 
 @Composable
-fun StandardProgramParticipantListItem(
+internal fun StandardProgramParticipantListItem(
     modifier: Modifier = Modifier,
     index: Int,
     data: StandardAttendListResponseEntity,

--- a/feature/standard/src/main/java/com/school_of_company/standard/viewmodel/StandardViewModel.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/viewmodel/StandardViewModel.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class StandardViewModel @Inject constructor(
+internal class StandardViewModel @Inject constructor(
     private val standardProgramAttendListUseCase: StandardProgramAttendListUseCase,
     private val standardQrCodeRequestUseCase: StandardQrCodeRequestUseCase
 ) : ViewModel() {

--- a/feature/training/src/main/java/com/school_of_company/training/view/TrainingProgramParticipantScreen.kt
+++ b/feature/training/src/main/java/com/school_of_company/training/view/TrainingProgramParticipantScreen.kt
@@ -70,7 +70,7 @@ internal fun TrainingProgramParticipantRoute(
 }
 
 @Composable
-internal fun TrainingProgramParticipantScreen(
+private fun TrainingProgramParticipantScreen(
     id: Long,
     modifier: Modifier = Modifier,
     swipeRefreshState: SwipeRefreshState,

--- a/feature/training/src/main/java/com/school_of_company/training/view/component/QrButton.kt
+++ b/feature/training/src/main/java/com/school_of_company/training/view/component/QrButton.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
@@ -51,4 +52,12 @@ internal fun QrButton(
             }
         }
     }
+}
+
+@Preview
+@Composable
+private fun QrButtonPreview() {
+    QrButton(
+        onClick = {},
+    )
 }

--- a/feature/training/src/main/java/com/school_of_company/training/view/component/QrButton.kt
+++ b/feature/training/src/main/java/com/school_of_company/training/view/component/QrButton.kt
@@ -15,7 +15,7 @@ import com.school_of_company.design_system.component.modifier.clickable.expoClic
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 
 @Composable
-fun QrButton(
+internal fun QrButton(
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {

--- a/feature/training/src/main/java/com/school_of_company/training/view/component/TrainingProgramParticipantList.kt
+++ b/feature/training/src/main/java/com/school_of_company/training/view/component/TrainingProgramParticipantList.kt
@@ -16,7 +16,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
-fun TrainingProgramParticipantList(
+internal fun TrainingProgramParticipantList(
     modifier: Modifier = Modifier,
     item: ImmutableList<TeacherTrainingProgramResponseEntity> = persistentListOf(),
     horizontalScrollState: ScrollState

--- a/feature/training/src/main/java/com/school_of_company/training/view/component/TrainingProgramParticipantList.kt
+++ b/feature/training/src/main/java/com/school_of_company/training/view/component/TrainingProgramParticipantList.kt
@@ -42,4 +42,19 @@ fun TrainingProgramParticipantList(
 @Preview
 @Composable
 private fun HomeDetailProgramParticipantListPreview() {
+    TrainingProgramParticipantList(
+        item = persistentListOf(
+            TeacherTrainingProgramResponseEntity(
+                id = 0,
+                name = "홍길동",
+                organization = "한국대학교",
+                position = "교사",
+                programName = "프로그램",
+                status = true,
+                entryTime = "2024-09-12 T 08:30",
+                leaveTime = "2024-09-12 T 08:30"
+            )
+        ),
+        horizontalScrollState = ScrollState(1)
+    )
 }

--- a/feature/training/src/main/java/com/school_of_company/training/view/component/TrainingProgramParticipantListItem.kt
+++ b/feature/training/src/main/java/com/school_of_company/training/view/component/TrainingProgramParticipantListItem.kt
@@ -21,7 +21,7 @@ import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.entity.training.TeacherTrainingProgramResponseEntity
 
 @Composable
-fun TrainingProgramParticipantListItem(
+internal fun TrainingProgramParticipantListItem(
     modifier: Modifier = Modifier,
     index: Int,
     data: TeacherTrainingProgramResponseEntity,

--- a/feature/training/src/main/java/com/school_of_company/training/viewmodel/TrainingViewModel.kt
+++ b/feature/training/src/main/java/com/school_of_company/training/viewmodel/TrainingViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class TrainingViewModel @Inject constructor(
+internal class TrainingViewModel @Inject constructor(
     private val teacherTrainingProgramListUseCase: TeacherTrainingProgramListUseCase
 ) : ViewModel() {
     private val _swipeRefreshLoading = MutableStateFlow(false)

--- a/feature/user/src/main/java/com/school_of_company/user/view/UserScreen.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/UserScreen.kt
@@ -32,7 +32,7 @@ import com.school_of_company.user.view.component.temparory
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 
-fun generateSignUpRequestSampleData(): ImmutableList<temparory> {
+private fun generateSignUpRequestSampleData(): ImmutableList<temparory> {
     return List(20) {
         temparory(
             name = "이명훈",
@@ -42,6 +42,7 @@ fun generateSignUpRequestSampleData(): ImmutableList<temparory> {
         )
     }.toPersistentList()
 }
+
 @Composable
 internal fun UserRoute() {
     UserScreen(

--- a/feature/user/src/main/java/com/school_of_company/user/view/component/SignUpRequestList.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/component/SignUpRequestList.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import kotlinx.collections.immutable.ImmutableList
@@ -35,4 +36,20 @@ internal fun SignUpRequestList(
             }
         }
     }
+}
+
+@Preview
+@Composable
+private fun SignUpRequestListPreview() {
+    SignUpRequestList(
+        item = persistentListOf(
+            temparory(
+                name = "이름",
+                id = "아이디",
+                email = "s23013@gsm.hs.kr",
+                phoneNumber = "101-2933-2334"
+            )
+        ),
+        horizontalScrollState = ScrollState(1),
+    )
 }


### PR DESCRIPTION
## 💡 개요  
프로젝트 내 여러 `Module`의 접근 제어자를 일관성 있게 수정하고, `Preview`를 추가하여 개발 편의성을 향상시켰습니다.

---

## 📃 작업내용  
1. **`expoModule` 관련 작업**  
   - Component, Screen, ViewModel의 접근 제어자 수정.  
   - `Preview` 추가.

2. **`programModule` 관련 작업**  
   - Component, Screen, ViewModel의 접근 제어자 수정.  
   - Util 함수 접근 제어자 수정.  
   - `Preview` 추가.

3. **`signInModule` 및 `signUpModule`**  
   - 전체 접근 제어자 수정.  
   - `Preview` 추가.

4. **`smsModule` 작업**  
   - 전체 접근 제어자 수정.  
   - `Preview` 추가.

5. **`standardModule` 작업**  
   - Component, Screen, ViewModel의 접근 제어자 수정.  
   - `Preview` 추가.

6. **`trainingModule` 작업**  
   - Component, Screen, ViewModel의 접근 제어자 수정.  
   - `Preview` 추가.

7. **`userModule` 작업**  
   - `generateSignUpRequestSampleData` 함수의 접근 제어자 수정.  
   - `Preview` 추가.

---

## 🔀 변경사항  
- **파일**: 각 Module 내 Component, Screen, ViewModel 관련 파일들.  
- **주요 변경점**:  
  - 기존의 불필요한 `public` 또는 `private` 접근 제어자를 컨텍스트에 맞게 수정.  
  - `Preview` 추가로 UI 컴포넌트 테스트 용이성 증가.

---

## 🙋‍♂️ 질문사항  
- 접근 제어자의 변경이 각 `Module` 컨벤션에 적합한지 확인 부탁드립니다.  
- `Preview` 추가 관련해서 다른 개선점이 있다면 피드백 바랍니다.  

---

## 🍴 사용방법  
- 모든 수정 사항은 각 `Module`의 기존 로직에 맞춰 변경되었으므로, 현재 동작에는 영향이 없습니다.  
---

## 🎸 기타  
- 코드의 접근 제어자 관련 팀 내 컨벤션이 명확하지 않은 경우, 논의 후 추가적으로 변경 가능.  

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

- **코드 가시성 변경**
	- 여러 모듈의 함수 및 클래스 가시성을 내부(internal)로 제한
	- 일부 화면 및 구성 요소의 접근 범위를 모듈 내부로 제한
	- 미리보기(Preview) 기능을 위한 새로운 함수 추가

- **UI 개선**
	- 일부 UI 구성 요소에 대한 미리보기 기능 강화
	- 개발자 경험 향상을 위한 샘플 데이터 추가

- **보안 및 모듈화**
	- 코드 캡슐화를 통한 모듈 간 의존성 감소
	- 내부 함수 및 클래스의 접근성 제한

<!-- end of auto-generated comment: release notes by coderabbit.ai -->