### PR TITLE
🔀 :: (#341) - authInterceptor의 코드에서 토큰을 추가하지 않는 부분에 대한 로직이 잘못되어 해결하였습니다.

### DIFF
--- a/core/network/src/main/java/com/school_of_company/network/util/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/school_of_company/network/util/AuthInterceptor.kt
@@ -14,7 +14,7 @@ class AuthInterceptor @Inject constructor(
     private val authTokenDataSource: AuthTokenDataSource
 ) : Interceptor {
     // 인증 없이 접근할 수 있도록 하는 경로입니다.
-    private val ignorePath = listOf("/auth", "/sms")
+    private val ignorePath = "/auth"
 
     private companion object {
         const val POST = "POST"
@@ -37,6 +37,12 @@ class AuthInterceptor @Inject constructor(
         val newRequest = when {
             // 인증이 필요없는 경로에 대해서는 토큰을 추가하지 않습니다.
             ignorePath.any { path.contains(it) && method in listOf(POST) } -> {
+                request
+            }
+
+            // "/sms"의 경로에 대해서는 토큰을 추가하지 않습니다.
+            // "/sms/message"와 같은 경로에 대해서는 토큰을 추가할 수 있습니다.
+            path == "/sms" && method in listOf(POST, GET) -> {
                 request
             }
 


### PR DESCRIPTION
## 💡 개요
- authInterceptor의 코드에서 토큰을 추가하지 않는 부분에 대한 로직이 잘못되어 해결이 필요해보였습니다.
## 📃 작업내용
- authInterceptor의 코드에서 토큰을 추가하지 않는 부분에 대한 로직이 잘못되어 해결하였습니다.
    - "/sms"의 경로에 대해서만 토큰을 추가하지 않도록 하였습니다. (POST, GET Method)
    - "/sms/message"와 같은 경로에서는 토큰이 추가가 됩니다.
   
    - before
       <img width="301" alt="스크린샷 2025-01-16 오후 4 13 29" src="https://github.com/user-attachments/assets/631b47c8-44d1-47d4-ab5e-b42a7c3777e2" />

    - after 
       <img width="307" alt="스크린샷 2025-01-16 오후 4 13 43" src="https://github.com/user-attachments/assets/fb615db6-af14-45ad-a139-fba69997187f" />

## 🔀 변경사항
- chore authInterceptor
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x