### PR TITLE
🔀 :: (#333) - 박람회 참가자 조회하기 디자인 변경 사항 수정 및 기능 구현을 하였습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -87,7 +87,9 @@ fun ExpoNavHost(
         expoDetailScreen(
             onBackClick = navController::popBackStack,
             onMessageClick = navController::navigateToSmsSendMessage,
-            onCheckClick = navController::navigateToProgramDetailParticipantManagement,
+            onCheckClick = { id ->
+                navController.navigateToProgramDetailParticipantManagement(id)
+            },
             onModifyClick = { id ->
                 navController.navigateToExpoModify(id)
             },

--- a/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
@@ -63,11 +63,15 @@ fun LeftArrowIcon(
 }
 
 @Composable
-fun UpArrowIcon(modifier: Modifier = Modifier) {
+fun UpArrowIcon(
+    modifier: Modifier = Modifier,
+    tint: Color = Color.Unspecified
+) {
     Icon(
         painter = painterResource(id = R.drawable.ic_up_arrow),
         contentDescription = stringResource(id = R.string.up_arrow_description),
-        modifier = modifier
+        modifier = modifier,
+        tint = tint
     )
 }
 

--- a/core/network/src/main/java/com/school_of_company/network/api/ParticipantAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/ParticipantAPI.kt
@@ -9,7 +9,7 @@ interface ParticipantAPI {
 
     @GET("/participant/{expo_id}")
     suspend fun getParticipantInformationList(
+        @Path("expo_id") expoId: String,
         @Query("type") type: String,
-        @Path("expo_id") expoId: String
-    ) : List<ParticipantInformationResponse>
+    ): List<ParticipantInformationResponse>
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
@@ -61,7 +61,7 @@ fun NavGraphBuilder.expoScreen(
 fun NavGraphBuilder.expoDetailScreen(
     onBackClick: () -> Unit,
     onMessageClick: () -> Unit,
-    onCheckClick: () -> Unit,
+    onCheckClick: (String) -> Unit,
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit
 ) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -56,7 +56,7 @@ internal fun ExpoDetailRoute(
     id: String,
     onBackClick: () -> Unit,
     onMessageClick: () -> Unit,
-    onCheckClick: () -> Unit,
+    onCheckClick: (String) -> Unit,
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit,
     viewModel: ExpoViewModel = hiltViewModel()
@@ -94,7 +94,7 @@ private fun ExpoDetailScreen(
     getStandardProgramUiState: GetStandardProgramListUiState,
     onBackClick: () -> Unit,
     onMessageClick: () -> Unit,
-    onCheckClick: () -> Unit,
+    onCheckClick: (String) -> Unit,
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit
 ) {
@@ -311,7 +311,7 @@ private fun ExpoDetailScreen(
                                 ExpoButton(
                                     text = "조회하기",
                                     color = colors.main,
-                                    onClick = onCheckClick,
+                                    onClick = { onCheckClick(id) },
                                     modifier = Modifier
                                         .weight(1f)
                                         .padding(

--- a/feature/program/src/main/java/com/school_of_company/program/navigation/ProgramNavigation.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/navigation/ProgramNavigation.kt
@@ -22,8 +22,14 @@ fun NavController.navigateToProgramDetailProgram(
     )
 }
 
-fun NavController.navigateToProgramDetailParticipantManagement(navOptions: NavOptions? = null) {
-    this.navigate(programDetailParticipantManagementRoute, navOptions)
+fun NavController.navigateToProgramDetailParticipantManagement(
+    id: String,
+    navOptions: NavOptions? = null
+) {
+    this.navigate(
+        route = "$programDetailParticipantManagementRoute/${id}",
+        navOptions
+    )
 }
 
 fun NavController.navigateQrScanner(
@@ -53,11 +59,11 @@ fun NavGraphBuilder.programDetailProgramScreen(
     }
 }
 
-fun NavGraphBuilder.programDetailParticipantManagementScreen(
-    onBackClick: () -> Unit
-) {
-    composable(route = programDetailParticipantManagementRoute) {
+fun NavGraphBuilder.programDetailParticipantManagementScreen(onBackClick: () -> Unit) {
+    composable(route = "$programDetailParticipantManagementRoute/{id}") { backStackEntry ->
+        val id = backStackEntry.arguments?.getString("id") ?: ""
         ProgramDetailParticipantManagementRoute(
+            id = id,
             onBackClick = onBackClick
         )
     }

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -147,12 +147,12 @@ private fun ProgramDetailParticipantManagementScreen(
                 )
 
                 if (isDropdownExpanded) {
-                    DownArrowIcon(
+                    UpArrowIcon(
                         tint = colors.black,
                         modifier = Modifier.padding(start = 10.dp)
                     )
                 } else {
-                    UpArrowIcon(
+                    DownArrowIcon(
                         tint = colors.black,
                         modifier = Modifier.padding(start = 10.dp)
                     )

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -1,15 +1,13 @@
 package com.school_of_company.program.view
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -17,6 +15,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,51 +32,82 @@ import com.google.accompanist.swiperefresh.SwipeRefreshState
 import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
+import com.school_of_company.design_system.component.uistate.empty.ShowEmptyState
+import com.school_of_company.design_system.component.uistate.error.ShowErrorState
 import com.school_of_company.design_system.icon.DownArrowIcon
 import com.school_of_company.design_system.icon.LeftArrowIcon
+import com.school_of_company.design_system.icon.UpArrowIcon
 import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
-import com.school_of_company.program.view.component.HomeDetailParticipantManagementData
+import com.school_of_company.program.enum.ParticipantEnum
 import com.school_of_company.program.view.component.ProgramDetailParticipantDropdownMenu
+import com.school_of_company.program.view.component.ProgramDetailParticipantManagementList
+import com.school_of_company.program.view.component.ProgramDetailParticipantTable
+import com.school_of_company.program.view.component.ProgramTraineeList
+import com.school_of_company.program.view.component.ProgramTraineeTable
 import com.school_of_company.program.viewmodel.ProgramViewModel
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toPersistentList
-
-internal fun generateParticipantManagementSampleData(): ImmutableList<HomeDetailParticipantManagementData> {
-    return List(20) {
-        HomeDetailParticipantManagementData(
-            name = "이명훈",
-            company = "초등학교",
-            position = "교사",
-            schoolSubject = "컴퓨터공학",
-            checkHere = true,
-            inTime = "12:00",
-            outTime = "13:00"
-        )
-    }.toPersistentList()
-}
+import com.school_of_company.program.viewmodel.uistate.ParticipantResponseListUiState
+import com.school_of_company.program.viewmodel.uistate.TraineeResponseListUiState
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 internal fun ProgramDetailParticipantManagementRoute(
+    id: String,
     onBackClick: () -> Unit,
     viewModel: ProgramViewModel = hiltViewModel()
 ) {
     val swipeRefreshLoading by viewModel.swipeRefreshLoading.collectAsStateWithLifecycle()
     val swipeRefreshState = rememberSwipeRefreshState(isRefreshing = swipeRefreshLoading)
 
+    val participantAheadResponseListUiState by viewModel.participantAheadResponseListUiState.collectAsStateWithLifecycle()
+    val participantFieldResponseListUiState by viewModel.participantFieldResponseListUiState.collectAsStateWithLifecycle()
+    val traineeInformationUiState by viewModel.traineeResponseListUiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(id) {
+
+        viewModel.getParticipantInformationList(
+            expoId = id,
+            type = ParticipantEnum.PRE
+        )
+
+        viewModel.getParticipantInformationList(
+            expoId = id,
+            type = ParticipantEnum.FIELD
+        )
+
+        viewModel.getTraineeList(expoId = id)
+    }
+
     ProgramDetailParticipantManagementScreen(
         onBackClick = onBackClick,
-        participantManagementData = generateParticipantManagementSampleData(),
-        swipeRefreshState = swipeRefreshState
+        swipeRefreshState = swipeRefreshState,
+        participantAheadResponseListUiState = participantAheadResponseListUiState,
+        participantFieldResponseListUiState = participantFieldResponseListUiState,
+        traineeInformationUiState = traineeInformationUiState,
+        getAheadParticipantList = { viewModel.getParticipantInformationList(
+            expoId = id,
+            type = ParticipantEnum.PRE
+        ) },
+        getFieldParticipantList = { viewModel.getParticipantInformationList(
+            expoId = id,
+            type = ParticipantEnum.FIELD
+        ) },
+        getTraineeList = { viewModel.getTraineeList(expoId = id) }
     )
 }
 
 @Composable
 private fun ProgramDetailParticipantManagementScreen(
     modifier: Modifier = Modifier,
-    participantManagementData: ImmutableList<HomeDetailParticipantManagementData>,
     onBackClick: () -> Unit,
-    swipeRefreshState: SwipeRefreshState
+    swipeRefreshState: SwipeRefreshState,
+    scrollState: ScrollState = rememberScrollState(),
+    participantAheadResponseListUiState: ParticipantResponseListUiState,
+    participantFieldResponseListUiState: ParticipantResponseListUiState,
+    traineeInformationUiState: TraineeResponseListUiState,
+    getAheadParticipantList: () -> Unit,
+    getFieldParticipantList: () -> Unit,
+    getTraineeList: () -> Unit
 ) {
     var participantTextState by remember { mutableStateOf("사전 행사 참가자") }
     var isDropdownExpanded by remember { mutableStateOf(false) }
@@ -116,10 +146,17 @@ private fun ProgramDetailParticipantManagementScreen(
                     modifier = Modifier.padding(start = 16.dp)
                 )
 
-                DownArrowIcon(
-                    tint = colors.black,
-                    modifier = Modifier.padding(start = 10.dp)
-                )
+                if (isDropdownExpanded) {
+                    DownArrowIcon(
+                        tint = colors.black,
+                        modifier = Modifier.padding(start = 10.dp)
+                    )
+                } else {
+                    UpArrowIcon(
+                        tint = colors.black,
+                        modifier = Modifier.padding(start = 10.dp)
+                    )
+                }
             }
 
             Box(modifier = Modifier.padding(start = 16.dp, top = 10.dp)) {
@@ -163,7 +200,6 @@ private fun ProgramDetailParticipantManagementScreen(
 
                 Spacer(
                     modifier = Modifier
-                        .padding(0.dp)
                         .width(1.dp)
                         .height(14.dp)
                         .background(color = colors.gray100)
@@ -178,90 +214,118 @@ private fun ProgramDetailParticipantManagementScreen(
                         color = colors.gray500
                     )
 
-                    Text(
-                        text = "${participantManagementData.size}명",
-                        style = typography.captionRegular2,
-                        color = colors.main
-                    )
-                }
-            }
+                    when (selectedItem) {
+                        0 -> {
+                            when (participantAheadResponseListUiState) {
+                                is ParticipantResponseListUiState.Loading -> {
+                                    Text(
+                                        text = "로딩중..",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is ParticipantResponseListUiState.Success -> {
+                                    Text(
+                                        text = "${participantAheadResponseListUiState.data.size}명",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is ParticipantResponseListUiState.Error -> {
+                                    Text(
+                                        text = "데이터를 불러올 수 없습니다..",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is ParticipantResponseListUiState.Empty -> {
+                                    Text(
+                                        text = "0명",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                            }
+                        }
 
-            Spacer(modifier = Modifier.height(24.dp))
+                        1 -> {
+                            when (participantFieldResponseListUiState) {
+                                is ParticipantResponseListUiState.Loading -> {
+                                    Text(
+                                        text = "로딩중..",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is ParticipantResponseListUiState.Success -> {
+                                    Text(
+                                        text = "${participantFieldResponseListUiState.data.size}명",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is ParticipantResponseListUiState.Error -> {
+                                    Text(
+                                        text = "데이터를 불러올 수 없습니다..",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is ParticipantResponseListUiState.Empty -> {
+                                    Text(
+                                        text = "0명",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                            }
+                        }
 
-            Box(
-                modifier = Modifier
-                    .border(
-                        width = 1.dp,
-                        color = colors.gray200
-                    )
-                    .fillMaxWidth()
-                    .padding(
-                        vertical = 16.dp
-                    )
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 16.dp)
-                        .horizontalScroll(rememberScrollState()),
-                    horizontalArrangement = Arrangement.spacedBy(20.dp)
-                ) {
-                    Spacer(modifier = Modifier.width(20.dp))
-
-                    Text(
-                        text = "성명",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(80.dp)
-                    )
-
-                    Text(
-                        text = "소속",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(100.dp)
-                    )
-
-                    Text(
-                        text = "직급",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(80.dp)
-                    )
-
-                    Text(
-                        text = "프로그램 선택",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(120.dp)
-                    )
-
-                    Text(
-                        text = "출석 여부",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(100.dp)
-                    )
-
-                    Text(
-                        text = "입실시간",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(80.dp)
-                    )
-
-                    Text(
-                        text = "퇴실시간",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(80.dp)
-                    )
+                        2 -> {
+                            when (traineeInformationUiState) {
+                                is TraineeResponseListUiState.Loading -> {
+                                    Text(
+                                        text = "로딩중..",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is TraineeResponseListUiState.Success -> {
+                                    Text(
+                                        text = "${traineeInformationUiState.data.size}명",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is TraineeResponseListUiState.Error -> {
+                                    Text(
+                                        text = "데이터를 불러올 수 없습니다..",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is TraineeResponseListUiState.Empty -> {
+                                    Text(
+                                        text = "0명",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
             }
 
             SwipeRefresh(
                 state = swipeRefreshState,
-                onRefresh = {  },
+                onRefresh = {
+                    when (selectedItem) {
+                        0 -> getAheadParticipantList()
+                        1 -> getFieldParticipantList()
+                        2 -> getTraineeList()
+                    }
+                },
                 indicator = { state, refreshTrigger ->
                     SwipeRefreshIndicator(
                         state = state,
@@ -272,15 +336,97 @@ private fun ProgramDetailParticipantManagementScreen(
             ) {
                 when (selectedItem) {
                     0 -> {
+                        when (participantAheadResponseListUiState) {
+                            is ParticipantResponseListUiState.Loading -> Unit
+                            is ParticipantResponseListUiState.Success -> {
 
+                                Column {
+
+                                    Spacer(modifier = Modifier.height(24.dp))
+
+                                    ProgramDetailParticipantTable(scrollState = scrollState)
+
+                                    ProgramDetailParticipantManagementList(
+                                        scrollState = scrollState,
+                                        item = participantAheadResponseListUiState.data.toImmutableList()
+                                    )
+                                }
+                            }
+                            is ParticipantResponseListUiState.Error -> {
+                                ShowErrorState(
+                                    errorText = "사전 행사 참가자를 불러올 수 없습니다..",
+                                    scrollState = scrollState
+                                )
+                            }
+                            is ParticipantResponseListUiState.Empty -> {
+                                ShowEmptyState(
+                                    emptyMessage = "사전 행사 참가자가 존재하지 않습니다..",
+                                    scrollState = scrollState
+                                )
+                            }
+                        }
                     }
 
                     1 -> {
+                        when (participantFieldResponseListUiState) {
+                            is ParticipantResponseListUiState.Loading -> Unit
+                            is ParticipantResponseListUiState.Success -> {
+                                Column {
 
+                                    Spacer(modifier = Modifier.height(24.dp))
+
+                                    ProgramDetailParticipantTable(scrollState = scrollState)
+
+                                    ProgramDetailParticipantManagementList(
+                                        scrollState = scrollState,
+                                        item = participantFieldResponseListUiState.data.toImmutableList()
+                                    )
+                                }
+                            }
+                            is ParticipantResponseListUiState.Error -> {
+                                ShowErrorState(
+                                    errorText = "현장 행사 참가자를 불러올 수 없습니다..",
+                                    scrollState = scrollState
+                                )
+                            }
+                            is ParticipantResponseListUiState.Empty -> {
+                                ShowEmptyState(
+                                    emptyMessage = "현장 행사 참가자가 존재하지 않습니다..",
+                                    scrollState = scrollState
+                                )
+                            }
+                        }
                     }
 
                     2 -> {
+                        when (traineeInformationUiState) {
+                            is TraineeResponseListUiState.Loading -> Unit
+                            is TraineeResponseListUiState.Success -> {
+                                Column {
 
+                                    Spacer(modifier = Modifier.height(24.dp))
+
+                                    ProgramTraineeTable(scrollState = scrollState)
+
+                                    ProgramTraineeList(
+                                        scrollState = scrollState,
+                                        item = traineeInformationUiState.data.toImmutableList()
+                                    )
+                                }
+                            }
+                            is TraineeResponseListUiState.Error -> {
+                                ShowErrorState(
+                                    errorText = "사전 교원 원수를 불러올 수 없습니다..",
+                                    scrollState = scrollState
+                                )
+                            }
+                            is TraineeResponseListUiState.Empty -> {
+                                ShowEmptyState(
+                                    emptyMessage = "사전 교원 원수가 존재하지 않습니다..",
+                                    scrollState = scrollState
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -293,7 +439,12 @@ private fun ProgramDetailParticipantManagementScreen(
 private fun HomeDetailParticipantManagementScreenPreview() {
     ProgramDetailParticipantManagementScreen(
         onBackClick = {},
-        participantManagementData = generateParticipantManagementSampleData(),
-        swipeRefreshState = rememberSwipeRefreshState(isRefreshing = false)
+        swipeRefreshState = rememberSwipeRefreshState(isRefreshing = false),
+        participantAheadResponseListUiState = ParticipantResponseListUiState.Loading,
+        participantFieldResponseListUiState = ParticipantResponseListUiState.Loading,
+        traineeInformationUiState = TraineeResponseListUiState.Loading,
+        getAheadParticipantList = {},
+        getFieldParticipantList = {},
+        getTraineeList = {}
     )
 }

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -109,9 +109,9 @@ private fun ProgramDetailParticipantManagementScreen(
     getFieldParticipantList: () -> Unit,
     getTraineeList: () -> Unit
 ) {
-    var participantTextState by remember { mutableStateOf("사전 행사 참가자") }
-    var isDropdownExpanded by remember { mutableStateOf(false) }
-    var selectedItem by remember { mutableStateOf<Int?>(0) }
+    var participantTextState by rememberSaveable { mutableStateOf("사전 행사 참가자") }
+    var isDropdownExpanded by rememberSaveable { mutableStateOf(false) }
+    var selectedItem by rememberSaveable { mutableStateOf<Int?>(0) }
 
 
     ExpoAndroidTheme { colors, typography ->

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -17,17 +17,29 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
+import com.google.accompanist.swiperefresh.SwipeRefreshState
+import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
+import com.school_of_company.design_system.icon.DownArrowIcon
 import com.school_of_company.design_system.icon.LeftArrowIcon
 import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.program.view.component.HomeDetailParticipantManagementData
-import com.school_of_company.program.view.component.ProgramDetailParticipantManagementList
+import com.school_of_company.program.view.component.ProgramDetailParticipantDropdownMenu
+import com.school_of_company.program.viewmodel.ProgramViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
 
@@ -47,11 +59,16 @@ internal fun generateParticipantManagementSampleData(): ImmutableList<HomeDetail
 
 @Composable
 internal fun ProgramDetailParticipantManagementRoute(
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    viewModel: ProgramViewModel = hiltViewModel()
 ) {
+    val swipeRefreshLoading by viewModel.swipeRefreshLoading.collectAsStateWithLifecycle()
+    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing = swipeRefreshLoading)
+
     ProgramDetailParticipantManagementScreen(
         onBackClick = onBackClick,
-        participantManagementData = generateParticipantManagementSampleData()
+        participantManagementData = generateParticipantManagementSampleData(),
+        swipeRefreshState = swipeRefreshState
     )
 }
 
@@ -59,9 +76,16 @@ internal fun ProgramDetailParticipantManagementRoute(
 private fun ProgramDetailParticipantManagementScreen(
     modifier: Modifier = Modifier,
     participantManagementData: ImmutableList<HomeDetailParticipantManagementData>,
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    swipeRefreshState: SwipeRefreshState
 ) {
+    var participantTextState by remember { mutableStateOf("사전 행사 참가자") }
+    var isDropdownExpanded by remember { mutableStateOf(false) }
+    var selectedItem by remember { mutableStateOf<Int?>(0) }
+
+
     ExpoAndroidTheme { colors, typography ->
+
         Column(
             modifier = modifier
                 .fillMaxSize()
@@ -79,14 +103,45 @@ private fun ProgramDetailParticipantManagementScreen(
                 modifier = Modifier.padding(horizontal = 16.dp)
             )
 
-            Spacer(modifier = Modifier.height(28.dp))
+            Spacer(modifier = Modifier.height(25.dp))
 
-            Text(
-                text = "참가자 조회하기",
-                style = typography.bodyBold2,
-                color = colors.black,
-                modifier = Modifier.padding(start = 16.dp)
-            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.expoClickable { isDropdownExpanded = true }
+            ) {
+                Text(
+                    text = participantTextState,
+                    style = typography.bodyBold2,
+                    color = colors.black,
+                    modifier = Modifier.padding(start = 16.dp)
+                )
+
+                DownArrowIcon(
+                    tint = colors.black,
+                    modifier = Modifier.padding(start = 10.dp)
+                )
+            }
+
+            Box(modifier = Modifier.padding(start = 16.dp, top = 10.dp)) {
+                if (isDropdownExpanded) {
+                    ProgramDetailParticipantDropdownMenu(
+                        onCancelClick = { isDropdownExpanded = false },
+                        onExpandClick = isDropdownExpanded,
+                        selectedItem = selectedItem,
+                        onItemSelected = { index ->
+                            selectedItem = index
+                            isDropdownExpanded = false
+
+                            participantTextState = when (index) {
+                                0 -> "사전 행사 참가자"
+                                1 -> "현장 행사 참가자"
+                                2 -> "사전 교원 원수 참가자"
+                                else -> participantTextState
+                            }
+                        },
+                    )
+                }
+            }
 
             Spacer(modifier = Modifier.height(12.dp))
 
@@ -204,7 +259,31 @@ private fun ProgramDetailParticipantManagementScreen(
                 }
             }
 
-            ProgramDetailParticipantManagementList(item = participantManagementData)
+            SwipeRefresh(
+                state = swipeRefreshState,
+                onRefresh = {  },
+                indicator = { state, refreshTrigger ->
+                    SwipeRefreshIndicator(
+                        state = state,
+                        refreshTriggerDistance = refreshTrigger,
+                        contentColor = colors.main
+                    )
+                }
+            ) {
+                when (selectedItem) {
+                    0 -> {
+
+                    }
+
+                    1 -> {
+
+                    }
+
+                    2 -> {
+
+                    }
+                }
+            }
         }
     }
 }
@@ -214,6 +293,7 @@ private fun ProgramDetailParticipantManagementScreen(
 private fun HomeDetailParticipantManagementScreenPreview() {
     ProgramDetailParticipantManagementScreen(
         onBackClick = {},
-        participantManagementData = generateParticipantManagementSampleData()
+        participantManagementData = generateParticipantManagementSampleData(),
+        swipeRefreshState = rememberSwipeRefreshState(isRefreshing = false)
     )
 }

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailProgramScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailProgramScreen.kt
@@ -169,10 +169,7 @@ private fun ProgramDetailProgramScreen(
                         width = 1.dp,
                         color = colors.white
                     )
-                    .padding(
-                        horizontal = 16.dp,
-                        vertical = 16.dp
-                    )
+                    .padding(all = 16.dp)
                     .horizontalScroll(scrollState)
             ) {
 

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParicipantTable.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParicipantTable.kt
@@ -1,0 +1,87 @@
+package com.school_of_company.program.view.component
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidthIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+internal fun ProgramDetailParticipantTable(
+    modifier: Modifier = Modifier,
+    scrollState: ScrollState
+) {
+    ExpoAndroidTheme { colors, typography ->
+
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(color = colors.gray200)
+        )
+
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp)
+                    .horizontalScroll(scrollState),
+                horizontalArrangement = Arrangement.spacedBy(44.dp)
+            ) {
+                Spacer(modifier = Modifier.width(20.dp))
+
+                Text(
+                    text = "성명",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(80.dp)
+                )
+
+                Text(
+                    text = "안내문자 발송용 연락처",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(130.dp)
+                )
+
+                Text(
+                    text = "개인정보 동의 제공 동의",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(150.dp)
+                )
+            }
+        }
+
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(color = colors.gray100)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ProgramDetailParticipantTablePreview() {
+    ProgramDetailParticipantTable(scrollState = rememberScrollState())
+}

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantDropdownMenu.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantDropdownMenu.kt
@@ -1,0 +1,60 @@
+package com.school_of_company.program.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+internal fun ProgramDetailParticipantDropdownMenu(
+    modifier: Modifier = Modifier,
+    onCancelClick: () -> Unit,
+    onExpandClick: Boolean,
+    selectedItem: Int?,
+    onItemSelected: (Int) -> Unit
+) {
+    ExpoAndroidTheme { colors, typography ->
+
+        DropdownMenu(
+            expanded = onExpandClick,
+            onDismissRequest = { onCancelClick() },
+            modifier = modifier.background(color = colors.white)
+        ) {
+
+            val menuItems = listOf("사전 행사 참가자", "현장 행사 참가자", "사전 교원 원수 참가자")
+
+            menuItems.forEachIndexed { index, title ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = title,
+                            style = typography.bodyRegular2,
+                            color = if (selectedItem == index) colors.main else colors.gray500,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    },
+                    onClick = {
+                        onItemSelected(index)
+                    },
+                    modifier = Modifier
+                        .padding(horizontal = 8.dp)
+                        .fillMaxWidth()
+                        .background(
+                            if (selectedItem == index) colors.main100 else colors.white,
+                            shape = RoundedCornerShape(size = 6.dp)
+                        )
+                )
+            }
+        }
+    }
+}

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementList.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementList.kt
@@ -1,10 +1,12 @@
 package com.school_of_company.program.view.component
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -17,7 +19,8 @@ import kotlinx.collections.immutable.persistentListOf
 @Composable
 internal fun ProgramDetailParticipantManagementList(
     modifier: Modifier = Modifier,
-    item: ImmutableList<HomeDetailParticipantManagementData> = persistentListOf()
+    item: ImmutableList<HomeDetailParticipantManagementData> = persistentListOf(),
+    scrollState: ScrollState
 ) {
     ExpoAndroidTheme { colors, _ ->
         LazyColumn(
@@ -29,7 +32,8 @@ internal fun ProgramDetailParticipantManagementList(
             itemsIndexed(item) { index, item ->
                 ProgramDetailParticipantManagementListItem(
                     index = index + 1,
-                    data = item
+                    data = item,
+                    horizontalScrollState = scrollState
                 )
             }
         }
@@ -40,6 +44,7 @@ internal fun ProgramDetailParticipantManagementList(
 @Composable
 private fun HomeDetailParticipantManagementListPreview() {
     ProgramDetailParticipantManagementList(
-        item = generateParticipantManagementSampleData()
+        item = generateParticipantManagementSampleData(),
+        scrollState = rememberScrollState()
     )
 }

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementList.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementList.kt
@@ -12,17 +12,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
-import com.school_of_company.program.view.generateParticipantManagementSampleData
+import com.school_of_company.model.entity.participant.ParticipantInformationResponseEntity
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun ProgramDetailParticipantManagementList(
     modifier: Modifier = Modifier,
-    item: ImmutableList<HomeDetailParticipantManagementData> = persistentListOf(),
+    item: ImmutableList<ParticipantInformationResponseEntity> = persistentListOf(),
     scrollState: ScrollState
 ) {
     ExpoAndroidTheme { colors, _ ->
+
         LazyColumn(
             modifier = modifier
                 .fillMaxSize()
@@ -44,7 +45,7 @@ internal fun ProgramDetailParticipantManagementList(
 @Composable
 private fun HomeDetailParticipantManagementListPreview() {
     ProgramDetailParticipantManagementList(
-        item = generateParticipantManagementSampleData(),
+        item = persistentListOf(),
         scrollState = rememberScrollState()
     )
 }

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementListItem.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementListItem.kt
@@ -33,7 +33,7 @@ internal fun ProgramDetailParticipantManagementListItem(
     modifier: Modifier = Modifier,
     index: Int,
     data: HomeDetailParticipantManagementData,
-    horizontalScrollState: ScrollState = rememberScrollState(),
+    horizontalScrollState: ScrollState,
 ) {
     Spacer(modifier = Modifier.height(20.dp))
 
@@ -118,6 +118,7 @@ private fun HomeDetailParticipantManagementListItemPreview() {
             checkHere = true,
             inTime = "12:00",
             outTime = "13:00"
-        )
+        ),
+        horizontalScrollState = rememberScrollState()
     )
 }

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementListItem.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementListItem.kt
@@ -3,12 +3,14 @@ package com.school_of_company.program.view.component
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.requiredWidthIn
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,91 +18,68 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.icon.CircleIcon
+import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
-
-data class HomeDetailParticipantManagementData(
-    val name: String,
-    val company: String,
-    val position: String,
-    val schoolSubject: String,
-    val checkHere: Boolean,
-    val inTime: String?,
-    val outTime: String?
-)
+import com.school_of_company.model.entity.participant.ParticipantInformationResponseEntity
 
 @Composable
 internal fun ProgramDetailParticipantManagementListItem(
     modifier: Modifier = Modifier,
     index: Int,
-    data: HomeDetailParticipantManagementData,
+    data: ParticipantInformationResponseEntity,
     horizontalScrollState: ScrollState,
 ) {
     Spacer(modifier = Modifier.height(20.dp))
 
     ExpoAndroidTheme { colors, typography ->
+
         Row(
             verticalAlignment = Alignment.CenterVertically,
             modifier = modifier
                 .fillMaxWidth()
                 .padding(vertical = 8.dp)
                 .horizontalScroll(horizontalScrollState),
-            horizontalArrangement = Arrangement.spacedBy(20.dp)
+            horizontalArrangement = Arrangement.spacedBy(44.dp)
         ) {
+
             Text(
                 text = index.toString(),
                 style = typography.captionRegular2,
                 color = colors.black,
-                modifier = Modifier.width(20.dp)
+                modifier = Modifier.requiredWidthIn(20.dp)
             )
 
             Text(
                 text = data.name,
                 style = typography.captionRegular2,
                 color = colors.black,
-                modifier = Modifier.width(80.dp)
+                modifier = Modifier.requiredWidthIn(80.dp)
             )
 
             Text(
-                text = data.company,
+                text = data.phoneNumber,
                 style = typography.captionRegular2,
                 color = colors.black,
-                modifier = Modifier.width(100.dp)
+                modifier = Modifier.requiredWidthIn(130.dp)
             )
 
-            Text(
-                text = data.position,
-                style = typography.captionRegular2,
-                color = colors.black,
-                modifier = Modifier.width(80.dp)
-            )
-
-            Text(
-                text = data.schoolSubject,
-                style = typography.captionRegular2,
-                color = colors.black,
-                modifier = Modifier.width(120.dp)
-            )
-
-            Text(
-                text = if (data.checkHere) "출석" else "미출석",
-                style = typography.captionRegular2,
-                color = colors.black,
-                modifier = Modifier.width(100.dp)
-            )
-
-            Text(
-                text = data.inTime ?: "x",
-                style = typography.captionRegular2,
-                color = colors.black,
-                modifier = Modifier.width(80.dp)
-            )
-
-            Text(
-                text = data.outTime ?: "x",
-                style = typography.captionRegular2,
-                color = colors.black,
-                modifier = Modifier.width(80.dp)
-            )
+            Box(
+                modifier = Modifier.requiredWidthIn(166.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                if (data.informationStatus) {
+                    CircleIcon(
+                        tint = colors.black,
+                        modifier = Modifier.size(16.dp)
+                    )
+                } else {
+                    XIcon(
+                        tint = colors.error,
+                        modifier = Modifier.size(16.dp)
+                    )
+                }
+            }
         }
     }
 }
@@ -110,14 +89,11 @@ internal fun ProgramDetailParticipantManagementListItem(
 private fun HomeDetailParticipantManagementListItemPreview() {
     ProgramDetailParticipantManagementListItem(
         index = 1,
-        data = HomeDetailParticipantManagementData(
+        data = ParticipantInformationResponseEntity(
             name = "이명훈",
-            company = "초등학교",
-            position = "교사",
-            schoolSubject = "컴퓨터공학",
-            checkHere = true,
-            inTime = "12:00",
-            outTime = "13:00"
+            id = 0,
+            phoneNumber = "01038251716",
+            informationStatus = true,
         ),
         horizontalScrollState = rememberScrollState()
     )

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramList.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramList.kt
@@ -30,7 +30,7 @@ internal fun ProgramList(
             modifier = modifier
                 .fillMaxSize()
                 .background(color = colors.white)
-                .padding(horizontal = 16.dp)
+                .padding(start = 16.dp)
         ) {
             itemsIndexed(trainingItem) { index, item ->
                 ProgramListItem(
@@ -57,7 +57,7 @@ internal fun StandardProgramList(
             modifier = modifier
                 .fillMaxSize()
                 .background(color = colors.white)
-                .padding(horizontal = 16.dp)
+                .padding(start = 16.dp)
         ) {
             itemsIndexed(standardItem) { index, item ->
                 StandardProgramListItem(

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramList.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramList.kt
@@ -30,7 +30,7 @@ internal fun ProgramList(
             modifier = modifier
                 .fillMaxSize()
                 .background(color = colors.white)
-                .padding(start = 16.dp)
+                .padding(horizontal = 16.dp)
         ) {
             itemsIndexed(trainingItem) { index, item ->
                 ProgramListItem(
@@ -57,7 +57,7 @@ internal fun StandardProgramList(
             modifier = modifier
                 .fillMaxSize()
                 .background(color = colors.white)
-                .padding(start = 16.dp)
+                .padding(horizontal = 16.dp)
         ) {
             itemsIndexed(standardItem) { index, item ->
                 StandardProgramListItem(

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramListItem.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramListItem.kt
@@ -88,16 +88,12 @@ internal fun ProgramListItem(
                 if (data.category == "ESSENTIAL") {
                     CircleIcon(
                         tint = colors.black,
-                        modifier = Modifier
-                            .size(16.dp)
-                            .width(25.dp)
+                        modifier = Modifier.size(16.dp)
                     )
                 } else {
                     XIcon(
                         tint = colors.error,
-                        modifier = Modifier
-                            .size(16.dp)
-                            .width(25.dp)
+                        modifier = Modifier.size(16.dp)
                     )
                 }
             }

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeList.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeList.kt
@@ -1,0 +1,40 @@
+package com.school_of_company.program.view.component
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.model.entity.trainee.TraineeResponseEntity
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+@Composable
+internal fun ProgramTraineeList(
+    modifier: Modifier = Modifier,
+    item: ImmutableList<TraineeResponseEntity> = persistentListOf(),
+    scrollState: ScrollState
+) {
+    ExpoAndroidTheme { colors, _ ->
+
+        LazyColumn(
+            modifier = modifier
+                .fillMaxSize()
+                .background(color = colors.white)
+                .padding(start = 16.dp)
+        ) {
+            itemsIndexed(item) { index, item ->
+                ProgramTraineeListItem(
+                    index = index,
+                    data = item,
+                    horizontalScrollState = scrollState
+                )
+            }
+        }
+    }
+}

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeListItem.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeListItem.kt
@@ -1,0 +1,76 @@
+package com.school_of_company.program.view.component
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidthIn
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.model.entity.trainee.TraineeResponseEntity
+
+@Composable
+internal fun ProgramTraineeListItem(
+    modifier: Modifier = Modifier,
+    index: Int,
+    data: TraineeResponseEntity,
+    horizontalScrollState: ScrollState
+) {
+    Spacer(modifier = Modifier.height(20.dp))
+
+    ExpoAndroidTheme { colors, typography ->
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+                .horizontalScroll(horizontalScrollState),
+            horizontalArrangement = Arrangement.spacedBy(44.dp)
+        ) {
+
+            Text(
+                text = index.toString(),
+                style = typography.captionRegular2,
+                color = colors.black,
+                modifier = Modifier.requiredWidthIn(20.dp)
+            )
+
+            Text(
+                text = data.name,
+                style = typography.captionRegular2,
+                color = colors.black,
+                modifier = Modifier.requiredWidthIn(80.dp)
+            )
+
+            Text(
+                text = data.trainingId,
+                style = typography.captionRegular2,
+                color = colors.black,
+                modifier = Modifier.requiredWidthIn(130.dp)
+            )
+
+            Text(
+                text = if (data.applicationType == "FIELD") "현장 신청" else "사전 신청",
+                style = typography.captionRegular2,
+                color = colors.black,
+                modifier = Modifier.requiredWidthIn(100.dp)
+            )
+
+            Text(
+                text = data.phoneNumber,
+                style = typography.captionRegular2,
+                color = colors.black,
+                modifier = Modifier.requiredWidthIn(130.dp)
+            )
+        }
+    }
+}

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeTable.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeTable.kt
@@ -1,0 +1,86 @@
+package com.school_of_company.program.view.component
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidthIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+internal fun ProgramTraineeTable(
+    modifier: Modifier = Modifier,
+    scrollState: ScrollState
+) {
+    ExpoAndroidTheme { colors, typography ->
+
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(color = colors.gray200)
+        )
+
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp)
+                    .horizontalScroll(scrollState),
+                horizontalArrangement = Arrangement.spacedBy(44.dp)
+            ) {
+                Spacer(modifier = Modifier.width(20.dp))
+
+                Text(
+                    text = "성명",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(80.dp)
+                )
+
+                Text(
+                    text = "연수원 아이디",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(130.dp)
+                )
+
+                Text(
+                    text = "신청 방법",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(100.dp)
+                )
+
+                Text(
+                    text = "휴대폰 번호",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(130.dp)
+                )
+            }
+        }
+
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(color = colors.gray100)
+        )
+    }
+}


### PR DESCRIPTION
## 💡 개요
- 박람회 참가자 조회하기 부분 디자인 변경 사항이 있어 이를 수정할 필요가 있었습니다.
- 박람회 참가자 조회하기 부분 네트워크 세팅이 모두 되어있어 기능 구현을 해야할 필요가 있었습니다.
## 📃 작업내용
- 박람회 참가자 조회하기 부분 디자인 변경 사항을 수정하였습니다.
   - 드롭다운 메뉴바 추가
   - 현장(사전) 신청 참가자, 사전 교원 연수 참가자 부분의 리스트에 디자인 변경 사항이 있어 수정
   - 패딩이 잘못들어간 부분이 있어 이를 수정
   - 스크린에 있던 Table을 컴포넌트로 빼서 각 상태에 맞게 나올 수 있도록 사용
   - tint color를 사용할 수 있게 수정

- 박람회 참가자 조회하기 부분 네트워크 세팅이 모두 되어있어 기능 구현을 하였습니다.
   - 선택된 인덱스를 통해서 각각의 메뉴에 따른 통신을 하여 원하는 값을 얻어 UI에 표시
   - UiState를 사용하여 각 상태에 따라 Ui 상태를 유연하게 관리

https://github.com/user-attachments/assets/fd1a5059-d8d3-4dcd-98c0-6bd25d296d3a


## 🔀 변경사항
![스크린샷 2025-01-18 오전 3 05 02](https://github.com/user-attachments/assets/f67c78c6-3b92-4bc8-ba77-720a32190f3a)
![스크린샷 2025-01-18 오전 3 05 17](https://github.com/user-attachments/assets/03b6e8a6-a15c-4797-a440-801ec7294cb7)

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- 지금 사전 교원 연수 참가자 부분은 통신을 하면 200 즉, 성공이 나오지만 서버에서 trainingId 값을 넣어주지 않아 생기는 문제로 서버가 값을 다시 제대로 넣어준다면 문제없이 Ui에 서버로 부터 받아온 값이 나올듯합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

- **새로운 기능**
	- 프로그램 참가자 및 연수생 관리 화면에 대한 UI 개선
	- 참가자 및 연수생 정보를 동적으로 표시하는 기능 추가
	- 드롭다운 메뉴를 통한 참가자 유형 선택 기능 강화
	- 프로그램 세부 정보 화면에서 ID를 기반으로 한 동적 네비게이션 추가
	- 참가자 관리 리스트와 연수생 리스트를 위한 새로운 컴포넌트 추가

- **버그 수정**
	- 네비게이션 흐름에서 ID 전달 방식 개선
	- 스크롤 상태 관리 최적화

- **디자인 개선**
	- 아이콘 및 테이블 레이아웃 스타일링 업데이트
	- 컴포넌트 간 일관된 패딩 및 간격 조정
	- UI 구성 요소의 가독성 및 사용자 경험 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->