### PR TITLE
🔀 :: (#346) - AuthInterceptor의 코드에서 토큰을 넣어주어야하는 경로에 토큰이 들어가지 않는 문제가 있어 이를 해결하였습니다.

### DIFF
--- a/core/network/src/main/java/com/school_of_company/network/util/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/school_of_company/network/util/AuthInterceptor.kt
@@ -1,6 +1,5 @@
 package com.school_of_company.network.util
 
-import android.util.Log
 import com.school_of_company.datastore.datasource.AuthTokenDataSource
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking

--- a/core/network/src/main/java/com/school_of_company/network/util/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/school_of_company/network/util/AuthInterceptor.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.network.util
 
+import android.util.Log
 import com.school_of_company.datastore.datasource.AuthTokenDataSource
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
@@ -36,7 +37,7 @@ class AuthInterceptor @Inject constructor(
         // 새로운 요청을 생성하고, 특정 조건에 따라 헤더에 토큰을 추가합니다.
         val newRequest = when {
             // 인증이 필요없는 경로에 대해서는 토큰을 추가하지 않습니다.
-            ignorePath.any { path.contains(it) && method in listOf(POST) } -> {
+            path.contains(ignorePath) && method in listOf(POST) -> {
                 request
             }
 
@@ -46,8 +47,8 @@ class AuthInterceptor @Inject constructor(
                 request
             }
 
-            // 특정 경로와 DELETE 메서드 요청에는 리프레시 토큰을 추가합니다.
-            path.endsWith("/auth") && method in listOf(DELETE, PATCH) -> {
+            // 특정 경로와 PATCH 메서드 요청에는 리프레시 토큰을 추가합니다.
+            path.endsWith("/auth") && method in listOf(PATCH) -> {
                 request.newBuilder().addHeader("Authorization", "Bearer $refreshToken" ).build()
             }
 


### PR DESCRIPTION
## 💡 개요
- AuthInterceptor의 코드에서 토큰을 넣어주어야하는 경로에 토큰이 들어가지 않는 문제가 있었습니다.
## 📃 작업내용
- AuthInterceptor의 코드에서 토큰을 넣어주어야하는 경로에 토큰이 들어가지 않는 문제가 있어 이를 해결하였습니다.
   - ignorePath가 단일 경로이기때문에 굳이 Any를 사용해줄 필요가 없어 해당 코드를 삭제하였습니다.
## 🔀 변경사항
- chore AuthInterceptor
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
	- 인증 토큰 처리 로직 개선
	- 특정 경로 및 HTTP 메서드에 대한 토큰 추가 조건 최적화
	- 리프레시 토큰 추가 조건 세분화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->