### PR TITLE
🔀 :: (#278) - 카메라 권한 허용을 했을때 자동으로 넘어가지 않던 문제를 해결하였습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -148,7 +148,8 @@ fun ExpoNavHost(
 
         qrScannerScreen(
             onBackClick = navController::popBackStack,
-            onPermissionBlock = navController::popBackStack
+            onPermissionBlock = navController::popBackStack,
+            onErrorToast = makeErrorToast
         )
 
         profileScreen(onErrorToast = makeErrorToast)

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -116,4 +116,6 @@
     <string name="sign_up_request_allow_success">회원가입 요청 수락 성공</string>
     <string name="sign_up_request_allow_fail">회원가입 요청 수락 실패</string>
     <string name="check_sign_up_request_list_item">가입을 수락할 회원을 선택해주세요.</string>
+
+    <string name="camera_access_allow_in_setting">카메라 권한이 필요합니다. 설정에서 권한을 허용해주세요.</string>
 </resources>

--- a/feature/program/src/main/java/com/school_of_company/program/navigation/ProgramNavigation.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/navigation/ProgramNavigation.kt
@@ -65,7 +65,8 @@ fun NavGraphBuilder.programDetailParticipantManagementScreen(
 
 fun NavGraphBuilder.qrScannerScreen(
     onBackClick: () -> Unit,
-    onPermissionBlock: () -> Unit
+    onPermissionBlock: () -> Unit,
+    onErrorToast: (throwable: Throwable?, message: Int?) -> Unit
 ) {
     composable(route = "$qrScannerRoute/{id}/{screenType}") { backStackEntry ->
         val id = backStackEntry.arguments?.getString("id")?.toLongOrNull()
@@ -76,7 +77,8 @@ fun NavGraphBuilder.qrScannerScreen(
                 id = id,
                 screenType = screenType,
                 onBackClick = onBackClick,
-                onPermissionBlock = onPermissionBlock
+                onPermissionBlock = onPermissionBlock,
+                onErrorToast = onErrorToast
             )
         }
     }

--- a/feature/program/src/main/java/com/school_of_company/program/view/QrScannerScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/QrScannerScreen.kt
@@ -10,6 +10,9 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -21,6 +24,7 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.google.accompanist.permissions.shouldShowRationale
+import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
 import com.school_of_company.design_system.icon.LeftArrowIcon
@@ -43,8 +47,11 @@ internal fun QrScannerRoute(
     screenType: String,
     onBackClick: () -> Unit,
     onPermissionBlock: () -> Unit,
+    onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
     viewModel: ProgramViewModel = hiltViewModel(),
 ) {
+    var showScanner by remember { mutableStateOf(false) }
+
     val trainingQrCodeUiState by viewModel.readQrCodeUiState.collectAsStateWithLifecycle()
 
     val cameraPermissionState = rememberPermissionState(Manifest.permission.CAMERA)
@@ -53,60 +60,76 @@ internal fun QrScannerRoute(
     val lifecycleOwner = context as? LifecycleOwner
         ?: throw IllegalStateException("Context is not a LifecycleOwner")
 
-    LaunchedEffect("getPermission") {
-        if (!cameraPermissionState.status.isGranted && !cameraPermissionState.status.shouldShowRationale) {
-            cameraPermissionState.launchPermissionRequest()
-        }
-    }
 
-    LaunchedEffect(trainingQrCodeUiState) {
-        when (trainingQrCodeUiState) {
-            is ReadQrCodeUiState.Loading -> {
-                makeToast(context, "로딩중..")
+    LaunchedEffect(cameraPermissionState.status) {
+        when {
+            // 권한이 이미 허용된 경우
+            cameraPermissionState.status.isGranted -> {
+                showScanner = true
+            }
+            // 권한이 없고 권한 요청 다이얼로그를 보여줄 수 있는 경우
+            !cameraPermissionState.status.isGranted &&
+                    !cameraPermissionState.status.shouldShowRationale -> {
+                cameraPermissionState.launchPermissionRequest()
             }
 
-            is ReadQrCodeUiState.Success -> {
-                makeToast(context, "인식 성공!")
-                onBackClick()
-            }
-
-            is ReadQrCodeUiState.Error -> {
-                makeToast(context, "인식을 하지 못하였습니다.")
+            else -> {
+                onErrorToast(null, R.string.camera_access_allow_in_setting)
             }
         }
     }
 
     if (cameraPermissionState.status.isGranted) {
-        QrScannerScreen(
-            onBackClick = onBackClick,
-            lifecycleOwner = lifecycleOwner,
-            onQrcodeScan = { jsonData ->
-                when (screenType) {
-                    QrReadScreenType.TrainingProgramParticipantScreen.routeName -> {
-                        viewModel.trainingQrCode(
-                            trainingId = id,
-                            body = TrainingQrCodeRequestParam(
-                                traineeId = jsonData.parseTrainingQr().toLong()
-                            )
-                        )
-                    }
+        LaunchedEffect(trainingQrCodeUiState) {
+            when (trainingQrCodeUiState) {
+                is ReadQrCodeUiState.Loading -> {
+                    makeToast(context, "로딩중..")
+                }
 
-                    QrReadScreenType.StandardProgramParticipantRoute.routeName -> {
-                        val parsedData = jsonData.parseStandardQrScanModel()
+                is ReadQrCodeUiState.Success -> {
+                    makeToast(context, "인식 성공!")
+                    onBackClick()
+                }
 
-                        viewModel.standardQrCode(
-                            standardId = id,
-                            body = StandardQrCodeRequestParam(
-                                participantId = parsedData.participantId,
-                                phoneNumber = parsedData.phoneNumber
-                            )
-                        )
-                    }
+                is ReadQrCodeUiState.Error -> {
+                    makeToast(context, "인식을 하지 못하였습니다.")
                 }
             }
-        )
-    } else {
-        onPermissionBlock()
+        }
+    }
+
+    when {
+        showScanner -> {
+            QrScannerScreen(
+                onBackClick = onBackClick,
+                lifecycleOwner = lifecycleOwner,
+                onQrcodeScan = { jsonData ->
+                    when (screenType) {
+                        QrReadScreenType.TrainingProgramParticipantScreen.routeName -> {
+                            viewModel.trainingQrCode(
+                                trainingId = id,
+                                body = TrainingQrCodeRequestParam(
+                                    traineeId = jsonData.parseTrainingQr().toLong()
+                                )
+                            )
+                        }
+                        QrReadScreenType.StandardProgramParticipantRoute.routeName -> {
+                            val parsedData = jsonData.parseStandardQrScanModel()
+                            viewModel.standardQrCode(
+                                standardId = id,
+                                body = StandardQrCodeRequestParam(
+                                    participantId = parsedData.participantId,
+                                    phoneNumber = parsedData.phoneNumber
+                                )
+                            )
+                        }
+                    }
+                }
+            )
+        }
+        cameraPermissionState.status.shouldShowRationale -> {
+            onPermissionBlock()
+        }
     }
 }
 

--- a/feature/program/src/main/java/com/school_of_company/program/view/QrScannerScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/QrScannerScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,7 +50,7 @@ internal fun QrScannerRoute(
     onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
     viewModel: ProgramViewModel = hiltViewModel(),
 ) {
-    var showScanner by remember { mutableStateOf(false) }
+    var showScanner by rememberSaveable { mutableStateOf(false) }
 
     val trainingQrCodeUiState by viewModel.readQrCodeUiState.collectAsStateWithLifecycle()
 
@@ -63,11 +63,10 @@ internal fun QrScannerRoute(
 
     LaunchedEffect(cameraPermissionState.status) {
         when {
-            // 권한이 이미 허용된 경우
             cameraPermissionState.status.isGranted -> {
                 showScanner = true
             }
-            // 권한이 없고 권한 요청 다이얼로그를 보여줄 수 있는 경우
+
             !cameraPermissionState.status.isGranted &&
                     !cameraPermissionState.status.shouldShowRationale -> {
                 cameraPermissionState.launchPermissionRequest()


### PR DESCRIPTION
## 💡 개요
- 카메라 권한 허용을 하였을때 바로 넘어가지 않던 문제가 있어 이를 자동으로 넘어갈 수 있도록 수정해줄 필요가 있었습니다.
## 📃 작업내용
- 카메라 권한 허용을 했을때 자동으로 넘어가지 않던 문제를 해결하였습니다. 
   - showScanner라는 State를 추가하여 사용하였습니다. -> QR 스캐너 화면 표시 여부
   - LaunchedEffect(cameraPermissionState.status)를 사용하여 권한 상태 변경을 모니터링하도록 하였습니다.
   - 권한이 허용된 경우, 권한이 없고 처음 요청하는 경우, 권한이 거부된 경우에 각각 실행될 이벤트를 추가하였습니다.
   - 권한이 있을 때만 QR 스캔 상태를 모니터링하도록 수정을 하였습니다.(trainingQrCodeUiState)
   - 스캐너를 보여줄 수 있는 경우 QR 스캔 화면을 표시, 권한 거부 상태인 경우 권한 블록 UI 표시를 하도록 하였습니다.

<br>   

   - 권한을 허용했을 경우 
   
      https://github.com/user-attachments/assets/50337b12-cf9b-4cff-be08-b8f5a9a2d723

   - 권한을 거부했을 경우
   
      https://github.com/user-attachments/assets/9b43b691-40a1-4220-b801-45bf038001f4


## 🔀 변경사항
- chore strings.xml(:core:design-system)
- chore QrScannerScreen
- chore ProgramNavigation
- chore ExpoNavHost
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- QR 스캐너 화면에 오류 처리 메커니즘 추가
	- 카메라 권한 관련 사용자 안내 메시지 개선

- **버그 수정**
	- 카메라 권한 요청 및 처리 로직 강화
	- 권한 거부 시 사용자에게 명확한 안내 제공

- **문서화**
	- 카메라 권한 관련 안내 문구 추가 (`카메라 권한이 필요합니다. 설정에서 권한을 허용해주세요.`)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->