### PR TITLE
🔀 :: (#302) - created expo screen communication implementation

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/ui/ExpoApp.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/ui/ExpoApp.kt
@@ -1,7 +1,6 @@
 package com.school_of_company.expo_android.ui
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
@@ -22,6 +21,7 @@ import com.school_of_company.design_system.component.navigation.ExpoNavigationBa
 import com.school_of_company.design_system.component.navigation.ExpoNavigationBarItem
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.expo.navigation.expoCreateRoute
+import com.school_of_company.expo.navigation.expoCreatedRoute
 import com.school_of_company.expo.navigation.homeRoute
 import com.school_of_company.expo_android.navigation.ExpoNavHost
 import com.school_of_company.expo_android.navigation.TopLevelDestination
@@ -46,7 +46,7 @@ fun ExpoApp(
     val topLevelDestinationRoute = arrayOf(
         homeRoute,
         expoCreateRoute,
-        // todo : Expo Created Route
+        expoCreatedRoute,
         profileRoute
     )
 

--- a/app/src/main/java/com/school_of_company/expo_android/ui/ExpoAppState.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/ui/ExpoAppState.kt
@@ -15,6 +15,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
 import com.school_of_company.expo.navigation.navigateToExpoCreate
+import com.school_of_company.expo.navigation.navigateToExpoCreated
 import com.school_of_company.expo.navigation.navigateToHome
 import com.school_of_company.expo_android.navigation.TopLevelDestination
 import com.school_of_company.user.navigation.navigateToProfile
@@ -25,7 +26,7 @@ fun rememberExpoAppState(
     windowSizeClass: WindowSizeClass, // 화면 크기 분류 정보를 받습니다.
     navController: NavHostController = rememberNavController(), // 네비게이션 컨트롤러를 생성합니다.
     coroutineScope: CoroutineScope = rememberCoroutineScope() // 코루틴 스코프를 생성합니다.
-) : ExpoAppState {
+): ExpoAppState {
     // windowSizeClass와 navController, coroutineScope가 변경될 때만 재생성하는 ExpoAppState를 기억합니다.
     return remember(
         windowSizeClass,
@@ -76,7 +77,7 @@ class ExpoAppState(
             when (topLevelDestination) {
                 TopLevelDestination.HOME -> navController.navigateToHome(topLevelNavOptions)
                 TopLevelDestination.EXPO -> navController.navigateToExpoCreate(topLevelNavOptions)
-                TopLevelDestination.EXPO_CREATED, // todo : Add Navigation Code
+                TopLevelDestination.EXPO_CREATED -> navController.navigateToExpoCreated(topLevelNavOptions)
                 TopLevelDestination.PROFILE -> navController.navigateToProfile(topLevelNavOptions)
             }
         }

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -79,6 +79,9 @@
     <string name="expo_modify_fail">박람회 수정을 실패하였습니다.</string>
     <string name="expo_register_fail">박람회 생성을 실패하였습니다.</string>
 
+    <string name="get_created_expo_list_fail">박람회 리스트를 불러오지 못했습니다.</string>
+    <string name="expo_not_selected">박람회를 선택하고 삭제버튼을 눌러주세요.</string>
+
     <string name="expo_image_fail">박람회 이미지가 유효하지 않습니다.</string>
 
     <string name="expo_image_size_fail">박람회 이미지를 다시 업로드 해주세요.</string>

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -81,6 +81,7 @@
 
     <string name="get_created_expo_list_fail">박람회 리스트를 불러오지 못했습니다.</string>
     <string name="expo_not_selected">박람회를 선택하고 삭제버튼을 눌러주세요.</string>
+    <string name="get_created_expo_list_empty">박람회 리스트가 비어있습니다.</string>
 
     <string name="expo_image_fail">박람회 이미지가 유효하지 않습니다.</string>
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
@@ -43,6 +43,7 @@ fun NavController.navigateToExpoModify(
 fun NavController.navigateToExpoCreate(navOptions: NavOptions? = null) {
     this.navigate(expoCreateRoute, navOptions)
 }
+
 fun NavController.navigateToExpoCreated(navOptions: NavOptions? = null) {
     this.navigate(expoCreatedRoute, navOptions)
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
@@ -11,7 +11,7 @@ import com.school_of_company.expo.view.ExpoModifyRoute
 import com.school_of_company.expo.view.ExpoRoute
 
 const val homeRoute = "home_route"
-const val expoDetailRoute=  "expo_detail_route"
+const val expoDetailRoute = "expo_detail_route"
 const val expoModifyRoute = "expo_modify_route"
 const val expoCreateRoute = "expo_create_route"
 const val expoCreatedRoute = "expo_created_route"
@@ -106,6 +106,6 @@ fun NavGraphBuilder.expoCreatedScreen(
     onErrorToast: (throwable: Throwable?, message: Int?) -> Unit
 ) {
     composable(route = expoCreatedRoute) {
-        ExpoCreatedRoute()
+        ExpoCreatedRoute(onErrorToast = onErrorToast)
     }
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/util/formatDateToMonthDay.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/util/formatDateToMonthDay.kt
@@ -1,0 +1,5 @@
+package com.school_of_company.expo.util
+
+fun formatDateToMonthDay(date: String): String {
+    return date.replace(Regex("^\\d{4}-(\\d{2})-(\\d{2})$"), "$1.$2")
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -3,8 +3,6 @@ package com.school_of_company.expo.view
 import CreatedExpoList
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -112,9 +110,7 @@ private fun ExpoCreatedScreen(
             Column(
                 verticalArrangement = Arrangement.spacedBy(14.dp, Alignment.CenterVertically),
                 horizontalAlignment = Alignment.Start,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .horizontalScroll(scrollState),
+                modifier = Modifier.fillMaxWidth()
             ) {
                 ExpoCreatedTable(modifier = Modifier.fillMaxWidth())
                 when (getExpoListUiState) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -12,7 +12,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -26,6 +28,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.swiperefresh.SwipeRefreshState
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
+import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.expo.view.component.ExpoCreatedDeleteButton
 import com.school_of_company.expo.view.component.ExpoCreatedTable
@@ -56,7 +59,11 @@ internal fun ExpoCreatedRoute(
         getExpoListUiState = getExpoListUiState,
         swipeRefreshState = swipeRefreshState,
         initCreatedExpoList = expoViewModel::getExpoList,
-        deleteExpoInformation = expoViewModel::deleteExpoInformation,
+        deleteSelectedExpo = { selectedId ->
+            if (getExpoListUiState is GetExpoListUiState.Success && selectedId != -1L) expoViewModel.deleteExpoInformation(
+                getExpoListUiState.data[selectedId.toInt()].id
+            )
+        },
     )
 }
 
@@ -68,11 +75,11 @@ private fun ExpoCreatedScreen(
     scrollState: ScrollState = rememberScrollState(),
     swipeRefreshState: SwipeRefreshState,
     initCreatedExpoList: () -> Unit,
-    deleteExpoInformation: (String) -> Unit,
+    deleteSelectedExpo: (Long) -> Unit,
 ) {
     val (selectedId, setSelectedId) = rememberSaveable { mutableLongStateOf(-1L) }
 
-    ExpoAndroidTheme { colors, _ ->
+    ExpoAndroidTheme { colors, typography ->
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = modifier
@@ -96,7 +103,7 @@ private fun ExpoCreatedScreen(
             ) {
                 ExpoCreatedTable()
                 when (getExpoListUiState) {
-                    GetExpoListUiState.Empty ,
+                    GetExpoListUiState.Empty,
                     is GetExpoListUiState.Error -> {
                         Column(
                             verticalArrangement = Arrangement.spacedBy(
@@ -119,6 +126,7 @@ private fun ExpoCreatedScreen(
                             )
                         }
                     }
+
                     GetExpoListUiState.Loading -> Unit
                     is GetExpoListUiState.Success -> {
                         CreatedExpoList(
@@ -136,11 +144,7 @@ private fun ExpoCreatedScreen(
             Spacer(modifier = Modifier.height(32.dp))
             ExpoCreatedDeleteButton(
                 enabled = selectedId != -1L,
-                onClick = {
-                    if (getExpoListUiState is GetExpoListUiState.Success && selectedId != -1L) deleteExpoInformation(
-                        getExpoListUiState.data[selectedId.toInt()].id
-                    )
-                }
+                onClick = { deleteSelectedExpo(selectedId) }
             )
         }
     }
@@ -171,7 +175,7 @@ private fun ExpoCreatedScreenPreview() {
             )
         ),
         expoListSize = 100,
-        deleteExpoInformation = { _ -> },
+        deleteSelectedExpo = { _ -> },
         swipeRefreshState = SwipeRefreshState(isRefreshing = true),
         initCreatedExpoList = {}
     )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -101,7 +101,7 @@ private fun ExpoCreatedScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = modifier
                 .background(color = colors.white)
-                .padding(top = 40.dp)
+                .padding(top = 68.dp)
                 .fillMaxSize(),
         ) {
             ExpoCreatedTopCard(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -43,6 +43,7 @@ import kotlinx.collections.immutable.toPersistentList
 internal fun ExpoCreatedRoute(
     modifier: Modifier = Modifier,
     expoViewModel: ExpoViewModel = hiltViewModel(),
+    onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
 ) {
     val getExpoListUiState by expoViewModel.getExpoListUiState.collectAsStateWithLifecycle()
     val swipeRefreshLoading by expoViewModel.swipeRefreshLoading.collectAsStateWithLifecycle()

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -117,7 +117,7 @@ private fun ExpoCreatedScreen(
                     .fillMaxWidth()
                     .horizontalScroll(scrollState),
             ) {
-                ExpoCreatedTable()
+                ExpoCreatedTable(modifier = Modifier.fillMaxWidth())
                 when (getExpoListUiState) {
                     GetExpoListUiState.Empty,
                     is GetExpoListUiState.Error -> {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -50,6 +50,7 @@ internal fun ExpoCreatedRoute(
     val swipeRefreshLoading by expoViewModel.swipeRefreshLoading.collectAsStateWithLifecycle()
     val expoListSize by expoViewModel.expoListSize.collectAsStateWithLifecycle()
     val swipeRefreshState = rememberSwipeRefreshState(isRefreshing = swipeRefreshLoading)
+    val (selectedIndex, setSelectedIndex) = rememberSaveable { mutableIntStateOf(-1) }
 
     LaunchedEffect("initCreatedExpo") {
         expoViewModel.getExpoList()
@@ -66,6 +67,8 @@ internal fun ExpoCreatedRoute(
     ExpoCreatedScreen(
         modifier = modifier,
         expoListSize = expoListSize,
+        selectedIndex = selectedIndex,
+        setSelectedIndex = setSelectedIndex,
         getExpoListUiState = getExpoListUiState,
         swipeRefreshState = swipeRefreshState,
         initCreatedExpoList = expoViewModel::getExpoList,
@@ -84,14 +87,14 @@ internal fun ExpoCreatedRoute(
 private fun ExpoCreatedScreen(
     modifier: Modifier = Modifier,
     expoListSize: Int,
+    selectedIndex: Int,
     getExpoListUiState: GetExpoListUiState,
     scrollState: ScrollState = rememberScrollState(),
     swipeRefreshState: SwipeRefreshState,
+    setSelectedIndex: (Int) -> Unit,
     initCreatedExpoList: () -> Unit,
     deleteSelectedExpo: (Int) -> Unit,
 ) {
-    val (selectedIndex, setSelectedIndex) = rememberSaveable { mutableIntStateOf(-1) }
-
     ExpoAndroidTheme { colors, typography ->
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
@@ -190,6 +193,8 @@ private fun ExpoCreatedScreenPreview() {
         expoListSize = 100,
         deleteSelectedExpo = { _ -> },
         swipeRefreshState = SwipeRefreshState(isRefreshing = true),
-        initCreatedExpoList = {}
+        initCreatedExpoList = {},
+        selectedIndex = 9,
+        setSelectedIndex = { _ -> }
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -81,7 +81,7 @@ private fun ExpoCreatedScreen(
         ) {
             ExpoCreatedTopCard(
                 modifier = Modifier.fillMaxWidth(),
-                participantCount = participantCount,
+                totalExpo = participantCount,
             )
             Spacer(modifier = Modifier.height(16.dp))
             Column(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -145,6 +145,7 @@ private fun ExpoCreatedScreen(
                     GetExpoListUiState.Loading -> Unit
                     is GetExpoListUiState.Success -> {
                         CreatedExpoList(
+                            scrollState = scrollState,
                             expoList = getExpoListUiState.data.toPersistentList(),
                             onItemClick = { isSelected, index ->
                                 setSelectedIndex(if (isSelected) -1 else index)

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,6 +28,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.swiperefresh.SwipeRefreshState
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
+import com.school_of_company.design_system.R
 import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.expo.view.component.ExpoCreatedDeleteButton
@@ -38,7 +39,6 @@ import com.school_of_company.expo.viewmodel.uistate.GetExpoListUiState
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 import kotlinx.collections.immutable.immutableListOf
 import kotlinx.collections.immutable.toPersistentList
-import com.school_of_company.design_system.R
 
 @Composable
 internal fun ExpoCreatedRoute(
@@ -71,10 +71,10 @@ internal fun ExpoCreatedRoute(
         initCreatedExpoList = expoViewModel::getExpoList,
         deleteSelectedExpo = { selectedId ->
             val currentGetExpoListUiState = getExpoListUiState
-            if (selectedId == -1L) {
+            if (selectedId == -1) {
                 onErrorToast(null, R.string.expo_not_selected)
             } else if (currentGetExpoListUiState is GetExpoListUiState.Success) expoViewModel.deleteExpoInformation(
-                currentGetExpoListUiState.data[selectedId.toInt()].id
+                currentGetExpoListUiState.data[selectedId].id
             )
         },
     )
@@ -88,9 +88,9 @@ private fun ExpoCreatedScreen(
     scrollState: ScrollState = rememberScrollState(),
     swipeRefreshState: SwipeRefreshState,
     initCreatedExpoList: () -> Unit,
-    deleteSelectedExpo: (Long) -> Unit,
+    deleteSelectedExpo: (Int) -> Unit,
 ) {
-    val (selectedId, setSelectedId) = rememberSaveable { mutableLongStateOf(-1L) }
+    val (selectedIndex, setSelectedIndex) = rememberSaveable { mutableIntStateOf(-1) }
 
     ExpoAndroidTheme { colors, typography ->
         Column(
@@ -145,9 +145,9 @@ private fun ExpoCreatedScreen(
                         CreatedExpoList(
                             expoList = getExpoListUiState.data.toPersistentList(),
                             onItemClick = { isSelected, index ->
-                                setSelectedId(if (isSelected) -1L else index)
+                                setSelectedIndex(if (isSelected) -1 else index)
                             },
-                            selectedIndex = selectedId,
+                            selectedIndex = selectedIndex,
                             swipeRefreshState = swipeRefreshState,
                             onRefresh = initCreatedExpoList
                         )
@@ -156,8 +156,8 @@ private fun ExpoCreatedScreen(
             }
             Spacer(modifier = Modifier.height(32.dp))
             ExpoCreatedDeleteButton(
-                enabled = selectedId != -1L,
-                onClick = { deleteSelectedExpo(selectedId) }
+                enabled = selectedIndex != -1,
+                onClick = { deleteSelectedExpo(selectedIndex) }
             )
         }
     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -43,6 +43,7 @@ internal fun ExpoCreatedRoute(
 ) {
     val getExpoListUiState by expoViewModel.getExpoListUiState.collectAsStateWithLifecycle()
     val swipeRefreshLoading by expoViewModel.swipeRefreshLoading.collectAsStateWithLifecycle()
+    val expoListSize by expoViewModel.expoListSize.collectAsStateWithLifecycle()
     val swipeRefreshState = rememberSwipeRefreshState(isRefreshing = swipeRefreshLoading)
 
     LaunchedEffect("initCreatedExpo") {
@@ -51,7 +52,7 @@ internal fun ExpoCreatedRoute(
 
     ExpoCreatedScreen(
         modifier = modifier,
-        participantCount = 0,
+        expoListSize = expoListSize,
         getExpoListUiState = getExpoListUiState,
         swipeRefreshState = swipeRefreshState,
         initCreatedExpoList = expoViewModel::getExpoList,
@@ -62,7 +63,7 @@ internal fun ExpoCreatedRoute(
 @Composable
 private fun ExpoCreatedScreen(
     modifier: Modifier = Modifier,
-    participantCount: Int,
+    expoListSize: Int,
     getExpoListUiState: GetExpoListUiState,
     scrollState: ScrollState = rememberScrollState(),
     swipeRefreshState: SwipeRefreshState,
@@ -81,7 +82,7 @@ private fun ExpoCreatedScreen(
         ) {
             ExpoCreatedTopCard(
                 modifier = Modifier.fillMaxWidth(),
-                totalExpo = participantCount,
+                totalExpo = expoListSize,
             )
             Spacer(modifier = Modifier.height(16.dp))
             Column(
@@ -143,7 +144,7 @@ private fun ExpoCreatedScreenPreview() {
                 )
             )
         ),
-        participantCount = 100,
+        expoListSize = 100,
         deleteExpoInformation = { _ -> },
         swipeRefreshState = SwipeRefreshState(isRefreshing = true),
         initCreatedExpoList = {}

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -115,7 +115,6 @@ private fun ExpoCreatedScreen(
                 modifier = Modifier
                     .border(width = 1.dp, color = colors.gray200)
                     .fillMaxWidth()
-                    .padding(vertical = 8.dp)
                     .horizontalScroll(scrollState),
             ) {
                 ExpoCreatedTable()

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -113,7 +113,6 @@ private fun ExpoCreatedScreen(
                 verticalArrangement = Arrangement.spacedBy(14.dp, Alignment.CenterVertically),
                 horizontalAlignment = Alignment.Start,
                 modifier = Modifier
-                    .border(width = 1.dp, color = colors.gray200)
                     .fillMaxWidth()
                     .horizontalScroll(scrollState),
             ) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -176,16 +176,16 @@ private fun ExpoCreatedScreenPreview() {
                     id = "2",
                     title = "제목",
                     description = "묘사",
-                    startedDay = "어제",
-                    finishedDay = "오늘",
+                    startedDay = "2024-11-23",
+                    finishedDay = "2024-11-23",
                     coverImage = null,
                 ),
                 ExpoListResponseEntity(
                     id = "2",
                     title = "제목",
                     description = "묘사",
-                    startedDay = "어제",
-                    finishedDay = "오늘",
+                    startedDay = "2024-11-23",
+                    finishedDay = "2024-11-23",
                     coverImage = null,
                 )
             )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -41,6 +42,10 @@ fun ExpoCreatedRoute(
     expoViewModel: ExpoViewModel = hiltViewModel(),
 ) {
     val getExpoListUiState by expoViewModel.getExpoListUiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect("initCreatedExpo") {
+        expoViewModel.getExpoList()
+    }
 
     ExpoCreatedScreen(
         modifier = modifier,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -60,8 +60,9 @@ internal fun ExpoCreatedRoute(
         swipeRefreshState = swipeRefreshState,
         initCreatedExpoList = expoViewModel::getExpoList,
         deleteSelectedExpo = { selectedId ->
-            if (getExpoListUiState is GetExpoListUiState.Success && selectedId != -1L) expoViewModel.deleteExpoInformation(
-                getExpoListUiState.data[selectedId.toInt()].id
+            val currentGetExpoListUiState = getExpoListUiState
+            if (currentGetExpoListUiState is GetExpoListUiState.Success && selectedId != -1L) expoViewModel.deleteExpoInformation(
+                currentGetExpoListUiState.data[selectedId.toInt()].id
             )
         },
     )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -96,9 +96,9 @@ private fun ExpoCreatedScreen(
             ) {
                 ExpoCreatedTable()
                 when (getExpoListUiState) {
-                    GetExpoListUiState.Empty -> TODO()
-                    is GetExpoListUiState.Error -> TODO()
-                    GetExpoListUiState.Loading -> TODO()
+                    GetExpoListUiState.Empty -> Unit
+                    is GetExpoListUiState.Error -> Unit
+                    GetExpoListUiState.Loading -> Unit
                     is GetExpoListUiState.Success -> {
                         CreatedExpoList(
                             expoList = getExpoListUiState.data.toPersistentList(),

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -96,8 +96,29 @@ private fun ExpoCreatedScreen(
             ) {
                 ExpoCreatedTable()
                 when (getExpoListUiState) {
-                    GetExpoListUiState.Empty -> Unit
-                    is GetExpoListUiState.Error -> Unit
+                    GetExpoListUiState.Empty ,
+                    is GetExpoListUiState.Error -> {
+                        Column(
+                            verticalArrangement = Arrangement.spacedBy(
+                                28.dp,
+                                Alignment.CenterVertically
+                            ),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(color = colors.white)
+                        ) {
+                            WarnIcon(
+                                tint = colors.black,
+                                modifier = Modifier.size(100.dp)
+                            )
+                            Text(
+                                text = "데이터를 불러올 수 없어요!",
+                                style = typography.bodyRegular2,
+                                color = colors.gray400
+                            )
+                        }
+                    }
                     GetExpoListUiState.Loading -> Unit
                     is GetExpoListUiState.Success -> {
                         CreatedExpoList(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -55,6 +55,14 @@ internal fun ExpoCreatedRoute(
         expoViewModel.getExpoList()
     }
 
+    LaunchedEffect(getExpoListUiState) {
+        when (getExpoListUiState) {
+            GetExpoListUiState.Empty -> onErrorToast(null, R.string.get_created_expo_list_empty)
+            is GetExpoListUiState.Error -> onErrorToast(null, R.string.get_created_expo_list_fail)
+            else -> Unit
+        }
+    }
+
     ExpoCreatedScreen(
         modifier = modifier,
         expoListSize = expoListSize,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -60,6 +60,7 @@ internal fun ExpoCreatedRoute(
         when (getExpoListUiState) {
             GetExpoListUiState.Empty -> onErrorToast(null, R.string.get_created_expo_list_empty)
             is GetExpoListUiState.Error -> onErrorToast(null, R.string.get_created_expo_list_fail)
+            is GetExpoListUiState.Success -> setSelectedIndex(-1)
             else -> Unit
         }
     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -38,6 +38,7 @@ import com.school_of_company.expo.viewmodel.uistate.GetExpoListUiState
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 import kotlinx.collections.immutable.immutableListOf
 import kotlinx.collections.immutable.toPersistentList
+import com.school_of_company.design_system.R
 
 @Composable
 internal fun ExpoCreatedRoute(
@@ -62,7 +63,9 @@ internal fun ExpoCreatedRoute(
         initCreatedExpoList = expoViewModel::getExpoList,
         deleteSelectedExpo = { selectedId ->
             val currentGetExpoListUiState = getExpoListUiState
-            if (currentGetExpoListUiState is GetExpoListUiState.Success && selectedId != -1L) expoViewModel.deleteExpoInformation(
+            if (selectedId == -1L) {
+                onErrorToast(null, R.string.expo_not_selected)
+            } else if (currentGetExpoListUiState is GetExpoListUiState.Success) expoViewModel.deleteExpoInformation(
                 currentGetExpoListUiState.data[selectedId.toInt()].id
             )
         },

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -70,7 +70,7 @@ private fun ExpoCreatedScreen(
     initCreatedExpoList: () -> Unit,
     deleteExpoInformation: (String) -> Unit,
 ) {
-    val (selectedId, setSelectedId) = rememberSaveable { mutableLongStateOf(0L) }
+    val (selectedId, setSelectedId) = rememberSaveable { mutableLongStateOf(-1L) }
 
     ExpoAndroidTheme { colors, _ ->
         Column(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -102,8 +102,8 @@ private fun ExpoCreatedScreen(
                     is GetExpoListUiState.Success -> {
                         CreatedExpoList(
                             expoList = getExpoListUiState.data.toPersistentList(),
-                            onItemClick = { isSelected, id ->
-                                setSelectedId(if (isSelected) 0L else id)
+                            onItemClick = { isSelected, index ->
+                                setSelectedId(if (isSelected) -1L else index)
                             },
                             selectedIndex = selectedId,
                             swipeRefreshState = swipeRefreshState,
@@ -114,8 +114,13 @@ private fun ExpoCreatedScreen(
             }
             Spacer(modifier = Modifier.height(32.dp))
             ExpoCreatedDeleteButton(
-                enabled = selectedId != 0L,
-                onClick = { deleteExpoInformation(selectedId.toString()) })
+                enabled = selectedId != -1L,
+                onClick = {
+                    if (getExpoListUiState is GetExpoListUiState.Success && selectedId != -1L) deleteExpoInformation(
+                        getExpoListUiState.data[selectedId.toInt()].id
+                    )
+                }
+            )
         }
     }
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
@@ -1,5 +1,6 @@
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
@@ -44,6 +45,7 @@ internal fun CreatedExpoList(
             ) {
                 itemsIndexed(expoList) { index, item ->
                     CreatedExpoListItem(
+                        modifier = Modifier.fillMaxWidth(),
                         scrollState = scrollState,
                         selectedIndex = selectedIndex,
                         item = item,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
@@ -7,7 +7,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
 import com.google.accompanist.swiperefresh.SwipeRefreshState
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.expo.view.component.CreatedExpoListItem
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 import kotlinx.collections.immutable.ImmutableList
@@ -22,22 +24,31 @@ internal fun CreatedExpoList(
     onItemClick: (Boolean, Long) -> Unit,
     onRefresh: () -> Unit, // 새로고침 콜백
 ) {
-    SwipeRefresh(
-        state = swipeRefreshState,
-        onRefresh = onRefresh // 새로고침 시 호출되는 함수
-    ) {
-        LazyColumn(
-            modifier = modifier,
-            verticalArrangement = Arrangement.spacedBy(20.dp)
-        ) {
-            items(expoList) { item ->
-                CreatedExpoListItem(
-                    selectedIndex = selectedIndex,
-                    item = item,
-                    onClick = { isSelected ->
-                        onItemClick(isSelected, item.id.toLong())
-                    }
+    ExpoAndroidTheme { colors, _ ->
+        SwipeRefresh(
+            state = swipeRefreshState,
+            onRefresh = onRefresh,// 새로고침 시 호출되는 함수
+            indicator = { state, refreshTrigger ->
+                SwipeRefreshIndicator(
+                    state = state,
+                    refreshTriggerDistance = refreshTrigger,
+                    contentColor = colors.main
                 )
+            }
+        ) {
+            LazyColumn(
+                modifier = modifier,
+                verticalArrangement = Arrangement.spacedBy(20.dp)
+            ) {
+                items(expoList) { item ->
+                    CreatedExpoListItem(
+                        selectedIndex = selectedIndex,
+                        item = item,
+                        onClick = { isSelected ->
+                            onItemClick(isSelected, item.id.toLong())
+                        }
+                    )
+                }
             }
         }
     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
@@ -45,8 +45,8 @@ internal fun CreatedExpoList(
                         selectedIndex = selectedIndex,
                         item = item,
                         index = index.toLong(),
-                        onClick = { isSelected ->
-                            onItemClick(isSelected, index.toLong())
+                        onClick = {
+                            onItemClick(selectedIndex == index.toLong(), index.toLong())
                         }
                     )
                 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
@@ -1,6 +1,6 @@
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -40,12 +40,13 @@ internal fun CreatedExpoList(
                 modifier = modifier,
                 verticalArrangement = Arrangement.spacedBy(20.dp)
             ) {
-                items(expoList) { item ->
+                itemsIndexed(expoList) { index, item ->
                     CreatedExpoListItem(
                         selectedIndex = selectedIndex,
                         item = item,
+                        index = index.toLong(),
                         onClick = { isSelected ->
-                            onItemClick(isSelected, item.id.toLong())
+                            onItemClick(isSelected, index.toLong())
                         }
                     )
                 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
@@ -19,9 +19,9 @@ import kotlinx.collections.immutable.persistentListOf
 internal fun CreatedExpoList(
     modifier: Modifier = Modifier,
     expoList: ImmutableList<ExpoListResponseEntity>,
-    selectedIndex: Long,
+    selectedIndex: Int,
     swipeRefreshState: SwipeRefreshState, // 상위에서 전달받은 SwipeRefreshState
-    onItemClick: (Boolean, Long) -> Unit,
+    onItemClick: (Boolean, Int) -> Unit,
     onRefresh: () -> Unit, // 새로고침 콜백
 ) {
     ExpoAndroidTheme { colors, _ ->
@@ -44,10 +44,8 @@ internal fun CreatedExpoList(
                     CreatedExpoListItem(
                         selectedIndex = selectedIndex,
                         item = item,
-                        index = index.toLong(),
-                        onClick = {
-                            onItemClick(selectedIndex == index.toLong(), index.toLong())
-                        }
+                        index = index,
+                        onClick = { onItemClick(selectedIndex == index, index) }
                     )
                 }
             }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
@@ -1,3 +1,4 @@
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -18,6 +19,7 @@ import kotlinx.collections.immutable.persistentListOf
 @Composable
 internal fun CreatedExpoList(
     modifier: Modifier = Modifier,
+    scrollState: ScrollState,
     expoList: ImmutableList<ExpoListResponseEntity>,
     selectedIndex: Int,
     swipeRefreshState: SwipeRefreshState, // 상위에서 전달받은 SwipeRefreshState
@@ -42,6 +44,7 @@ internal fun CreatedExpoList(
             ) {
                 itemsIndexed(expoList) { index, item ->
                     CreatedExpoListItem(
+                        scrollState = scrollState,
                         selectedIndex = selectedIndex,
                         item = item,
                         index = index,
@@ -72,6 +75,7 @@ fun CreatedExpoListPreview() {
         onItemClick = { _, _ -> },
         selectedIndex = 1,
         onRefresh = { /* 새로고침 시 동작할 함수 */ },
-        swipeRefreshState = swipeRefreshState // 상위에서 전달한 상태
-    )
+        swipeRefreshState = swipeRefreshState,// 상위에서 전달한 상태
+        scrollState = ScrollState(1)
+        )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.icon.CircleIcon
 import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
@@ -28,7 +27,7 @@ internal fun CreatedExpoListItem(
     selectedIndex: Long,
     index: Long,
     item: ExpoListResponseEntity,
-    onClick: (Boolean) -> Unit,
+    onClick: () -> Unit,
 ) {
     with(item) {
         ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
@@ -40,7 +39,7 @@ internal fun CreatedExpoListItem(
                         color = if (selectedIndex == index) colors.main100 else colors.white,
                         shape = RoundedCornerShape(size = 4.dp)
                     )
-                    .clickable { onClick(selectedIndex == index) }
+                    .clickable { onClick() }
                     .padding(8.dp),
             ) {
                 Text(
@@ -93,7 +92,7 @@ private fun CreatedExpoListItemNotSelectedPreview() {
         ),
         selectedIndex = 0,
         index = 1,
-        onClick = { _ -> },
+        onClick = { },
     )
 }
 
@@ -111,6 +110,6 @@ private fun CreatedExpoListItemSelectedPreview() {
         ),
         index = 1,
         selectedIndex = 1,
-        onClick = { _ -> },
+        onClick = { },
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.requiredWidthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -65,7 +65,7 @@ internal fun CreatedExpoListItem(
                         CircleIcon(tint = colors.black)
                     }
                     Text(
-                        modifier = Modifier.width(136.dp),
+                        modifier = Modifier.requiredWidthIn(136.dp),
                         text = title,
                         style = typography.captionRegular2,
                         fontWeight = FontWeight.W400,
@@ -73,7 +73,7 @@ internal fun CreatedExpoListItem(
                         textAlign = TextAlign.Center,
                     )
                     Text(
-                        modifier = Modifier.width(70.dp),
+                        modifier = Modifier.requiredWidthIn(70.dp),
                         text = "${formatDateToMonthDay(startedDay)}~${formatDateToMonthDay(finishedDay)}",
                         style = typography.captionRegular2,
                         fontWeight = FontWeight.W400,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -1,7 +1,9 @@
 package com.school_of_company.expo.view.component
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
@@ -26,6 +28,7 @@ import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 @Composable
 internal fun CreatedExpoListItem(
     modifier: Modifier = Modifier,
+    scrollState: ScrollState,
     selectedIndex: Int,
     index: Int,
     item: ExpoListResponseEntity,
@@ -37,6 +40,7 @@ internal fun CreatedExpoListItem(
                 horizontalArrangement = Arrangement.spacedBy(38.dp, Alignment.Start),
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = modifier
+                    .horizontalScroll(scrollState)
                     .background(
                         color = if (selectedIndex == index) colors.main100 else colors.white,
                         shape = RoundedCornerShape(size = 4.dp)
@@ -97,6 +101,7 @@ private fun CreatedExpoListItemNotSelectedPreview() {
         selectedIndex = 0,
         index = 1,
         onClick = { },
+        scrollState = ScrollState(6)
     )
 }
 
@@ -115,5 +120,6 @@ private fun CreatedExpoListItemSelectedPreview() {
         index = 1,
         selectedIndex = 1,
         onClick = { },
+        scrollState = ScrollState(6)
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -69,8 +69,8 @@ internal fun CreatedExpoListItem(
                         textAlign = TextAlign.Center,
                     )
                     Text(
-                        modifier = Modifier.width(68.dp),
-                        text = "${formatDateToMonthDay(startedDay)} ~ ${formatDateToMonthDay(finishedDay)}",
+                        modifier = Modifier.width(70.dp),
+                        text = "${formatDateToMonthDay(startedDay)}~${formatDateToMonthDay(finishedDay)}",
                         style = typography.captionRegular2,
                         fontWeight = FontWeight.W400,
                         color = colors.black,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -25,6 +25,7 @@ import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 internal fun CreatedExpoListItem(
     modifier: Modifier = Modifier,
     selectedIndex: Long,
+    index: Long,
     item: ExpoListResponseEntity,
     onClick: (Boolean) -> Unit,
 ) {
@@ -35,14 +36,14 @@ internal fun CreatedExpoListItem(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = modifier
                     .background(
-                        color = if (selectedIndex == id.toLong()) colors.main100 else colors.white,
+                        color = if (selectedIndex == index) colors.main100 else colors.white,
                         shape = RoundedCornerShape(size = 4.dp)
                     )
-                    .expoClickable { onClick(selectedIndex == id.toLong()) }
+                    .expoClickable { onClick(selectedIndex == index) }
                     .padding(8.dp),
             ) {
                 Text(
-                    text = id.toString(),
+                    text = "${index + 1}",
                     style = typography.captionBold1,
                     fontWeight = FontWeight.W600,
                     color = colors.black,
@@ -90,6 +91,7 @@ private fun CreatedExpoListItemNotSelectedPreview() {
             coverImage = null
         ),
         selectedIndex = 0,
+        index = 1,
         onClick = { _ -> },
     )
 }
@@ -106,6 +108,7 @@ private fun CreatedExpoListItemSelectedPreview() {
             finishedDay = "09.20",
             coverImage = null
         ),
+        index = 1,
         selectedIndex = 1,
         onClick = { _ -> },
     )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -59,6 +60,7 @@ internal fun CreatedExpoListItem(
                         CircleIcon(tint = colors.black)
                     }
                     Text(
+                        modifier = Modifier.width(140.dp),
                         text = title,
                         style = typography.captionRegular2,
                         fontWeight = FontWeight.W400,
@@ -66,6 +68,7 @@ internal fun CreatedExpoListItem(
                         textAlign = TextAlign.Center,
                     )
                     Text(
+                        modifier = Modifier.width(70.dp),
                         text = "$startedDay ~ $finishedDay",
                         style = typography.captionRegular2,
                         fontWeight = FontWeight.W400,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -24,8 +24,8 @@ import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 @Composable
 internal fun CreatedExpoListItem(
     modifier: Modifier = Modifier,
-    selectedIndex: Long,
-    index: Long,
+    selectedIndex: Int,
+    index: Int,
     item: ExpoListResponseEntity,
     onClick: () -> Unit,
 ) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -60,7 +60,7 @@ internal fun CreatedExpoListItem(
                         CircleIcon(tint = colors.black)
                     }
                     Text(
-                        modifier = Modifier.width(140.dp),
+                        modifier = Modifier.width(136.dp),
                         text = title,
                         style = typography.captionRegular2,
                         fontWeight = FontWeight.W400,
@@ -68,7 +68,7 @@ internal fun CreatedExpoListItem(
                         textAlign = TextAlign.Center,
                     )
                     Text(
-                        modifier = Modifier.width(70.dp),
+                        modifier = Modifier.width(68.dp),
                         text = "$startedDay ~ $finishedDay",
                         style = typography.captionRegular2,
                         fontWeight = FontWeight.W400,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -1,6 +1,7 @@
 package com.school_of_company.expo.view.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
@@ -39,7 +40,7 @@ internal fun CreatedExpoListItem(
                         color = if (selectedIndex == index) colors.main100 else colors.white,
                         shape = RoundedCornerShape(size = 4.dp)
                     )
-                    .expoClickable { onClick(selectedIndex == index) }
+                    .clickable { onClick(selectedIndex == index) }
                     .padding(8.dp),
             ) {
                 Text(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -20,6 +20,7 @@ import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.design_system.theme.ExpoTypography
 import com.school_of_company.design_system.theme.color.ColorTheme
+import com.school_of_company.expo.util.formatDateToMonthDay
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 
 @Composable
@@ -69,7 +70,7 @@ internal fun CreatedExpoListItem(
                     )
                     Text(
                         modifier = Modifier.width(68.dp),
-                        text = "$startedDay ~ $finishedDay",
+                        text = "${formatDateToMonthDay(startedDay)} ~ ${formatDateToMonthDay(finishedDay)}",
                         style = typography.captionRegular2,
                         fontWeight = FontWeight.W400,
                         color = colors.black,
@@ -107,8 +108,8 @@ private fun CreatedExpoListItemSelectedPreview() {
             id = "1",
             title = "2024 AI광주미래교육박람회",
             description = "",
-            startedDay = "09.10",
-            finishedDay = "09.20",
+            startedDay = "2024-11-23",
+            finishedDay = "2024-11-23",
             coverImage = null
         ),
         index = 1,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedDeleteButton.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedDeleteButton.kt
@@ -55,8 +55,7 @@ fun ExpoCreatedDeleteButton(
                 textValue = "삭제하기",
                 leadingIcon = { color -> TrashIcon(tint = color) },
                 onClick = { onClick() }
-                )
-            }
+            )
         }
     }
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedDeleteButton.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedDeleteButton.kt
@@ -32,7 +32,7 @@ fun ExpoCreatedDeleteButton(
                 horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = modifier
-                    .expoClickable(enabled = enabled) { onClick() }
+                    .expoClickable { onClick() }
                     .background(
                         color = colors.error,
                         shape = RoundedCornerShape(size = 6.dp)

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedDeleteButton.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedDeleteButton.kt
@@ -31,7 +31,7 @@ fun ExpoCreatedDeleteButton(
             horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
             verticalAlignment = Alignment.CenterVertically,
             modifier = modifier
-                .expoClickable { onClick() }
+                .expoClickable(enabled = enabled) { onClick() }
                 .background(
                     color = if (enabled) colors.error
                     else colors.white,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTable.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTable.kt
@@ -2,14 +2,15 @@ package com.school_of_company.expo.view.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -21,48 +22,40 @@ import com.school_of_company.design_system.theme.color.ColorTheme
 @Composable
 fun ExpoCreatedTable(modifier: Modifier = Modifier) {
     ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(73.dp, Alignment.Start),
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = modifier
-                .background(color = colors.white)
-                .drawBehind {
-                    // 아래쪽 Border 그리기
-                    val strokeWidth = 1.dp.toPx()
-                    val y = size.height - strokeWidth / 2
-                    drawLine(
-                        color = colors.gray100, // Border 색상
-                        start = Offset(0f, y),
-                        end = Offset(size.maxDimension, y),
-                        strokeWidth = strokeWidth
+        Column {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(73.dp, Alignment.Start),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = modifier
+                    .background(color = colors.white)
+                    .padding(
+                        horizontal = 54.dp,
+                        vertical = 14.dp,
                     )
-                }
-                .padding(
-                    horizontal = 54.dp,
-                    vertical = 14.dp,
+            ) {
+                Text(
+                    text = "이미지",
+                    style = typography.captionBold1,
+                    fontWeight = FontWeight.W600,
+                    color = colors.gray600,
+                    textAlign = TextAlign.Center,
                 )
-        ) {
-            Text(
-                text = "이미지",
-                style = typography.captionBold1,
-                fontWeight = FontWeight.W600,
-                color = colors.gray600,
-                textAlign = TextAlign.Center,
-            )
-            Text(
-                text = "박람회 이름",
-                style = typography.captionBold1,
-                fontWeight = FontWeight.W600,
-                color = colors.gray600,
-                textAlign = TextAlign.Center,
-            )
-            Text(
-                text = "모집 기간",
-                style = typography.captionBold1,
-                fontWeight = FontWeight.W600,
-                color = colors.gray600,
-                textAlign = TextAlign.Center,
-            )
+                Text(
+                    text = "박람회 이름",
+                    style = typography.captionBold1,
+                    fontWeight = FontWeight.W600,
+                    color = colors.gray600,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = "모집 기간",
+                    style = typography.captionBold1,
+                    fontWeight = FontWeight.W600,
+                    color = colors.gray600,
+                    textAlign = TextAlign.Center,
+                )
+            }
+            Spacer(modifier = Modifier.background(colors.gray100).fillMaxWidth())
         }
     }
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTable.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTable.kt
@@ -33,7 +33,7 @@ fun ExpoCreatedTable(modifier: Modifier = Modifier) {
                     drawLine(
                         color = colors.gray100, // Border 색상
                         start = Offset(0f, y),
-                        end = Offset(size.width, y),
+                        end = Offset(size.maxDimension, y),
                         strokeWidth = strokeWidth
                     )
                 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTable.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTable.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidthIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
@@ -36,7 +37,7 @@ fun ExpoCreatedTable(modifier: Modifier = Modifier) {
                     )
             ) {
                 Text(
-                    modifier = Modifier.width(37.dp),
+                    modifier = Modifier.requiredWidthIn(37.dp),
                     text = "이미지",
                     style = typography.captionBold1,
                     fontWeight = FontWeight.W600,
@@ -44,7 +45,7 @@ fun ExpoCreatedTable(modifier: Modifier = Modifier) {
                     textAlign = TextAlign.Center,
                 )
                 Text(
-                    modifier = Modifier.width(64.dp),
+                    modifier = Modifier.requiredWidthIn(64.dp),
                     text = "박람회 이름",
                     style = typography.captionBold1,
                     fontWeight = FontWeight.W600,
@@ -52,7 +53,7 @@ fun ExpoCreatedTable(modifier: Modifier = Modifier) {
                     textAlign = TextAlign.Center,
                 )
                 Text(
-                    modifier = Modifier.width(52.dp),
+                    modifier = Modifier.requiredWidthIn(52.dp),
                     text = "모집 기간",
                     style = typography.captionBold1,
                     fontWeight = FontWeight.W600,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTable.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTable.kt
@@ -4,10 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -37,6 +36,7 @@ fun ExpoCreatedTable(modifier: Modifier = Modifier) {
                     )
             ) {
                 Text(
+                    modifier = Modifier.width(37.dp),
                     text = "이미지",
                     style = typography.captionBold1,
                     fontWeight = FontWeight.W600,
@@ -44,6 +44,7 @@ fun ExpoCreatedTable(modifier: Modifier = Modifier) {
                     textAlign = TextAlign.Center,
                 )
                 Text(
+                    modifier = Modifier.width(64.dp),
                     text = "박람회 이름",
                     style = typography.captionBold1,
                     fontWeight = FontWeight.W600,
@@ -51,6 +52,7 @@ fun ExpoCreatedTable(modifier: Modifier = Modifier) {
                     textAlign = TextAlign.Center,
                 )
                 Text(
+                    modifier = Modifier.width(52.dp),
                     text = "모집 기간",
                     style = typography.captionBold1,
                     fontWeight = FontWeight.W600,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTable.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTable.kt
@@ -6,7 +6,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -22,7 +24,8 @@ import com.school_of_company.design_system.theme.color.ColorTheme
 @Composable
 fun ExpoCreatedTable(modifier: Modifier = Modifier) {
     ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
-        Column {
+        Column(Modifier.fillMaxWidth()) {
+            HorizontalDivider(thickness = 1.dp, color = colors.gray200)
             Row(
                 horizontalArrangement = Arrangement.spacedBy(73.dp, Alignment.Start),
                 verticalAlignment = Alignment.CenterVertically,
@@ -55,7 +58,7 @@ fun ExpoCreatedTable(modifier: Modifier = Modifier) {
                     textAlign = TextAlign.Center,
                 )
             }
-            Spacer(modifier = Modifier.background(colors.gray100).fillMaxWidth())
+            HorizontalDivider(thickness = 1.dp, color = colors.gray100)
         }
     }
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTopCard.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTopCard.kt
@@ -24,7 +24,7 @@ import com.school_of_company.design_system.theme.color.ColorTheme
 @Composable
 fun ExpoCreatedTopCard(
     modifier: Modifier = Modifier,
-    participantCount: Int,
+    totalExpo: Int,
 ) {
     ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
         Column(
@@ -67,13 +67,13 @@ fun ExpoCreatedTopCard(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
-                        text = "참가자 전체 인원",
+                        text = "등록된 박람회",
                         style = typography.captionRegular2,
                         fontWeight = FontWeight.W400,
                         color = colors.gray500,
                     )
                     Text(
-                        text = "${participantCount}명",
+                        text = "${totalExpo}개",
                         style = typography.captionRegular2,
                         fontWeight = FontWeight.W400,
                         color = colors.main,
@@ -88,6 +88,6 @@ fun ExpoCreatedTopCard(
 @Composable
 fun ExpoCreatedTopCardPreview(){
     ExpoCreatedTopCard(
-        participantCount = 30
+        totalExpo = 30
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -38,9 +38,13 @@ import com.school_of_company.model.model.standard.StandardRequestModel
 import com.school_of_company.model.model.training.TrainingDtoModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -133,6 +137,15 @@ class ExpoViewModel @Inject constructor(
     internal var location = savedStateHandle.getStateFlow(key = LOCATION, initialValue = "")
 
     internal var cover_image = savedStateHandle.getStateFlow(key = COVER_IMAGE, initialValue = "")
+
+    val expoListSize: StateFlow<Int> = getExpoListUiState
+        .map { state ->
+            when (state) {
+                is GetExpoListUiState.Success -> state.data.size
+                else -> 0
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
 
     internal fun getExpoInformation(expoId: String) = viewModelScope.launch {
         getExpoInformationUseCase(expoId = expoId)

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -228,6 +228,7 @@ class ExpoViewModel @Inject constructor(
                     _deleteExpoInformationUiState.value = DeleteExpoInformationUiState.Error(remoteError)
                 }.collect {
                     _deleteExpoInformationUiState.value = DeleteExpoInformationUiState.Success
+                    getExpoList()
                 }
             }
             .onFailure { error ->


### PR DESCRIPTION
## 💡 개요

CreatedExpo 관련 기능 개선 및 오류 수정을 통해 더 안정적인 사용자 경험을 제공하기 위한 작업입니다.
CreatedExpo 화면의 데이터처리를 연결했습니다

## 📃 작업내용

- 등록된 Expo 리스트를 초기화하는 로직 추가
- `deleteExpoInformation`이 성공한 후 Expo 리스트를 다시 불러오도록 수정
- `ExpoCreatedDeleteButton`의 `enabled` 상태에 따라 `expoClickable`의 활성화 상태를 연동
- `navigateToExpoCreate`와 `navigateToExpoCreated` 사이 공백 추가
- `SwipeRefresh`의 Indicator 색상을 커스텀 (`colors.main`)으로 변경
- 디자인 변경사항 반영
- Expo 데이터 크기 추적을 위한 `expoListSize StateFlow` 추가 및 Screen에 전달
- `TopLevelDestination`에서 `EXPO_CREATED`에 Navigation 함수 추가
- Index를 입력받아 표시할 때 `index + 1` 값이 표시되도록 수정
- `items`가 아닌 `itemsIndexed`를 사용해 Index를 `CreatedExpoListItem`에 전달
- `selectedId`의 기본값을 `-1`로 변경
- `todo`를 `Unit`으로 변경해 오류 발생 방지
- `selectedId` 조건식의 값들을 `0 -> -1`로 변경
- 클릭 이벤트 누락 문제를 해결하기 위해 `expoClickable`에서 `clickable`로 변경

## 🔀 변경사항

- UI 개선
- 데이터 신뢰도 향상
- Expo 리스트 관리 로직 개선

## 🙋‍♂️ 질문사항

- 개선할 점, 오타, 또는 코드에 이상한 부분이 있다면 Comment 부탁드립니다.

## 🍴 사용방법

- 수정된 기능은 기존 방식과 동일하게 사용할 수 있습니다. 
- Expo 리스트 초기화 및 삭제 시 리스트가 자동 갱신됩니다.

## 🎸 기타
- 클릭 이벤트 누락 문제를 재발 방지하기 위해 추가적인 논의가 피요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- 박람회 생성 화면의 탐색 및 상호작용 기능 개선
	- 박람회 목록 동적 로딩 및 상태 관리 최적화
	- 새로운 경로 추가 및 탐색 구조 통합
	- 사용자 피드백을 위한 새로운 문자열 리소스 추가
	- 날짜 형식 변환 기능 추가

- **버그 수정**
	- 선택된 항목 처리 로직 개선
	- 목록 상호작용의 안정성 향상
	- 오류 발생 시 사용자 안내 메시지 개선

- **사용자 경험**
	- 박람회 목록 표시 방식 업데이트
	- 삭제 및 선택 기능의 사용성 개선
	- UI 구성 요소의 레이아웃 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->