### PR TITLE
🔀 :: (#338) - date input text field should only accept numbers

### DIFF
--- a/core/ui/src/main/java/com/school_of_company/ui/keyBoardOption/NumberKetBoard.kt
+++ b/core/ui/src/main/java/com/school_of_company/ui/keyBoardOption/NumberKetBoard.kt
@@ -3,7 +3,7 @@ package com.school_of_company.ui.keyBoardOption
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
 
-fun numericKeyboardOptions(): KeyboardOptions {
+fun numberKeyboardOptions(): KeyboardOptions {
     return KeyboardOptions.Default.copy(
         keyboardType = KeyboardType.Number
     )

--- a/core/ui/src/main/java/com/school_of_company/ui/keyBoardOption/NumberKetBoard.kt
+++ b/core/ui/src/main/java/com/school_of_company/ui/keyBoardOption/NumberKetBoard.kt
@@ -1,0 +1,10 @@
+package com.school_of_company.ui.keyBoardOption
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+
+fun numericKeyboardOptions(): KeyboardOptions {
+    return KeyboardOptions.Default.copy(
+        keyboardType = KeyboardType.Number
+    )
+}

--- a/core/ui/src/main/java/com/school_of_company/ui/util/filterNonDigits.kt
+++ b/core/ui/src/main/java/com/school_of_company/ui/util/filterNonDigits.kt
@@ -1,0 +1,3 @@
+package com.school_of_company.ui.util
+
+fun String.filterNonDigits() = this.filter { it.isDigit() }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -75,6 +75,7 @@ import com.school_of_company.expo.viewmodel.uistate.RegisterTrainingProgramListU
 import com.school_of_company.model.model.expo.ExpoRequestAndResponseModel
 import com.school_of_company.model.model.standard.StandardRequestModel
 import com.school_of_company.model.model.training.TrainingDtoModel
+import com.school_of_company.ui.keyBoardOption.numericKeyboardOptions
 import com.school_of_company.ui.toast.makeToast
 import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
 
@@ -379,6 +380,7 @@ private fun ExpoCreateScreen(
                         showLengthCounter = false,
                         placeholder = "시작일",
                         isError = false,
+                        keyboardOptions = numericKeyboardOptions(),
                         visualTransformation = DateTimeVisualTransformation(),
                         updateTextValue = onStartedDateChange,
                         modifier = Modifier.weight(1f)
@@ -390,6 +392,7 @@ private fun ExpoCreateScreen(
                         showLengthCounter = false,
                         placeholder = "마감일",
                         isError = false,
+                        keyboardOptions = numericKeyboardOptions(),
                         visualTransformation = DateTimeVisualTransformation(),
                         updateTextValue = onEndedDateChange,
                         modifier = Modifier.weight(1f)

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -77,6 +77,7 @@ import com.school_of_company.model.model.standard.StandardRequestModel
 import com.school_of_company.model.model.training.TrainingDtoModel
 import com.school_of_company.ui.keyBoardOption.numericKeyboardOptions
 import com.school_of_company.ui.toast.makeToast
+import com.school_of_company.ui.util.filterNonDigits
 import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
 
 @Composable
@@ -382,7 +383,7 @@ private fun ExpoCreateScreen(
                         isError = false,
                         keyboardOptions = numericKeyboardOptions(),
                         visualTransformation = DateTimeVisualTransformation(),
-                        updateTextValue = onStartedDateChange,
+                        updateTextValue = { newText -> onStartedDateChange(newText.filterNonDigits()) },
                         modifier = Modifier.weight(1f)
                     )
 
@@ -394,7 +395,7 @@ private fun ExpoCreateScreen(
                         isError = false,
                         keyboardOptions = numericKeyboardOptions(),
                         visualTransformation = DateTimeVisualTransformation(),
-                        updateTextValue = onEndedDateChange,
+                        updateTextValue = { newText -> onEndedDateChange(newText.filterNonDigits()) },
                         modifier = Modifier.weight(1f)
                     )
                 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -75,7 +75,7 @@ import com.school_of_company.expo.viewmodel.uistate.RegisterTrainingProgramListU
 import com.school_of_company.model.model.expo.ExpoRequestAndResponseModel
 import com.school_of_company.model.model.standard.StandardRequestModel
 import com.school_of_company.model.model.training.TrainingDtoModel
-import com.school_of_company.ui.keyBoardOption.numericKeyboardOptions
+import com.school_of_company.ui.keyBoardOption.numberKeyboardOptions
 import com.school_of_company.ui.toast.makeToast
 import com.school_of_company.ui.util.filterNonDigits
 import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
@@ -381,7 +381,7 @@ private fun ExpoCreateScreen(
                         showLengthCounter = false,
                         placeholder = "시작일",
                         isError = false,
-                        keyboardOptions = numericKeyboardOptions(),
+                        keyboardOptions = numberKeyboardOptions(),
                         visualTransformation = DateTimeVisualTransformation(),
                         updateTextValue = { newText -> onStartedDateChange(newText.filterNonDigits()) },
                         modifier = Modifier.weight(1f)
@@ -393,7 +393,7 @@ private fun ExpoCreateScreen(
                         showLengthCounter = false,
                         placeholder = "마감일",
                         isError = false,
-                        keyboardOptions = numericKeyboardOptions(),
+                        keyboardOptions = numberKeyboardOptions(),
                         visualTransformation = DateTimeVisualTransformation(),
                         updateTextValue = { newText -> onEndedDateChange(newText.filterNonDigits()) },
                         modifier = Modifier.weight(1f)

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -2,7 +2,6 @@ package com.school_of_company.expo.view
 
 import android.graphics.BitmapFactory
 import android.net.Uri
-import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -83,7 +82,7 @@ import com.school_of_company.expo.viewmodel.uistate.ModifyTrainingProgramUiState
 import com.school_of_company.model.model.expo.ExpoRequestAndResponseModel
 import com.school_of_company.model.model.standard.StandardRequestModel
 import com.school_of_company.model.model.training.TrainingDtoModel
-import com.school_of_company.ui.keyBoardOption.numericKeyboardOptions
+import com.school_of_company.ui.keyBoardOption.numberKeyboardOptions
 import com.school_of_company.ui.toast.makeToast
 import com.school_of_company.ui.util.filterNonDigits
 import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
@@ -485,7 +484,7 @@ private fun ExpoModifyScreen(
                         lengthLimit = 8,
                         placeholder = "시작일",
                         isError = false,
-                        keyboardOptions = numericKeyboardOptions(),
+                        keyboardOptions = numberKeyboardOptions(),
                         visualTransformation = DateTimeVisualTransformation(),
                         updateTextValue = { newText -> onStartedDateChange(newText.filterNonDigits()) },
                         modifier = Modifier.weight(1f)
@@ -496,7 +495,7 @@ private fun ExpoModifyScreen(
                         lengthLimit = 8,
                         placeholder = "마감일",
                         isError = false,
-                        keyboardOptions = numericKeyboardOptions(),
+                        keyboardOptions = numberKeyboardOptions(),
                         visualTransformation = DateTimeVisualTransformation(),
                         updateTextValue = { newText -> onEndedDateChange(newText.filterNonDigits()) },
                         modifier = Modifier.weight(1f)

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -83,6 +83,7 @@ import com.school_of_company.expo.viewmodel.uistate.ModifyTrainingProgramUiState
 import com.school_of_company.model.model.expo.ExpoRequestAndResponseModel
 import com.school_of_company.model.model.standard.StandardRequestModel
 import com.school_of_company.model.model.training.TrainingDtoModel
+import com.school_of_company.ui.keyBoardOption.numericKeyboardOptions
 import com.school_of_company.ui.toast.makeToast
 import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
 
@@ -481,6 +482,7 @@ private fun ExpoModifyScreen(
                         lengthLimit = 8,
                         placeholder = "시작일",
                         isError = false,
+                        keyboardOptions = numericKeyboardOptions(),
                         visualTransformation = DateTimeVisualTransformation(),
                         updateTextValue = onStartedDateChange,
                         modifier = Modifier.weight(1f)
@@ -491,6 +493,7 @@ private fun ExpoModifyScreen(
                         lengthLimit = 8,
                         placeholder = "마감일",
                         isError = false,
+                        keyboardOptions = numericKeyboardOptions(),
                         visualTransformation = DateTimeVisualTransformation(),
                         updateTextValue = onEndedDateChange,
                         modifier = Modifier.weight(1f)

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -85,6 +85,7 @@ import com.school_of_company.model.model.standard.StandardRequestModel
 import com.school_of_company.model.model.training.TrainingDtoModel
 import com.school_of_company.ui.keyBoardOption.numericKeyboardOptions
 import com.school_of_company.ui.toast.makeToast
+import com.school_of_company.ui.util.filterNonDigits
 import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
 
 @Composable
@@ -123,8 +124,8 @@ internal fun ExpoModifyRoute(
                 val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
                 context.contentResolver.openInputStream(uri)?.use { inputStream ->
                     BitmapFactory.decodeStream(inputStream, null, options)
-                        selectedImageUri = uri
-                        viewModel.onCoverImageChange(uri.toString())
+                    selectedImageUri = uri
+                    viewModel.onCoverImageChange(uri.toString())
                 }
             }
         }
@@ -208,9 +209,10 @@ internal fun ExpoModifyRoute(
         modifyTrainingProgramUiState,
         modifyStandardProgramUiState
     ) {
-        val allTasksSuccess = modifyExpoInformationUiState is ModifyExpoInformationUiState.Success &&
-                modifyTrainingProgramUiState is ModifyTrainingProgramUiState.Success &&
-                modifyStandardProgramUiState is ModifyStandardProgramUiState.Success
+        val allTasksSuccess =
+            modifyExpoInformationUiState is ModifyExpoInformationUiState.Success &&
+                    modifyTrainingProgramUiState is ModifyTrainingProgramUiState.Success &&
+                    modifyStandardProgramUiState is ModifyStandardProgramUiState.Success
 
         val anyTaskError = modifyExpoInformationUiState is ModifyExpoInformationUiState.Error ||
                 modifyTrainingProgramUiState is ModifyTrainingProgramUiState.Error ||
@@ -224,6 +226,7 @@ internal fun ExpoModifyRoute(
                 viewModel.initModifyExpo()
                 makeToast(context, "박람회 수정을 완료하였습니다.")
             }
+
             anyTaskError && !hasErrorBeenHandled -> {
                 hasErrorBeenHandled = true
                 onErrorToast(null, R.string.expo_modify_fail)
@@ -484,7 +487,7 @@ private fun ExpoModifyScreen(
                         isError = false,
                         keyboardOptions = numericKeyboardOptions(),
                         visualTransformation = DateTimeVisualTransformation(),
-                        updateTextValue = onStartedDateChange,
+                        updateTextValue = { newText -> onStartedDateChange(newText.filterNonDigits()) },
                         modifier = Modifier.weight(1f)
                     )
 
@@ -495,7 +498,7 @@ private fun ExpoModifyScreen(
                         isError = false,
                         keyboardOptions = numericKeyboardOptions(),
                         visualTransformation = DateTimeVisualTransformation(),
-                        updateTextValue = onEndedDateChange,
+                        updateTextValue = { newText -> onEndedDateChange(newText.filterNonDigits()) },
                         modifier = Modifier.weight(1f)
                     )
                 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
@@ -48,6 +48,7 @@ import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.design_system.theme.color.ExpoColor
 import com.school_of_company.expo.enum.TrainingCategory
 import com.school_of_company.model.model.training.TrainingDtoModel
+import com.school_of_company.ui.keyBoardOption.numericKeyboardOptions
 import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -122,6 +123,7 @@ internal fun ExpoSettingBottomSheet(
                         ExpoNoneLineTextField(
                             textState = currentItem.startedAt,
                             lengthLimit = 12,
+                            keyboardOptions = numericKeyboardOptions(),
                             visualTransformation = DateTimeVisualTransformation(),
                             placeHolder = {
                                 Text(
@@ -139,6 +141,7 @@ internal fun ExpoSettingBottomSheet(
                         ExpoNoneLineTextField(
                             textState = currentItem.endedAt,
                             lengthLimit = 12,
+                            keyboardOptions = numericKeyboardOptions(),
                             visualTransformation = DateTimeVisualTransformation(),
                             placeHolder = {
                                 Text(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
@@ -49,6 +49,7 @@ import com.school_of_company.design_system.theme.color.ExpoColor
 import com.school_of_company.expo.enum.TrainingCategory
 import com.school_of_company.model.model.training.TrainingDtoModel
 import com.school_of_company.ui.keyBoardOption.numericKeyboardOptions
+import com.school_of_company.ui.util.filterNonDigits
 import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -134,7 +135,7 @@ internal fun ExpoSettingBottomSheet(
                                 )
                             },
                             onTextChange = { newText ->
-                                currentItem = currentItem.copy(startedAt = newText)
+                                currentItem = currentItem.copy(startedAt = newText.filterNonDigits())
                             }
                         )
 
@@ -152,7 +153,7 @@ internal fun ExpoSettingBottomSheet(
                                 )
                             },
                             onTextChange = { newText ->
-                                currentItem = currentItem.copy(endedAt = newText)
+                                currentItem = currentItem.copy(endedAt = newText.filterNonDigits())
                             }
                         )
                     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.common.regex.isValidDateTime
@@ -48,7 +47,7 @@ import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.design_system.theme.color.ExpoColor
 import com.school_of_company.expo.enum.TrainingCategory
 import com.school_of_company.model.model.training.TrainingDtoModel
-import com.school_of_company.ui.keyBoardOption.numericKeyboardOptions
+import com.school_of_company.ui.keyBoardOption.numberKeyboardOptions
 import com.school_of_company.ui.util.filterNonDigits
 import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
 
@@ -124,7 +123,7 @@ internal fun ExpoSettingBottomSheet(
                         ExpoNoneLineTextField(
                             textState = currentItem.startedAt,
                             lengthLimit = 12,
-                            keyboardOptions = numericKeyboardOptions(),
+                            keyboardOptions = numberKeyboardOptions(),
                             visualTransformation = DateTimeVisualTransformation(),
                             placeHolder = {
                                 Text(
@@ -142,7 +141,7 @@ internal fun ExpoSettingBottomSheet(
                         ExpoNoneLineTextField(
                             textState = currentItem.endedAt,
                             lengthLimit = 12,
-                            keyboardOptions = numericKeyboardOptions(),
+                            keyboardOptions = numberKeyboardOptions(),
                             visualTransformation = DateTimeVisualTransformation(),
                             placeHolder = {
                                 Text(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
@@ -33,6 +33,7 @@ import com.school_of_company.design_system.component.modifier.clickable.expoClic
 import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.model.standard.StandardRequestModel
+import com.school_of_company.ui.keyBoardOption.numericKeyboardOptions
 import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -100,6 +101,7 @@ internal fun ExpoStandardSettingBottomSheet(
                 ExpoNoneLineTextField(
                     textState = currentItem.startedAt,
                     lengthLimit = 12,
+                    keyboardOptions = numericKeyboardOptions(),
                     visualTransformation = DateTimeVisualTransformation(),
                     placeHolder = {
                         Text(
@@ -117,6 +119,7 @@ internal fun ExpoStandardSettingBottomSheet(
                 ExpoNoneLineTextField(
                     textState = currentItem.endedAt,
                     lengthLimit = 12,
+                    keyboardOptions = numericKeyboardOptions(),
                     visualTransformation = DateTimeVisualTransformation(),
                     placeHolder = {
                         Text(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
@@ -5,11 +5,9 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
@@ -33,7 +31,7 @@ import com.school_of_company.design_system.component.modifier.clickable.expoClic
 import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.model.standard.StandardRequestModel
-import com.school_of_company.ui.keyBoardOption.numericKeyboardOptions
+import com.school_of_company.ui.keyBoardOption.numberKeyboardOptions
 import com.school_of_company.ui.util.filterNonDigits
 import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
 
@@ -102,7 +100,7 @@ internal fun ExpoStandardSettingBottomSheet(
                 ExpoNoneLineTextField(
                     textState = currentItem.startedAt,
                     lengthLimit = 12,
-                    keyboardOptions = numericKeyboardOptions(),
+                    keyboardOptions = numberKeyboardOptions(),
                     visualTransformation = DateTimeVisualTransformation(),
                     placeHolder = {
                         Text(
@@ -120,7 +118,7 @@ internal fun ExpoStandardSettingBottomSheet(
                 ExpoNoneLineTextField(
                     textState = currentItem.endedAt,
                     lengthLimit = 12,
-                    keyboardOptions = numericKeyboardOptions(),
+                    keyboardOptions = numberKeyboardOptions(),
                     visualTransformation = DateTimeVisualTransformation(),
                     placeHolder = {
                         Text(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
@@ -34,6 +34,7 @@ import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.model.standard.StandardRequestModel
 import com.school_of_company.ui.keyBoardOption.numericKeyboardOptions
+import com.school_of_company.ui.util.filterNonDigits
 import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -112,7 +113,7 @@ internal fun ExpoStandardSettingBottomSheet(
                         )
                     },
                     onTextChange = { newText ->
-                        currentItem = currentItem.copy(startedAt = newText)
+                        currentItem = currentItem.copy(startedAt = newText.filterNonDigits())
                     }
                 )
 
@@ -130,7 +131,7 @@ internal fun ExpoStandardSettingBottomSheet(
                         )
                     },
                     onTextChange = { newText ->
-                        currentItem = currentItem.copy(endedAt = newText)
+                        currentItem = currentItem.copy(endedAt = newText.filterNonDigits())
                     }
                 )
 


### PR DESCRIPTION
### 💡 개요  
사용자가 숫자 입력과 관련된 기능을 추가하여 더 나은 UX를 제공했습니다

### 📃 작업내용  
- numericKeyboardOptions 함수 추가
   - 숫자 타입의 `KeyboardOptions`를 반환하는 함수로, 입력 필드에서 숫자 전용 키보드를 사용할 수 있도록 구현했습니다.  
- 각 화면에서 `KeyboardOptions`로 사용하도록 적용했습니다.  
- 입력된 문자열에서 숫자 이외의 문자를 필터링하여 숫자만 반환하는 유틸리티 함수입니다.  
- 숫자 필터링이 필요한 입력 필드에 filterNonDigits 로직을 적용했습니다.  

https://github.com/user-attachments/assets/f4ebd364-4286-4842-837b-2dbc681b5c80

### 🔀 변경사항  
- 새로운 유틸리티 함수와 키보드 옵션 추가에 따라 관련 UI 및 입력 처리 로직이 업데이트되었습니다.  

### 🎸 기타  
- 개선할 점이나 추가해야 할 기능이 있다면 의견 부탁드립니다!  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
	- 날짜 입력 필드에 숫자 키보드 옵션 추가
	- 입력 데이터의 숫자 문자만 필터링하는 기능 구현

- **개선 사항**
	- 날짜 및 시간 입력의 데이터 무결성 향상
	- 사용자 입력 경험 개선을 위한 키보드 옵션 최적화

- **기술적 변경**
	- 숫자 키보드 옵션 및 문자 필터링을 위한 유틸리티 함수 도입
<!-- end of auto-generated comment: release notes by coderabbit.ai -->