### PR TITLE
🔀 :: (#331) - 등록된 박람회에서 상태가 empty, error일때 새로고침이 되지 않는 문제가 있어 이를 수정하였습니다.

### DIFF
--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -82,7 +82,7 @@
     <string name="get_created_expo_list_fail">박람회 리스트를 불러오지 못했습니다.</string>
     <string name="expo_not_selected">박람회를 선택하고 삭제버튼을 눌러주세요.</string>
     <string name="get_created_expo_list_empty">박람회 리스트가 비어있습니다.</string>
-    <string name="expo_delete_fail">박람회 삭제를 실패하였습니다.</string>"
+    <string name="expo_delete_fail">박람회 삭제를 실패하였습니다.</string>
 
     <string name="expo_image_fail">박람회 이미지가 유효하지 않습니다.</string>
 

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
     <string name="get_created_expo_list_fail">박람회 리스트를 불러오지 못했습니다.</string>
     <string name="expo_not_selected">박람회를 선택하고 삭제버튼을 눌러주세요.</string>
     <string name="get_created_expo_list_empty">박람회 리스트가 비어있습니다.</string>
+    <string name="expo_delete_fail">박람회 삭제를 실패하였습니다.</string>"
 
     <string name="expo_image_fail">박람회 이미지가 유효하지 않습니다.</string>
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
 import com.google.accompanist.swiperefresh.SwipeRefreshState
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.school_of_company.design_system.R
@@ -112,42 +114,51 @@ private fun ExpoCreatedScreen(
                 modifier = Modifier.fillMaxWidth()
             ) {
                 ExpoCreatedTable(modifier = Modifier.fillMaxWidth())
-                when (getExpoListUiState) {
-                    is GetExpoListUiState.Loading -> Unit
-                    is GetExpoListUiState.Success -> {
-                        CreatedExpoList(
-                            scrollState = scrollState,
-                            expoList = getExpoListUiState.data.toPersistentList(),
-                            onItemClick = { isSelected, index ->
-                                setSelectedIndex(if (isSelected) -1 else index)
-                            },
-                            selectedIndex = selectedIndex,
-                            swipeRefreshState = swipeRefreshState,
-                            onRefresh = initCreatedExpoList
+                SwipeRefresh(
+                    state = swipeRefreshState,
+                    onRefresh = { initCreatedExpoList() },// 새로고침 시 호출되는 함수
+                    indicator = { state, refreshTrigger ->
+                        SwipeRefreshIndicator(
+                            state = state,
+                            refreshTriggerDistance = refreshTrigger,
+                            contentColor = colors.main
                         )
                     }
+                ) {
+                    when (getExpoListUiState) {
+                        is GetExpoListUiState.Loading -> Unit
+                        is GetExpoListUiState.Success -> {
+                            CreatedExpoList(
+                                scrollState = scrollState,
+                                expoList = getExpoListUiState.data.toPersistentList(),
+                                onItemClick = { isSelected, index ->
+                                    setSelectedIndex(if (isSelected) -1 else index)
+                                },
+                                selectedIndex = selectedIndex,
+                            )
+                            Spacer(modifier = Modifier.height(32.dp))
+                            ExpoCreatedDeleteButton(
+                                enabled = selectedIndex != -1,
+                                onClick = { deleteSelectedExpo(selectedIndex) }
+                            )
+                        }
 
-                    is GetExpoListUiState.Empty -> {
-                        ShowEmptyState(
-                            scrollState = scrollState,
-                            emptyMessage = "등뢱된 박람회가 없습니다.."
-                        )
-                    }
+                        is GetExpoListUiState.Empty -> {
+                            ShowEmptyState(
+                                scrollState = scrollState,
+                                emptyMessage = "등뢱된 박람회가 없습니다.."
+                            )
+                        }
 
-                    is GetExpoListUiState.Error -> {
-                        ShowErrorState(
-                            scrollState = scrollState,
-                            errorText = "등록된 박람회를 불러올 수 없습니다.."
-                        )
+                        is GetExpoListUiState.Error -> {
+                            ShowErrorState(
+                                scrollState = scrollState,
+                                errorText = "등록된 박람회를 불러올 수 없습니다.."
+                            )
+                        }
                     }
                 }
             }
-            Spacer(modifier = Modifier.height(32.dp))
-            // TODO: 데이터 로딩시에 버튼 안보이게 설정
-            ExpoCreatedDeleteButton(
-                enabled = selectedIndex != -1,
-                onClick = { deleteSelectedExpo(selectedIndex) }
-            )
         }
     }
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -57,7 +57,7 @@ internal fun ExpoCreatedRoute(
 
     LaunchedEffect(getExpoListUiState) {
         when (getExpoListUiState) {
-            GetExpoListUiState.Empty -> onErrorToast(null, R.string.get_created_expo_list_empty)
+            GetExpoListUiState.Empty -> Unit
             is GetExpoListUiState.Error -> onErrorToast(null, R.string.get_created_expo_list_fail)
             is GetExpoListUiState.Success -> setSelectedIndex(-1)
             else -> Unit

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
@@ -23,36 +23,23 @@ internal fun CreatedExpoList(
     scrollState: ScrollState,
     expoList: ImmutableList<ExpoListResponseEntity>,
     selectedIndex: Int,
-    swipeRefreshState: SwipeRefreshState, // 상위에서 전달받은 SwipeRefreshState
     onItemClick: (Boolean, Int) -> Unit,
-    onRefresh: () -> Unit, // 새로고침 콜백
 ) {
     ExpoAndroidTheme { colors, _ ->
-        SwipeRefresh(
-            state = swipeRefreshState,
-            onRefresh = onRefresh,// 새로고침 시 호출되는 함수
-            indicator = { state, refreshTrigger ->
-                SwipeRefreshIndicator(
-                    state = state,
-                    refreshTriggerDistance = refreshTrigger,
-                    contentColor = colors.main
-                )
-            }
+
+        LazyColumn(
+            modifier = modifier,
+            verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            LazyColumn(
-                modifier = modifier,
-                verticalArrangement = Arrangement.spacedBy(20.dp)
-            ) {
-                itemsIndexed(expoList) { index, item ->
-                    CreatedExpoListItem(
-                        modifier = Modifier.fillMaxWidth(),
-                        scrollState = scrollState,
-                        selectedIndex = selectedIndex,
-                        item = item,
-                        index = index,
-                        onClick = { onItemClick(selectedIndex == index, index) }
-                    )
-                }
+            itemsIndexed(expoList) { index, item ->
+                CreatedExpoListItem(
+                    modifier = Modifier.fillMaxWidth(),
+                    scrollState = scrollState,
+                    selectedIndex = selectedIndex,
+                    item = item,
+                    index = index,
+                    onClick = { onItemClick(selectedIndex == index, index) }
+                )
             }
         }
     }
@@ -76,8 +63,6 @@ fun CreatedExpoListPreview() {
         ),
         onItemClick = { _, _ -> },
         selectedIndex = 1,
-        onRefresh = { /* 새로고침 시 동작할 함수 */ },
-        swipeRefreshState = swipeRefreshState,// 상위에서 전달한 상태
         scrollState = ScrollState(1)
-        )
+    )
 }


### PR DESCRIPTION
## 💡 개요
- 등록된 박람회에서 상태가 empty, error일때 새로고침이 되지 않는 문제가 있어 이를 수정할 필요가 있었습니다.
## 📃 작업내용
- 등록된 박람회에서 상태가 empty, error일때 새로고침이 되지 않는 문제가 있어 이를 수정하였습니다.

    https://github.com/user-attachments/assets/ff2b3001-ed0d-46c6-855e-f587e695428d


## 🔀 변경사항
- chore ExpoCreatedScreen
- CreatedExpoList
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 박람회 삭제 실패 시 사용자에게 명확한 오류 메시지 추가
	- 박람회 삭제 프로세스의 상태 관리 개선
	- 스와이프 새로 고침 기능 통합

- **버그 수정**
	- 박람회 삭제 중 발생할 수 있는 오류 상황에 대한 사용자 피드백 강화

- **사용자 경험**
	- 삭제 작업의 상태를 더욱 명확하게 표시
	- 오류 발생 시 구체적인 안내 메시지 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->