### PR TITLE
🔀 :: (#314) - add input masking when entering date

### DIFF
--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
@@ -220,7 +220,7 @@ fun ExpoNoneLabelTextField(
                 visualTransformation = if (visualTransformationState) PasswordVisualTransformation() else VisualTransformation.None,
                 trailingIcon = trailingIcon
             )
-            if (isError) {
+            if (isError) { // TODO: 항상 참인 식 
                 Row(horizontalArrangement = if (isError) Arrangement.Start else Arrangement.End) {
                     ErrorText(text = errorText)
                 }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
@@ -162,7 +162,7 @@ fun ExpoNoneLabelTextField(
     value: String? = null,
     visualTransformationState: Boolean = false,
     trailingIcon: @Composable (() -> Unit)? = null
-    ) {
+) {
     var text by remember { mutableStateOf(value ?: "") }
     val isFocused = remember { mutableStateOf(false) }
 
@@ -238,6 +238,7 @@ fun LimitedLengthTextField(
     overflowErrorMessage: String = "",
     isError: Boolean,
     lengthLimit: Int = 0,
+    visualTransformation: VisualTransformation = VisualTransformation.None,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     updateTextValue: (String) -> Unit,
 ) {
@@ -279,6 +280,7 @@ fun LimitedLengthTextField(
                         }
                     },
                     keyboardOptions = keyboardOptions,
+                    visualTransformation = visualTransformation,
                     value = textState,
                     textStyle = typography.captionRegular1.copy(
                         fontWeight = FontWeight.Normal,
@@ -476,11 +478,11 @@ fun ExpoOutlinedTextFieldPreview() {
                 label = "비밀번호"
             )
             LimitedLengthTextField(textState = "", placeholder = "", isError = false) {
-                
+
             }
 
             NoneLimitedLengthTextField(textState = "", placeholder = "") {
-                
+
             }
         }
     }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
@@ -237,6 +237,7 @@ fun LimitedLengthTextField(
     placeholder: String,
     overflowErrorMessage: String = "",
     isError: Boolean,
+    showLengthCounter: Boolean = true,
     lengthLimit: Int = 0,
     visualTransformation: VisualTransformation = VisualTransformation.None,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
@@ -303,7 +304,7 @@ fun LimitedLengthTextField(
                 }
             }
 
-            if (lengthLimit != 0) {
+            if (lengthLimit != 0 && showLengthCounter) {
                 Text(
                     text = "${textState.length} / $lengthLimit",
                     style = typography.captionRegular2,

--- a/core/ui/src/main/java/com/school_of_company/ui/util/autoFormatToDateTime.kt
+++ b/core/ui/src/main/java/com/school_of_company/ui/util/autoFormatToDateTime.kt
@@ -1,0 +1,17 @@
+package com.school_of_company.ui.util
+
+fun String.autoFormatToDateTime(): String {
+    val year = this.take(4)
+    val month = this.drop(4).take(2)
+    val day = this.drop(6).take(2)
+    val hour = this.drop(8).take(2)
+    val minute = this.drop(10).take(2)
+
+    return buildString {
+        if (year.isNotEmpty()) append(year)
+        if (month.isNotEmpty()) append("-$month")
+        if (day.isNotEmpty()) append("-$day")
+        if (hour.isNotEmpty()) append(" $hour")
+        if (minute.isNotEmpty()) append(":$minute")
+    }
+}

--- a/core/ui/src/main/java/com/school_of_company/ui/visualTransformation/DateTimeVisualTransformation.kt
+++ b/core/ui/src/main/java/com/school_of_company/ui/visualTransformation/DateTimeVisualTransformation.kt
@@ -1,0 +1,71 @@
+package com.school_of_company.ui.visualTransformation
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import com.school_of_company.ui.util.autoFormatToDateTime
+
+class DateTimeVisualTransformation : VisualTransformation {
+    override fun filter(text: AnnotatedString): TransformedText {
+        // 입력된 텍스트에서 숫자만 추출
+        val digitsOnly = text.text.filter { it.isDigit() }
+        // 숫자를 날짜 및 시간 형식으로 변환
+        val transformedText = digitsOnly.autoFormatToDateTime()
+
+        // 원본과 변환된 텍스트 간의 오프셋 매핑 생성
+        val offsetMapping = createOffsetMapping(digitsOnly, transformedText)
+
+        // 변환된 텍스트와 오프셋 매핑을 사용해 TransformedText 반환
+        return TransformedText(AnnotatedString(transformedText), offsetMapping)
+    }
+
+    /**
+     * 원본 텍스트와 변환된 텍스트 간의 오프셋 매핑을 생성합니다.
+     * @param original 변환 이전의 숫자 문자열
+     * @param transformed 변환 이후의 날짜 및 시간 문자열
+     * @return OffsetMapping 객체
+     */
+    private fun createOffsetMapping(original: String, transformed: String): OffsetMapping {
+        // 원본 텍스트의 각 문자와 변환된 텍스트 간의 매핑을 저장
+        val originalToTransformedMap = mutableListOf<Int>()
+
+        // 변환된 텍스트의 위치를 원본 텍스트의 인덱스와 연결
+        val reverseMap = mutableMapOf<Int, Int>()
+
+        var digitIndex = 0 // 원본 텍스트에서 숫자의 현재 위치를 추적
+
+        // 변환된 텍스트를 순회하며 매핑 생성
+        for (i in transformed.indices) {
+            // 변환된 텍스트에서 숫자를 찾고 매핑에 추가
+            if (digitIndex < original.length && transformed[i].isDigit()) {
+                originalToTransformedMap.add(i) // 원본 -> 변환된 위치
+                reverseMap[i] = digitIndex      // 변환된 -> 원본 위치
+                digitIndex++
+            }
+        }
+
+        // OffsetMapping 객체 반환
+        return object : OffsetMapping {
+            /**
+             * 원본 텍스트의 오프셋을 변환된 텍스트의 오프셋으로 변환합니다.
+             * @param offset 원본 텍스트에서의 커서 위치
+             * @return 변환된 텍스트에서의 커서 위치
+             */
+            override fun originalToTransformed(offset: Int): Int {
+                // 원본 오프셋이 매핑된 값을 반환하거나 변환된 텍스트의 길이를 반환
+                return originalToTransformedMap.getOrElse(offset) { transformed.length }
+            }
+
+            /**
+             * 변환된 텍스트의 오프셋을 원본 텍스트의 오프셋으로 변환합니다.
+             * @param offset 변환된 텍스트에서의 커서 위치
+             * @return 원본 텍스트에서의 커서 위치
+             */
+            override fun transformedToOriginal(offset: Int): Int {
+                // 변환된 텍스트의 오프셋을 원본 오프셋으로 매핑하거나 원본 길이를 반환
+                return reverseMap[offset] ?: original.length
+            }
+        }
+    }
+}

--- a/core/ui/src/test/java/com/school_of_company/ui/ExampleUnitTest.kt
+++ b/core/ui/src/test/java/com/school_of_company/ui/ExampleUnitTest.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.ui
 
+import com.school_of_company.ui.util.autoFormatToDateTime
 import org.junit.Test
 
 import org.junit.Assert.*
@@ -13,5 +14,13 @@ class ExampleUnitTest {
     @Test
     fun addition_isCorrect() {
         assertEquals(4, 2 + 2)
+    }
+    @Test
+    fun testAutoFormatToDateTime() {
+        assertEquals("2025", "2025".autoFormatToDateTime())
+        assertEquals("2025-01", "202501".autoFormatToDateTime())
+        assertEquals("2025-01-14", "20250114".autoFormatToDateTime())
+        assertEquals("2025-01-14 13:45", "202501141345".autoFormatToDateTime())
+        assertEquals("", "".autoFormatToDateTime())
     }
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -375,7 +375,11 @@ private fun ExpoCreateScreen(
                         placeholder = "시작일",
                         isError = false,
                         visualTransformation = DateTimeVisualTransformation(),
-                        updateTextValue = onStartedDateChange,
+                        updateTextValue = { value ->
+                            if (endedDateState.length <= 8) {
+                                onStartedDateChange(value)
+                            }
+                        },
                         modifier = Modifier.weight(1f)
                     )
 
@@ -384,7 +388,11 @@ private fun ExpoCreateScreen(
                         placeholder = "마감일",
                         isError = false,
                         visualTransformation = DateTimeVisualTransformation(),
-                        updateTextValue = onEndedDateChange,
+                        updateTextValue = { value ->
+                            if (endedDateState.length <= 8) {
+                                onEndedDateChange(value)
+                            }
+                        },
                         modifier = Modifier.weight(1f)
                     )
                 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -375,11 +375,7 @@ private fun ExpoCreateScreen(
                         placeholder = "시작일",
                         isError = false,
                         visualTransformation = DateTimeVisualTransformation(),
-                        updateTextValue = { value ->
-                            if (endedDateState.length <= 8) {
-                                onStartedDateChange(value)
-                            }
-                        },
+                        updateTextValue = onStartedDateChange,
                         modifier = Modifier.weight(1f)
                     )
 
@@ -388,11 +384,7 @@ private fun ExpoCreateScreen(
                         placeholder = "마감일",
                         isError = false,
                         visualTransformation = DateTimeVisualTransformation(),
-                        updateTextValue = { value ->
-                            if (endedDateState.length <= 8) {
-                                onEndedDateChange(value)
-                            }
-                        },
+                        updateTextValue = onEndedDateChange,
                         modifier = Modifier.weight(1f)
                     )
                 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -372,6 +372,8 @@ private fun ExpoCreateScreen(
                     LimitedLengthTextField(
                         label = "모집기간",
                         textState = startedDateState,
+                        lengthLimit = 8,
+                        showLengthCounter = false,
                         placeholder = "시작일",
                         isError = false,
                         visualTransformation = DateTimeVisualTransformation(),
@@ -381,6 +383,8 @@ private fun ExpoCreateScreen(
 
                     LimitedLengthTextField(
                         textState = endedDateState,
+                        lengthLimit = 8,
+                        showLengthCounter = false,
                         placeholder = "마감일",
                         isError = false,
                         visualTransformation = DateTimeVisualTransformation(),

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -76,6 +76,7 @@ import com.school_of_company.model.model.expo.ExpoRequestAndResponseModel
 import com.school_of_company.model.model.standard.StandardRequestModel
 import com.school_of_company.model.model.training.TrainingDtoModel
 import com.school_of_company.ui.toast.makeToast
+import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
 
 @Composable
 internal fun ExpoCreateRoute(
@@ -373,6 +374,7 @@ private fun ExpoCreateScreen(
                         textState = startedDateState,
                         placeholder = "시작일",
                         isError = false,
+                        visualTransformation = DateTimeVisualTransformation(),
                         updateTextValue = onStartedDateChange,
                         modifier = Modifier.weight(1f)
                     )
@@ -381,6 +383,7 @@ private fun ExpoCreateScreen(
                         textState = endedDateState,
                         placeholder = "마감일",
                         isError = false,
+                        visualTransformation = DateTimeVisualTransformation(),
                         updateTextValue = onEndedDateChange,
                         modifier = Modifier.weight(1f)
                     )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -143,6 +143,7 @@ private fun ExpoCreatedScreen(
                 }
             }
             Spacer(modifier = Modifier.height(32.dp))
+            // TODO: 데이터 로딩시에 버튼 안보이게 설정
             ExpoCreatedDeleteButton(
                 enabled = selectedIndex != -1,
                 onClick = { deleteSelectedExpo(selectedIndex) }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -480,11 +480,7 @@ private fun ExpoModifyScreen(
                         placeholder = "시작일",
                         isError = false,
                         visualTransformation = DateTimeVisualTransformation(),
-                        updateTextValue = { value ->
-                            if (endedDateState.length <= 8) {
-                                onStartedDateChange(value)
-                            }
-                        },
+                        updateTextValue = onStartedDateChange,
                         modifier = Modifier.weight(1f)
                     )
 
@@ -493,11 +489,7 @@ private fun ExpoModifyScreen(
                         placeholder = "마감일",
                         isError = false,
                         visualTransformation = DateTimeVisualTransformation(),
-                        updateTextValue = { value ->
-                            if (endedDateState.length <= 8) {
-                                onEndedDateChange(value)
-                            }
-                        },
+                        updateTextValue = onEndedDateChange,
                         modifier = Modifier.weight(1f)
                     )
                 }
@@ -637,7 +629,7 @@ private fun ExpoModifyScreen(
             val selectedTrainingItem = selectedTrainingIndex?.let { trainingProgramTextState[it] }
 
             SettingBottomSheet(
-                isOpen = openTrainingSettingBottomSheet, // TODO: 항상 참인식
+                isOpen = openTrainingSettingBottomSheet,
                 onDismiss = { isOpenTrainingSettingBottomSheet(false) },
                 selectedItem = selectedTrainingItem,
                 onUpdateItem = { updateItem ->
@@ -662,7 +654,7 @@ private fun ExpoModifyScreen(
             val selectedStandardItem = selectedStandardIndex?.let { standardProgramTextState[it] }
 
             SettingBottomSheet(
-                isOpen = openStandardSettingBottomSheet,// TODO: 항상 참인식
+                isOpen = openStandardSettingBottomSheet,
                 onDismiss = { isOpenStandardSettingBottomSheet(false) },
                 selectedItem = selectedStandardItem,
                 onUpdateItem = { updateItem ->

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -480,7 +480,11 @@ private fun ExpoModifyScreen(
                         placeholder = "시작일",
                         isError = false,
                         visualTransformation = DateTimeVisualTransformation(),
-                        updateTextValue = onStartedDateChange,
+                        updateTextValue = { value ->
+                            if (endedDateState.length <= 8) {
+                                onStartedDateChange(value)
+                            }
+                        },
                         modifier = Modifier.weight(1f)
                     )
 
@@ -489,7 +493,11 @@ private fun ExpoModifyScreen(
                         placeholder = "마감일",
                         isError = false,
                         visualTransformation = DateTimeVisualTransformation(),
-                        updateTextValue = onEndedDateChange,
+                        updateTextValue = { value ->
+                            if (endedDateState.length <= 8) {
+                                onEndedDateChange(value)
+                            }
+                        },
                         modifier = Modifier.weight(1f)
                     )
                 }
@@ -629,7 +637,7 @@ private fun ExpoModifyScreen(
             val selectedTrainingItem = selectedTrainingIndex?.let { trainingProgramTextState[it] }
 
             SettingBottomSheet(
-                isOpen = openTrainingSettingBottomSheet,
+                isOpen = openTrainingSettingBottomSheet, // TODO: 항상 참인식
                 onDismiss = { isOpenTrainingSettingBottomSheet(false) },
                 selectedItem = selectedTrainingItem,
                 onUpdateItem = { updateItem ->
@@ -654,7 +662,7 @@ private fun ExpoModifyScreen(
             val selectedStandardItem = selectedStandardIndex?.let { standardProgramTextState[it] }
 
             SettingBottomSheet(
-                isOpen = openStandardSettingBottomSheet,
+                isOpen = openStandardSettingBottomSheet,// TODO: 항상 참인식
                 onDismiss = { isOpenStandardSettingBottomSheet(false) },
                 selectedItem = selectedStandardItem,
                 onUpdateItem = { updateItem ->

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -477,6 +477,7 @@ private fun ExpoModifyScreen(
                     LimitedLengthTextField(
                         label = "모집기간",
                         textState = startedDateState,
+                        lengthLimit = 8,
                         placeholder = "시작일",
                         isError = false,
                         visualTransformation = DateTimeVisualTransformation(),
@@ -486,6 +487,7 @@ private fun ExpoModifyScreen(
 
                     LimitedLengthTextField(
                         textState = endedDateState,
+                        lengthLimit = 8,
                         placeholder = "마감일",
                         isError = false,
                         visualTransformation = DateTimeVisualTransformation(),

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -83,7 +83,7 @@ import com.school_of_company.model.model.expo.ExpoRequestAndResponseModel
 import com.school_of_company.model.model.standard.StandardRequestModel
 import com.school_of_company.model.model.training.TrainingDtoModel
 import com.school_of_company.ui.toast.makeToast
-import java.util.Locale.Category
+import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
 
 @Composable
 internal fun ExpoModifyRoute(
@@ -479,6 +479,7 @@ private fun ExpoModifyScreen(
                         textState = startedDateState,
                         placeholder = "시작일",
                         isError = false,
+                        visualTransformation = DateTimeVisualTransformation(),
                         updateTextValue = onStartedDateChange,
                         modifier = Modifier.weight(1f)
                     )
@@ -487,6 +488,7 @@ private fun ExpoModifyScreen(
                         textState = endedDateState,
                         placeholder = "마감일",
                         isError = false,
+                        visualTransformation = DateTimeVisualTransformation(),
                         updateTextValue = onEndedDateChange,
                         modifier = Modifier.weight(1f)
                     )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoNoneLineTextField.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoNoneLineTextField.kt
@@ -4,18 +4,15 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -29,6 +26,7 @@ internal fun ExpoNoneLineTextField(
     textState: String,
     placeHolder: @Composable () -> Unit,
     singleLine: Boolean = false,
+    lengthLimit: Int = 0,
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
     minLines: Int = 1,
     visualTransformation: VisualTransformation = VisualTransformation.None,
@@ -51,7 +49,11 @@ internal fun ExpoNoneLineTextField(
                         shape = RoundedCornerShape(size = 8.dp)
                     ),
                 value = textState,
-                onValueChange = { newText -> onTextChange(newText) },
+                onValueChange = { newText ->
+                    if (lengthLimit == 0 || newText.length <= lengthLimit) {
+                        onTextChange(newText)
+                    }
+                },
                 cursorBrush = SolidColor(colors.main),
                 singleLine = singleLine,
                 minLines = minLines,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
@@ -129,9 +129,11 @@ internal fun ExpoSettingBottomSheet(
                                     maxLines = 1
                                 )
                             },
-                            onTextChange = { newText ->
-                                currentItem = currentItem.copy(startedAt = newText)
-                            }
+                            onTextChange = { value ->
+                                if (currentItem.endedAt.length <= 12) {
+                                    currentItem = currentItem.copy(startedAt = value)
+                                }
+                            },
                         )
 
                         ExpoNoneLineTextField(
@@ -145,9 +147,11 @@ internal fun ExpoSettingBottomSheet(
                                     maxLines = 1
                                 )
                             },
-                            onTextChange = { newText ->
-                                currentItem = currentItem.copy(endedAt = newText)
-                            }
+                            onTextChange = { value ->
+                                if (currentItem.endedAt.length <= 12) {
+                                    currentItem = currentItem.copy(endedAt = value)
+                                }
+                            },
                         )
                     }
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.component.button.ExpoStateButton
@@ -46,6 +47,7 @@ import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.design_system.theme.color.ExpoColor
 import com.school_of_company.expo.enum.TrainingCategory
 import com.school_of_company.model.model.training.TrainingDtoModel
+import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -118,6 +120,7 @@ internal fun ExpoSettingBottomSheet(
                     ) {
                         ExpoNoneLineTextField(
                             textState = currentItem.startedAt,
+                            visualTransformation = DateTimeVisualTransformation(),
                             placeHolder = {
                                 Text(
                                     text = "yyyy-MM-dd HH:mm",
@@ -133,6 +136,7 @@ internal fun ExpoSettingBottomSheet(
 
                         ExpoNoneLineTextField(
                             textState = currentItem.endedAt,
+                            visualTransformation = DateTimeVisualTransformation(),
                             placeHolder = {
                                 Text(
                                     text = "yyyy-MM-dd HH:mm",

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
@@ -129,11 +129,9 @@ internal fun ExpoSettingBottomSheet(
                                     maxLines = 1
                                 )
                             },
-                            onTextChange = { value ->
-                                if (currentItem.endedAt.length <= 12) {
-                                    currentItem = currentItem.copy(startedAt = value)
-                                }
-                            },
+                            onTextChange = { newText ->
+                                currentItem = currentItem.copy(startedAt = newText)
+                            }
                         )
 
                         ExpoNoneLineTextField(
@@ -147,11 +145,9 @@ internal fun ExpoSettingBottomSheet(
                                     maxLines = 1
                                 )
                             },
-                            onTextChange = { value ->
-                                if (currentItem.endedAt.length <= 12) {
-                                    currentItem = currentItem.copy(endedAt = value)
-                                }
-                            },
+                            onTextChange = { newText ->
+                                currentItem = currentItem.copy(endedAt = newText)
+                            }
                         )
                     }
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
@@ -120,6 +120,7 @@ internal fun ExpoSettingBottomSheet(
                     ) {
                         ExpoNoneLineTextField(
                             textState = currentItem.startedAt,
+                            lengthLimit = 12,
                             visualTransformation = DateTimeVisualTransformation(),
                             placeHolder = {
                                 Text(
@@ -136,6 +137,7 @@ internal fun ExpoSettingBottomSheet(
 
                         ExpoNoneLineTextField(
                             textState = currentItem.endedAt,
+                            lengthLimit = 12,
                             visualTransformation = DateTimeVisualTransformation(),
                             placeHolder = {
                                 Text(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
@@ -107,11 +107,9 @@ internal fun ExpoStandardSettingBottomSheet(
                                 maxLines = 1
                             )
                         },
-                        onTextChange = { value ->
-                            if (currentItem.endedAt.length <= 12) {
-                                currentItem = currentItem.copy(startedAt = value)
-                            }
-                        },
+                        onTextChange = { newText ->
+                            currentItem = currentItem.copy(startedAt = newText)
+                        }
                     )
 
                     ExpoNoneLineTextField(
@@ -125,11 +123,9 @@ internal fun ExpoStandardSettingBottomSheet(
                                 maxLines = 1
                             )
                         },
-                        onTextChange = { value ->
-                            if (currentItem.endedAt.length <= 12) {
-                                currentItem = currentItem.copy(endedAt = value)
-                            }
-                        },
+                        onTextChange = { newText ->
+                            currentItem = currentItem.copy(endedAt = newText)
+                        }
                     )
 
                 ExpoStateButton(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
@@ -98,6 +98,7 @@ internal fun ExpoStandardSettingBottomSheet(
                 }
                     ExpoNoneLineTextField(
                         textState = currentItem.startedAt,
+                        lengthLimit = 12,
                         visualTransformation = DateTimeVisualTransformation(),
                         placeHolder = {
                             Text(
@@ -114,6 +115,7 @@ internal fun ExpoStandardSettingBottomSheet(
 
                     ExpoNoneLineTextField(
                         textState = currentItem.endedAt,
+                        lengthLimit = 12,
                         visualTransformation = DateTimeVisualTransformation(),
                         placeHolder = {
                             Text(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
@@ -32,6 +32,7 @@ import com.school_of_company.design_system.component.modifier.clickable.expoClic
 import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.model.standard.StandardRequestModel
+import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -97,6 +98,7 @@ internal fun ExpoStandardSettingBottomSheet(
                 }
                     ExpoNoneLineTextField(
                         textState = currentItem.startedAt,
+                        visualTransformation = DateTimeVisualTransformation(),
                         placeHolder = {
                             Text(
                                 text = "yyyy-MM-dd HH:mm",
@@ -112,6 +114,7 @@ internal fun ExpoStandardSettingBottomSheet(
 
                     ExpoNoneLineTextField(
                         textState = currentItem.endedAt,
+                        visualTransformation = DateTimeVisualTransformation(),
                         placeHolder = {
                             Text(
                                 text = "yyyy-MM-dd HH:mm",

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
@@ -107,9 +107,11 @@ internal fun ExpoStandardSettingBottomSheet(
                                 maxLines = 1
                             )
                         },
-                        onTextChange = { newText ->
-                            currentItem = currentItem.copy(startedAt = newText)
-                        }
+                        onTextChange = { value ->
+                            if (currentItem.endedAt.length <= 12) {
+                                currentItem = currentItem.copy(startedAt = value)
+                            }
+                        },
                     )
 
                     ExpoNoneLineTextField(
@@ -123,9 +125,11 @@ internal fun ExpoStandardSettingBottomSheet(
                                 maxLines = 1
                             )
                         },
-                        onTextChange = { newText ->
-                            currentItem = currentItem.copy(endedAt = newText)
-                        }
+                        onTextChange = { value ->
+                            if (currentItem.endedAt.length <= 12) {
+                                currentItem = currentItem.copy(endedAt = value)
+                            }
+                        },
                     )
 
                 ExpoStateButton(

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -36,6 +36,7 @@ import com.school_of_company.expo.viewmodel.uistate.RegisterTrainingProgramListU
 import com.school_of_company.model.model.expo.ExpoRequestAndResponseModel
 import com.school_of_company.model.model.standard.StandardRequestModel
 import com.school_of_company.model.model.training.TrainingDtoModel
+import com.school_of_company.ui.util.autoFormatToDateTime
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -173,7 +174,12 @@ internal class ExpoViewModel @Inject constructor(
     internal fun registerExpoInformation(body: ExpoRequestAndResponseModel) =
         viewModelScope.launch {
             _registerExpoInformationUiState.value = RegisterExpoInformationUiState.Loading
-            registerExpoInformationUseCase(body = body)
+            registerExpoInformationUseCase(
+                body = body.copy(
+                    startedDay = body.startedDay.autoFormatToDateTime(),
+                    finishedDay = body.finishedDay.autoFormatToDateTime(),
+                ),
+            )
                 .asResult()
                 .collectLatest { result ->
                     when (result) {
@@ -302,7 +308,12 @@ internal class ExpoViewModel @Inject constructor(
         _registerTrainingProgramListUiState.value = RegisterTrainingProgramListUiState.Loading
         registerTrainingProgramListUseCase(
             expoId = expoId,
-            body = body
+            body = body.map { list ->
+                list.copy(
+                    startedAt = list.startedAt.autoFormatToDateTime(),
+                    endedAt = list.endedAt.autoFormatToDateTime(),
+                )
+            }
         )
             .onSuccess {
                 it.catch { remoteError ->
@@ -365,7 +376,12 @@ internal class ExpoViewModel @Inject constructor(
         _registerStandardProgramListUiState.value = RegisterStandardProgramListUiState.Loading
         registerStandardProgramListUseCase(
             expoId = expoId,
-            body = body
+            body = body.map { list ->
+                list.copy(
+                    startedAt = list.startedAt.autoFormatToDateTime(),
+                    endedAt = list.endedAt.autoFormatToDateTime(),
+                )
+            }
         )
             .onSuccess {
                 it.catch { remoteError ->

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -203,7 +203,10 @@ internal class ExpoViewModel @Inject constructor(
         _modifyExpoInformationUiState.value = ModifyExpoInformationUiState.Loading
         modifyExpoInformationUseCase(
             expoId = expoId,
-            body = body
+            body = body.copy(
+                startedDay = body.startedDay.autoFormatToDateTime(),
+                finishedDay = body.finishedDay.autoFormatToDateTime(),
+            )
         )
             .onSuccess {
                 it.catch { remoteError ->
@@ -334,7 +337,10 @@ internal class ExpoViewModel @Inject constructor(
         _modifyTrainingProgramUiState.value = ModifyTrainingProgramUiState.Loading
         modifyTrainingProgramUseCase(
             trainingProId = trainingProId,
-            body = body
+            body = body.copy(
+                startedAt = body.startedAt.autoFormatToDateTime(),
+                endedAt = body.endedAt.autoFormatToDateTime(),
+            )
         )
             .onSuccess {
                 it.catch { remoteError ->
@@ -355,7 +361,10 @@ internal class ExpoViewModel @Inject constructor(
         _modifyStandardProgramUiState.value = ModifyStandardProgramUiState.Loading
         modifyStandardProgramUseCase(
             standardProId = standardProId,
-            body = body
+            body = body.copy(
+                startedAt = body.startedAt.autoFormatToDateTime(),
+                endedAt = body.endedAt.autoFormatToDateTime(),
+            )
         )
             .onSuccess {
                 it.catch { remoteError ->


### PR DESCRIPTION
## 💡 개요  
`autoFormatToDateTime` 및 `DateTimeVisualTransformation` 관련 로직을 추가하고 이를 텍스트 필드에 적용하여 날짜/시간 입력 형식과 길이 제한을 구현했습니다.

## 📃 작업내용  
- `autoFormatToDateTime` 테스트 코드 작성 및 로직 검증.  
- `DateTimeVisualTransformation` 클래스 구현: 날짜/시간 형식 자동 변환 및 OffsetMapping 주석 추가.  
- `LimitedLengthTextField`에 `DateTimeVisualTransformation` 및 길이 제한 추가.  
- `expo` 생성/수정 API에 `autoFormatToDateTime` 적용.  
- `expo` 관련 `BottomSheet` 텍스트 필드에 `DateTimeVisualTransformation` 추가.  
- `LimitedLengthTextField`에 입력 길이 카운터(`showLengthCounter`) 추가.  
- `DateTimeVisualTransformation`이 적용된 텍스트 필드에서 길이 제한(`lengthLimit`) 처리 로직 구현.

https://github.com/user-attachments/assets/f45410bc-fed1-45e2-8c0c-fcc23d909e82

## 🔀 변경사항  

- `autoFormatToDateTime` 로직 및 테스트 코드.  
- `DateTimeVisualTransformation` 클래스 및 관련 주석.  
- 텍스트 필드에서 시각적 변환(`visualTransformation`) 처리 방식 개선.  
- API와 UI 상호작용 시 날짜/시간 형식 일관성 유지.  
- `LimitedLengthTextField`에 길이 제한과 카운터 기능 추가.

## 🙋‍♂️ 질문사항  
- 현재 `DateTimeVisualTransformation`과 `autoFormatToDateTime`의 테스트 케이스가 충분히 커버된다고 생각하나요?  
- 길이 제한과 변환 로직이 결합된 구조가 적합한지, 혹은 분리하는 것이 더 나을지 의견 부탁드립니다.  
- 추가적으로 개선할 점이나 코드 가독성 관련 피드백이 있다면 알려주세요.  

## 🍴 사용방법  
1. `LimitedLengthTextField`에 `visualTransformation`으로 `DateTimeVisualTransformation`을 설정하면 자동으로 날짜/시간 형식으로 변환됩니다.  
2. `lengthLimit` 속성을 사용해 입력 길이 제한을 설정할 수 있습니다.  
3. 생성 및 수정 API에 전달되는 `startedAt`과 `endedAt`은 자동으로 날짜/시간 형식으로 변환됩니다.  

## 🎸 기타  
- viewModel에 있는 실제 데이터는 숫자지만 textField를 통해 보이는 텍스트는 yyyy-MM-dd HH:MM 형식으로 바뀝니다.
- 통신시에 viewModel에서 usecase로 값을 전달할때는 autoFormatToDateTime를 이용하여 api  요구 형식에 맞춥니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
  - 날짜 입력 필드에 대한 자동 서식 및 시각적 변환 기능 추가
  - 텍스트 필드의 길이 제한 및 길이 카운터 표시 옵션 개선

- **개선 사항**
  - 날짜 입력 시 자동 포맷팅 지원
  - 텍스트 필드 입력 제한 및 포맷팅 기능 강화

- **버그 수정**
  - 날짜 입력 시 일관된 형식 유지를 위한 시각적 변환 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->