### PR TITLE
🔀 :: (#307) - login keyboard overlapping login button imepadding not working

### DIFF
--- a/feature/signin/src/main/java/com/school_of_company/view/SignInScreen.kt
+++ b/feature/signin/src/main/java/com/school_of_company/view/SignInScreen.kt
@@ -158,40 +158,39 @@ private fun SignInScreen(
     ExpoAndroidTheme { colors, typography ->
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.SpaceBetween,
             modifier = Modifier
                 .fillMaxSize()
+                .background(color = colors.white)
+                .padding(horizontal = 16.dp)
                 .imePadding()
                 .verticalScroll(scrollState)
-                .background(color = colors.white)
                 .pointerInput(Unit) {
                     detectTapGestures {
                         focusManager.clearFocus()
                     }
                 }
         ) {
-            Spacer(modifier = modifier.padding(top = 150.dp))
-
-            Text(
-                text = stringResource(id = R.string.main_string),
-                style = typography.mainTypo,
-                color = colors.main
-            )
-
-            Text(
-                text = stringResource(id = R.string.admin_sign_in),
-                style = typography.titleBold2,
-                color = colors.black,
-                fontWeight = FontWeight.Medium
-            )
-
-            Spacer(modifier = modifier.padding(40.dp))
-
             Column(
-                modifier = modifier
-                    .padding(horizontal = 16.dp)
-                    .weight(1f),
+                modifier = modifier,
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
+                Spacer(modifier = modifier.padding(top = 150.dp))
+
+                Text(
+                    text = stringResource(id = R.string.main_string),
+                    style = typography.mainTypo,
+                    color = colors.main
+                )
+
+                Text(
+                    text = stringResource(id = R.string.admin_sign_in),
+                    style = typography.titleBold2,
+                    color = colors.black,
+                    fontWeight = FontWeight.Medium
+                )
+
+                Spacer(modifier = modifier.padding(40.dp))
                 ExpoDefaultTextField(
                     modifier = modifier
                         .fillMaxWidth()

--- a/feature/signin/src/main/java/com/school_of_company/view/SignInScreen.kt
+++ b/feature/signin/src/main/java/com/school_of_company/view/SignInScreen.kt
@@ -255,18 +255,16 @@ private fun SignInScreen(
                         modifier = modifier.expoClickable { onSignUpClick() }
                     )
                 }
-
-                Spacer(modifier = modifier.weight(1f))
-
-                ExpoStateButton(
-                    text = stringResource(id = R.string.sign_in),
-                    state = if (id.isNotBlank() && password.isNotBlank()) ButtonState.Enable else ButtonState.Disable,
-                    modifier = modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 52.dp)
-                ) {
-                    signInCallBack()
-                }
+            }
+            Spacer(modifier = modifier.height(24.dp))
+            ExpoStateButton(
+                text = stringResource(id = R.string.sign_in),
+                state = if (id.isNotBlank() && password.isNotBlank()) ButtonState.Enable else ButtonState.Disable,
+                modifier = modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 52.dp)
+            ) {
+                signInCallBack()
             }
         }
     }


### PR DESCRIPTION
## 💡 개요
- `SignInScreen`에서 버튼의 위치와 스크롤을 처리하는 방식 개선.

## 📃 작업내용
- `.버튼의 위치를 imePadding이 적용된 column 안으로 이동`하여 버튼이 화면 하단에 잘 위치하도록 조정.
- `weight`를 제거하고 다른 수정자로 변경하여 스크롤이 가능하도록 변경.

## 🔀 변경사항
- `ExpoStateButton` 위치를 `imePadding`이 적용된 `Column` 안으로 이동.
- 스크롤을 위한 `weight` 삭제 및 `verticalScroll`과 다른 수정자 적용