### PR TITLE
🔀 :: (#334) - 유저 스크린에서 로그아웃, 탈퇴하기를 눌렀을때 바로 통신이 되는 것이 아닌 팝을 띄워 다시 물어볼 수 있도록 수정하였습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -87,7 +87,9 @@ fun ExpoNavHost(
         expoDetailScreen(
             onBackClick = navController::popBackStack,
             onMessageClick = navController::navigateToSmsSendMessage,
-            onCheckClick = navController::navigateToProgramDetailParticipantManagement,
+            onCheckClick = { id ->
+                navController.navigateToProgramDetailParticipantManagement(id)
+            },
             onModifyClick = { id ->
                 navController.navigateToExpoModify(id)
             },

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
@@ -101,6 +101,7 @@ fun ExpoStateButton(
 fun ExpoEnableButton(
     modifier: Modifier = Modifier,
     text: String,
+    textColor: Color = Color.Black,
     onClick: () -> Unit,
 ) {
     ExpoAndroidTheme { colors, typography ->
@@ -121,7 +122,7 @@ fun ExpoEnableButton(
             Text(
                 text = text,
                 style = typography.bodyBold2,
-                color = colors.main
+                color = textColor
             )
         }
     }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/icon/ExpoIcon.kt
@@ -63,11 +63,15 @@ fun LeftArrowIcon(
 }
 
 @Composable
-fun UpArrowIcon(modifier: Modifier = Modifier) {
+fun UpArrowIcon(
+    modifier: Modifier = Modifier,
+    tint: Color = Color.Unspecified
+) {
     Icon(
         painter = painterResource(id = R.drawable.ic_up_arrow),
         contentDescription = stringResource(id = R.string.up_arrow_description),
-        modifier = modifier
+        modifier = modifier,
+        tint = tint
     )
 }
 

--- a/core/network/src/main/java/com/school_of_company/network/api/ParticipantAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/ParticipantAPI.kt
@@ -9,7 +9,7 @@ interface ParticipantAPI {
 
     @GET("/participant/{expo_id}")
     suspend fun getParticipantInformationList(
+        @Path("expo_id") expoId: String,
         @Query("type") type: String,
-        @Path("expo_id") expoId: String
-    ) : List<ParticipantInformationResponse>
+    ): List<ParticipantInformationResponse>
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
@@ -61,7 +61,7 @@ fun NavGraphBuilder.expoScreen(
 fun NavGraphBuilder.expoDetailScreen(
     onBackClick: () -> Unit,
     onMessageClick: () -> Unit,
-    onCheckClick: () -> Unit,
+    onCheckClick: (String) -> Unit,
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit
 ) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -336,6 +336,7 @@ private fun ExpoDetailScreen(
                             ExpoEnableButton(
                                 text = "수정하기",
                                 onClick = { onModifyClick(id) },
+                                textColor = colors.main,
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .border(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -56,7 +56,7 @@ internal fun ExpoDetailRoute(
     id: String,
     onBackClick: () -> Unit,
     onMessageClick: () -> Unit,
-    onCheckClick: () -> Unit,
+    onCheckClick: (String) -> Unit,
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit,
     viewModel: ExpoViewModel = hiltViewModel()
@@ -94,7 +94,7 @@ private fun ExpoDetailScreen(
     getStandardProgramUiState: GetStandardProgramListUiState,
     onBackClick: () -> Unit,
     onMessageClick: () -> Unit,
-    onCheckClick: () -> Unit,
+    onCheckClick: (String) -> Unit,
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit
 ) {
@@ -311,7 +311,7 @@ private fun ExpoDetailScreen(
                                 ExpoButton(
                                     text = "조회하기",
                                     color = colors.main,
-                                    onClick = onCheckClick,
+                                    onClick = { onCheckClick(id) },
                                     modifier = Modifier
                                         .weight(1f)
                                         .padding(

--- a/feature/program/src/main/java/com/school_of_company/program/navigation/ProgramNavigation.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/navigation/ProgramNavigation.kt
@@ -22,8 +22,14 @@ fun NavController.navigateToProgramDetailProgram(
     )
 }
 
-fun NavController.navigateToProgramDetailParticipantManagement(navOptions: NavOptions? = null) {
-    this.navigate(programDetailParticipantManagementRoute, navOptions)
+fun NavController.navigateToProgramDetailParticipantManagement(
+    id: String,
+    navOptions: NavOptions? = null
+) {
+    this.navigate(
+        route = "$programDetailParticipantManagementRoute/${id}",
+        navOptions
+    )
 }
 
 fun NavController.navigateQrScanner(
@@ -53,11 +59,11 @@ fun NavGraphBuilder.programDetailProgramScreen(
     }
 }
 
-fun NavGraphBuilder.programDetailParticipantManagementScreen(
-    onBackClick: () -> Unit
-) {
-    composable(route = programDetailParticipantManagementRoute) {
+fun NavGraphBuilder.programDetailParticipantManagementScreen(onBackClick: () -> Unit) {
+    composable(route = "$programDetailParticipantManagementRoute/{id}") { backStackEntry ->
+        val id = backStackEntry.arguments?.getString("id") ?: ""
         ProgramDetailParticipantManagementRoute(
+            id = id,
             onBackClick = onBackClick
         )
     }

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -1,15 +1,13 @@
 package com.school_of_company.program.view
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -17,51 +15,107 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
+import com.google.accompanist.swiperefresh.SwipeRefreshState
+import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
+import com.school_of_company.design_system.component.uistate.empty.ShowEmptyState
+import com.school_of_company.design_system.component.uistate.error.ShowErrorState
+import com.school_of_company.design_system.icon.DownArrowIcon
 import com.school_of_company.design_system.icon.LeftArrowIcon
+import com.school_of_company.design_system.icon.UpArrowIcon
 import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
-import com.school_of_company.program.view.component.HomeDetailParticipantManagementData
+import com.school_of_company.program.enum.ParticipantEnum
+import com.school_of_company.program.view.component.ProgramDetailParticipantDropdownMenu
 import com.school_of_company.program.view.component.ProgramDetailParticipantManagementList
-import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.toPersistentList
-
-internal fun generateParticipantManagementSampleData(): ImmutableList<HomeDetailParticipantManagementData> {
-    return List(20) {
-        HomeDetailParticipantManagementData(
-            name = "이명훈",
-            company = "초등학교",
-            position = "교사",
-            schoolSubject = "컴퓨터공학",
-            checkHere = true,
-            inTime = "12:00",
-            outTime = "13:00"
-        )
-    }.toPersistentList()
-}
+import com.school_of_company.program.view.component.ProgramDetailParticipantTable
+import com.school_of_company.program.view.component.ProgramTraineeList
+import com.school_of_company.program.view.component.ProgramTraineeTable
+import com.school_of_company.program.viewmodel.ProgramViewModel
+import com.school_of_company.program.viewmodel.uistate.ParticipantResponseListUiState
+import com.school_of_company.program.viewmodel.uistate.TraineeResponseListUiState
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 internal fun ProgramDetailParticipantManagementRoute(
-    onBackClick: () -> Unit
+    id: String,
+    onBackClick: () -> Unit,
+    viewModel: ProgramViewModel = hiltViewModel()
 ) {
+    val swipeRefreshLoading by viewModel.swipeRefreshLoading.collectAsStateWithLifecycle()
+    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing = swipeRefreshLoading)
+
+    val participantAheadResponseListUiState by viewModel.participantAheadResponseListUiState.collectAsStateWithLifecycle()
+    val participantFieldResponseListUiState by viewModel.participantFieldResponseListUiState.collectAsStateWithLifecycle()
+    val traineeInformationUiState by viewModel.traineeResponseListUiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(id) {
+
+        viewModel.getParticipantInformationList(
+            expoId = id,
+            type = ParticipantEnum.PRE
+        )
+
+        viewModel.getParticipantInformationList(
+            expoId = id,
+            type = ParticipantEnum.FIELD
+        )
+
+        viewModel.getTraineeList(expoId = id)
+    }
+
     ProgramDetailParticipantManagementScreen(
         onBackClick = onBackClick,
-        participantManagementData = generateParticipantManagementSampleData()
+        swipeRefreshState = swipeRefreshState,
+        participantAheadResponseListUiState = participantAheadResponseListUiState,
+        participantFieldResponseListUiState = participantFieldResponseListUiState,
+        traineeInformationUiState = traineeInformationUiState,
+        getAheadParticipantList = { viewModel.getParticipantInformationList(
+            expoId = id,
+            type = ParticipantEnum.PRE
+        ) },
+        getFieldParticipantList = { viewModel.getParticipantInformationList(
+            expoId = id,
+            type = ParticipantEnum.FIELD
+        ) },
+        getTraineeList = { viewModel.getTraineeList(expoId = id) }
     )
 }
 
 @Composable
 private fun ProgramDetailParticipantManagementScreen(
     modifier: Modifier = Modifier,
-    participantManagementData: ImmutableList<HomeDetailParticipantManagementData>,
-    onBackClick: () -> Unit
+    onBackClick: () -> Unit,
+    swipeRefreshState: SwipeRefreshState,
+    scrollState: ScrollState = rememberScrollState(),
+    participantAheadResponseListUiState: ParticipantResponseListUiState,
+    participantFieldResponseListUiState: ParticipantResponseListUiState,
+    traineeInformationUiState: TraineeResponseListUiState,
+    getAheadParticipantList: () -> Unit,
+    getFieldParticipantList: () -> Unit,
+    getTraineeList: () -> Unit
 ) {
+    var participantTextState by rememberSaveable { mutableStateOf("사전 행사 참가자") }
+    var isDropdownExpanded by rememberSaveable { mutableStateOf(false) }
+    var selectedItem by rememberSaveable { mutableStateOf<Int?>(0) }
+
+
     ExpoAndroidTheme { colors, typography ->
+
         Column(
             modifier = modifier
                 .fillMaxSize()
@@ -79,14 +133,52 @@ private fun ProgramDetailParticipantManagementScreen(
                 modifier = Modifier.padding(horizontal = 16.dp)
             )
 
-            Spacer(modifier = Modifier.height(28.dp))
+            Spacer(modifier = Modifier.height(25.dp))
 
-            Text(
-                text = "참가자 조회하기",
-                style = typography.bodyBold2,
-                color = colors.black,
-                modifier = Modifier.padding(start = 16.dp)
-            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.expoClickable { isDropdownExpanded = true }
+            ) {
+                Text(
+                    text = participantTextState,
+                    style = typography.bodyBold2,
+                    color = colors.black,
+                    modifier = Modifier.padding(start = 16.dp)
+                )
+
+                if (isDropdownExpanded) {
+                    UpArrowIcon(
+                        tint = colors.black,
+                        modifier = Modifier.padding(start = 10.dp)
+                    )
+                } else {
+                    DownArrowIcon(
+                        tint = colors.black,
+                        modifier = Modifier.padding(start = 10.dp)
+                    )
+                }
+            }
+
+            Box(modifier = Modifier.padding(start = 16.dp, top = 10.dp)) {
+                if (isDropdownExpanded) {
+                    ProgramDetailParticipantDropdownMenu(
+                        onCancelClick = { isDropdownExpanded = false },
+                        onExpandClick = isDropdownExpanded,
+                        selectedItem = selectedItem,
+                        onItemSelected = { index ->
+                            selectedItem = index
+                            isDropdownExpanded = false
+
+                            participantTextState = when (index) {
+                                0 -> "사전 행사 참가자"
+                                1 -> "현장 행사 참가자"
+                                2 -> "사전 교원 원수 참가자"
+                                else -> participantTextState
+                            }
+                        },
+                    )
+                }
+            }
 
             Spacer(modifier = Modifier.height(12.dp))
 
@@ -108,7 +200,6 @@ private fun ProgramDetailParticipantManagementScreen(
 
                 Spacer(
                     modifier = Modifier
-                        .padding(0.dp)
                         .width(1.dp)
                         .height(14.dp)
                         .background(color = colors.gray100)
@@ -123,88 +214,222 @@ private fun ProgramDetailParticipantManagementScreen(
                         color = colors.gray500
                     )
 
-                    Text(
-                        text = "${participantManagementData.size}명",
-                        style = typography.captionRegular2,
-                        color = colors.main
-                    )
+                    when (selectedItem) {
+                        0 -> {
+                            when (participantAheadResponseListUiState) {
+                                is ParticipantResponseListUiState.Loading -> {
+                                    Text(
+                                        text = "로딩중..",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is ParticipantResponseListUiState.Success -> {
+                                    Text(
+                                        text = "${participantAheadResponseListUiState.data.size}명",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is ParticipantResponseListUiState.Error -> {
+                                    Text(
+                                        text = "데이터를 불러올 수 없습니다..",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is ParticipantResponseListUiState.Empty -> {
+                                    Text(
+                                        text = "0명",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                            }
+                        }
+
+                        1 -> {
+                            when (participantFieldResponseListUiState) {
+                                is ParticipantResponseListUiState.Loading -> {
+                                    Text(
+                                        text = "로딩중..",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is ParticipantResponseListUiState.Success -> {
+                                    Text(
+                                        text = "${participantFieldResponseListUiState.data.size}명",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is ParticipantResponseListUiState.Error -> {
+                                    Text(
+                                        text = "데이터를 불러올 수 없습니다..",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is ParticipantResponseListUiState.Empty -> {
+                                    Text(
+                                        text = "0명",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                            }
+                        }
+
+                        2 -> {
+                            when (traineeInformationUiState) {
+                                is TraineeResponseListUiState.Loading -> {
+                                    Text(
+                                        text = "로딩중..",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is TraineeResponseListUiState.Success -> {
+                                    Text(
+                                        text = "${traineeInformationUiState.data.size}명",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is TraineeResponseListUiState.Error -> {
+                                    Text(
+                                        text = "데이터를 불러올 수 없습니다..",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                                is TraineeResponseListUiState.Empty -> {
+                                    Text(
+                                        text = "0명",
+                                        style = typography.captionRegular2,
+                                        color = colors.main
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Box(
-                modifier = Modifier
-                    .border(
-                        width = 1.dp,
-                        color = colors.gray200
+            SwipeRefresh(
+                state = swipeRefreshState,
+                onRefresh = {
+                    when (selectedItem) {
+                        0 -> getAheadParticipantList()
+                        1 -> getFieldParticipantList()
+                        2 -> getTraineeList()
+                    }
+                },
+                indicator = { state, refreshTrigger ->
+                    SwipeRefreshIndicator(
+                        state = state,
+                        refreshTriggerDistance = refreshTrigger,
+                        contentColor = colors.main
                     )
-                    .fillMaxWidth()
-                    .padding(
-                        vertical = 16.dp
-                    )
+                }
             ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 16.dp)
-                        .horizontalScroll(rememberScrollState()),
-                    horizontalArrangement = Arrangement.spacedBy(20.dp)
-                ) {
-                    Spacer(modifier = Modifier.width(20.dp))
+                when (selectedItem) {
+                    0 -> {
+                        when (participantAheadResponseListUiState) {
+                            is ParticipantResponseListUiState.Loading -> Unit
+                            is ParticipantResponseListUiState.Success -> {
 
-                    Text(
-                        text = "성명",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(80.dp)
-                    )
+                                Column {
 
-                    Text(
-                        text = "소속",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(100.dp)
-                    )
+                                    Spacer(modifier = Modifier.height(24.dp))
 
-                    Text(
-                        text = "직급",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(80.dp)
-                    )
+                                    ProgramDetailParticipantTable(scrollState = scrollState)
 
-                    Text(
-                        text = "프로그램 선택",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(120.dp)
-                    )
+                                    ProgramDetailParticipantManagementList(
+                                        scrollState = scrollState,
+                                        item = participantAheadResponseListUiState.data.toImmutableList()
+                                    )
+                                }
+                            }
+                            is ParticipantResponseListUiState.Error -> {
+                                ShowErrorState(
+                                    errorText = "사전 행사 참가자를 불러올 수 없습니다..",
+                                    scrollState = scrollState
+                                )
+                            }
+                            is ParticipantResponseListUiState.Empty -> {
+                                ShowEmptyState(
+                                    emptyMessage = "사전 행사 참가자가 존재하지 않습니다..",
+                                    scrollState = scrollState
+                                )
+                            }
+                        }
+                    }
 
-                    Text(
-                        text = "출석 여부",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(100.dp)
-                    )
+                    1 -> {
+                        when (participantFieldResponseListUiState) {
+                            is ParticipantResponseListUiState.Loading -> Unit
+                            is ParticipantResponseListUiState.Success -> {
+                                Column {
 
-                    Text(
-                        text = "입실시간",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(80.dp)
-                    )
+                                    Spacer(modifier = Modifier.height(24.dp))
 
-                    Text(
-                        text = "퇴실시간",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(80.dp)
-                    )
+                                    ProgramDetailParticipantTable(scrollState = scrollState)
+
+                                    ProgramDetailParticipantManagementList(
+                                        scrollState = scrollState,
+                                        item = participantFieldResponseListUiState.data.toImmutableList()
+                                    )
+                                }
+                            }
+                            is ParticipantResponseListUiState.Error -> {
+                                ShowErrorState(
+                                    errorText = "현장 행사 참가자를 불러올 수 없습니다..",
+                                    scrollState = scrollState
+                                )
+                            }
+                            is ParticipantResponseListUiState.Empty -> {
+                                ShowEmptyState(
+                                    emptyMessage = "현장 행사 참가자가 존재하지 않습니다..",
+                                    scrollState = scrollState
+                                )
+                            }
+                        }
+                    }
+
+                    2 -> {
+                        when (traineeInformationUiState) {
+                            is TraineeResponseListUiState.Loading -> Unit
+                            is TraineeResponseListUiState.Success -> {
+                                Column {
+
+                                    Spacer(modifier = Modifier.height(24.dp))
+
+                                    ProgramTraineeTable(scrollState = scrollState)
+
+                                    ProgramTraineeList(
+                                        scrollState = scrollState,
+                                        item = traineeInformationUiState.data.toImmutableList()
+                                    )
+                                }
+                            }
+                            is TraineeResponseListUiState.Error -> {
+                                ShowErrorState(
+                                    errorText = "사전 교원 원수를 불러올 수 없습니다..",
+                                    scrollState = scrollState
+                                )
+                            }
+                            is TraineeResponseListUiState.Empty -> {
+                                ShowEmptyState(
+                                    emptyMessage = "사전 교원 원수가 존재하지 않습니다..",
+                                    scrollState = scrollState
+                                )
+                            }
+                        }
+                    }
                 }
             }
-
-            ProgramDetailParticipantManagementList(item = participantManagementData)
         }
     }
 }
@@ -214,6 +439,12 @@ private fun ProgramDetailParticipantManagementScreen(
 private fun HomeDetailParticipantManagementScreenPreview() {
     ProgramDetailParticipantManagementScreen(
         onBackClick = {},
-        participantManagementData = generateParticipantManagementSampleData()
+        swipeRefreshState = rememberSwipeRefreshState(isRefreshing = false),
+        participantAheadResponseListUiState = ParticipantResponseListUiState.Loading,
+        participantFieldResponseListUiState = ParticipantResponseListUiState.Loading,
+        traineeInformationUiState = TraineeResponseListUiState.Loading,
+        getAheadParticipantList = {},
+        getFieldParticipantList = {},
+        getTraineeList = {}
     )
 }

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailProgramScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailProgramScreen.kt
@@ -169,10 +169,7 @@ private fun ProgramDetailProgramScreen(
                         width = 1.dp,
                         color = colors.white
                     )
-                    .padding(
-                        horizontal = 16.dp,
-                        vertical = 16.dp
-                    )
+                    .padding(all = 16.dp)
                     .horizontalScroll(scrollState)
             ) {
 

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParicipantTable.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParicipantTable.kt
@@ -1,0 +1,87 @@
+package com.school_of_company.program.view.component
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidthIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+internal fun ProgramDetailParticipantTable(
+    modifier: Modifier = Modifier,
+    scrollState: ScrollState
+) {
+    ExpoAndroidTheme { colors, typography ->
+
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(color = colors.gray200)
+        )
+
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp)
+                    .horizontalScroll(scrollState),
+                horizontalArrangement = Arrangement.spacedBy(44.dp)
+            ) {
+                Spacer(modifier = Modifier.width(20.dp))
+
+                Text(
+                    text = "성명",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(80.dp)
+                )
+
+                Text(
+                    text = "안내문자 발송용 연락처",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(130.dp)
+                )
+
+                Text(
+                    text = "개인정보 동의 제공 동의",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(150.dp)
+                )
+            }
+        }
+
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(color = colors.gray100)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ProgramDetailParticipantTablePreview() {
+    ProgramDetailParticipantTable(scrollState = rememberScrollState())
+}

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantDropdownMenu.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantDropdownMenu.kt
@@ -1,0 +1,60 @@
+package com.school_of_company.program.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+internal fun ProgramDetailParticipantDropdownMenu(
+    modifier: Modifier = Modifier,
+    onCancelClick: () -> Unit,
+    onExpandClick: Boolean,
+    selectedItem: Int?,
+    onItemSelected: (Int) -> Unit
+) {
+    ExpoAndroidTheme { colors, typography ->
+
+        DropdownMenu(
+            expanded = onExpandClick,
+            onDismissRequest = { onCancelClick() },
+            modifier = modifier.background(color = colors.white)
+        ) {
+
+            val menuItems = listOf("사전 행사 참가자", "현장 행사 참가자", "사전 교원 원수 참가자")
+
+            menuItems.forEachIndexed { index, title ->
+                DropdownMenuItem(
+                    text = {
+                        Text(
+                            text = title,
+                            style = typography.bodyRegular2,
+                            color = if (selectedItem == index) colors.main else colors.gray500,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    },
+                    onClick = {
+                        onItemSelected(index)
+                    },
+                    modifier = Modifier
+                        .padding(horizontal = 8.dp)
+                        .fillMaxWidth()
+                        .background(
+                            if (selectedItem == index) colors.main100 else colors.white,
+                            shape = RoundedCornerShape(size = 6.dp)
+                        )
+                )
+            }
+        }
+    }
+}

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramListItem.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramListItem.kt
@@ -88,16 +88,12 @@ internal fun ProgramListItem(
                 if (data.category == "ESSENTIAL") {
                     CircleIcon(
                         tint = colors.black,
-                        modifier = Modifier
-                            .size(16.dp)
-                            .width(25.dp)
+                        modifier = Modifier.size(16.dp)
                     )
                 } else {
                     XIcon(
                         tint = colors.error,
-                        modifier = Modifier
-                            .size(16.dp)
-                            .width(25.dp)
+                        modifier = Modifier.size(16.dp)
                     )
                 }
             }

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeList.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeList.kt
@@ -6,20 +6,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
-import com.school_of_company.model.entity.participant.ParticipantInformationResponseEntity
+import com.school_of_company.model.entity.trainee.TraineeResponseEntity
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
-internal fun ProgramDetailParticipantManagementList(
+internal fun ProgramTraineeList(
     modifier: Modifier = Modifier,
-    item: ImmutableList<ParticipantInformationResponseEntity> = persistentListOf(),
+    item: ImmutableList<TraineeResponseEntity> = persistentListOf(),
     scrollState: ScrollState
 ) {
     ExpoAndroidTheme { colors, _ ->
@@ -31,21 +29,12 @@ internal fun ProgramDetailParticipantManagementList(
                 .padding(start = 16.dp)
         ) {
             itemsIndexed(item) { index, item ->
-                ProgramDetailParticipantManagementListItem(
-                    index = index + 1,
+                ProgramTraineeListItem(
+                    index = index,
                     data = item,
                     horizontalScrollState = scrollState
                 )
             }
         }
     }
-}
-
-@Preview
-@Composable
-private fun HomeDetailParticipantManagementListPreview() {
-    ProgramDetailParticipantManagementList(
-        item = persistentListOf(),
-        scrollState = rememberScrollState()
-    )
 }

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeListItem.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeListItem.kt
@@ -3,32 +3,26 @@ package com.school_of_company.program.view.component
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidthIn
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.school_of_company.design_system.icon.CircleIcon
-import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
-import com.school_of_company.model.entity.participant.ParticipantInformationResponseEntity
+import com.school_of_company.model.entity.trainee.TraineeResponseEntity
 
 @Composable
-internal fun ProgramDetailParticipantManagementListItem(
+internal fun ProgramTraineeListItem(
     modifier: Modifier = Modifier,
     index: Int,
-    data: ParticipantInformationResponseEntity,
-    horizontalScrollState: ScrollState,
+    data: TraineeResponseEntity,
+    horizontalScrollState: ScrollState
 ) {
     Spacer(modifier = Modifier.height(20.dp))
 
@@ -58,43 +52,25 @@ internal fun ProgramDetailParticipantManagementListItem(
             )
 
             Text(
-                text = data.phoneNumber,
+                text = data.trainingId,
                 style = typography.captionRegular2,
                 color = colors.black,
                 modifier = Modifier.requiredWidthIn(130.dp)
             )
 
-            Box(
-                modifier = Modifier.requiredWidthIn(166.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                if (data.informationStatus) {
-                    CircleIcon(
-                        tint = colors.black,
-                        modifier = Modifier.size(16.dp)
-                    )
-                } else {
-                    XIcon(
-                        tint = colors.error,
-                        modifier = Modifier.size(16.dp)
-                    )
-                }
-            }
+            Text(
+                text = if (data.applicationType == "FIELD") "현장 신청" else "사전 신청",
+                style = typography.captionRegular2,
+                color = colors.black,
+                modifier = Modifier.requiredWidthIn(100.dp)
+            )
+
+            Text(
+                text = data.phoneNumber,
+                style = typography.captionRegular2,
+                color = colors.black,
+                modifier = Modifier.requiredWidthIn(130.dp)
+            )
         }
     }
-}
-
-@Preview
-@Composable
-private fun HomeDetailParticipantManagementListItemPreview() {
-    ProgramDetailParticipantManagementListItem(
-        index = 1,
-        data = ParticipantInformationResponseEntity(
-            name = "이명훈",
-            id = 0,
-            phoneNumber = "01038251716",
-            informationStatus = true,
-        ),
-        horizontalScrollState = rememberScrollState()
-    )
 }

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeTable.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeTable.kt
@@ -1,0 +1,86 @@
+package com.school_of_company.program.view.component
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidthIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+internal fun ProgramTraineeTable(
+    modifier: Modifier = Modifier,
+    scrollState: ScrollState
+) {
+    ExpoAndroidTheme { colors, typography ->
+
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(color = colors.gray200)
+        )
+
+        Box(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 16.dp)
+                    .horizontalScroll(scrollState),
+                horizontalArrangement = Arrangement.spacedBy(44.dp)
+            ) {
+                Spacer(modifier = Modifier.width(20.dp))
+
+                Text(
+                    text = "성명",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(80.dp)
+                )
+
+                Text(
+                    text = "연수원 아이디",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(130.dp)
+                )
+
+                Text(
+                    text = "신청 방법",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(100.dp)
+                )
+
+                Text(
+                    text = "휴대폰 번호",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(130.dp)
+                )
+            }
+        }
+
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(1.dp)
+                .background(color = colors.gray100)
+        )
+    }
+}

--- a/feature/user/src/main/java/com/school_of_company/user/view/UserScreen.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/UserScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.swiperefresh.SwipeRefresh
@@ -47,6 +48,7 @@ import com.school_of_company.user.view.component.SignUpRequestList
 import com.school_of_company.user.view.component.UserAllowButton
 import com.school_of_company.user.view.component.UserBottomSheet
 import com.school_of_company.user.view.component.UserDeleteButton
+import com.school_of_company.user.view.component.UserDialog
 import com.school_of_company.user.viewmodel.UserViewModel
 import com.school_of_company.user.viewmodel.uistate.AllowAdminRequestUiState
 import com.school_of_company.user.viewmodel.uistate.GetAdminRequestAllowListUiState
@@ -139,6 +141,8 @@ private fun UserScreen(
 ) {
     val (selectedId, setSelectedId) = rememberSaveable { mutableLongStateOf(0L) }
     val (openBottomSheet, isOpenBottomSheet) = rememberSaveable { mutableStateOf(false) }
+    val (openLogoutDialog, isOpenLogoutDialog) = rememberSaveable { mutableStateOf(false) }
+    val (openWithdrawDialog, isOpenWithdrawDialog) = rememberSaveable { mutableStateOf(false) }
 
     ExpoAndroidTheme { colors, typography ->
         Column(
@@ -443,15 +447,47 @@ private fun UserScreen(
     if (openBottomSheet) {
         UserBottomSheet(
             onLogoutClick = {
-                logoutCallBack()
                 isOpenBottomSheet(false)
+                isOpenLogoutDialog(true)
             },
             onWithdrawClick = {
-                withdrawalCallBack()
                 isOpenBottomSheet(false)
+                isOpenWithdrawDialog(true)
             },
             onCancelClick = { isOpenBottomSheet(false) }
         )
+    }
+
+    if (openLogoutDialog) {
+        Dialog(onDismissRequest = { isOpenLogoutDialog(false) }) {
+
+            UserDialog(
+                titleText = "정말로 로그아웃 하시겠습니까?",
+                contentText = "로그아웃 했을 경우 다시 로그인 해야하는 경우가 발생합니다.",
+                buttonText = "로그아웃",
+                onConfirmClick = {
+                    logoutCallBack()
+                    isOpenLogoutDialog(false)
+                },
+                onCancelClick = { isOpenLogoutDialog(false) }
+            )
+        }
+    }
+
+    if (openWithdrawDialog) {
+        Dialog(onDismissRequest = { isOpenWithdrawDialog(false) }) {
+
+            UserDialog(
+                titleText = "정말로 탈퇴하기 하시겠습니까?",
+                contentText = "탈퇴하기 했을 경우 다시 로그인 해야하는 경우가 발생합니다",
+                buttonText = "탈퇴하기",
+                onConfirmClick = {
+                    withdrawalCallBack()
+                    isOpenWithdrawDialog(false)
+                },
+                onCancelClick = { isOpenWithdrawDialog(false) }
+            )
+        }
     }
 }
 

--- a/feature/user/src/main/java/com/school_of_company/user/view/component/UserDialog.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/component/UserDialog.kt
@@ -1,0 +1,104 @@
+package com.school_of_company.user.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.component.button.ExpoEnableButton
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+internal fun UserDialog(
+    modifier: Modifier = Modifier,
+    onCancelClick: () -> Unit,
+    onConfirmClick: () -> Unit,
+    titleText: String,
+    contentText: String,
+    buttonText: String
+) {
+
+    ExpoAndroidTheme { colors, typography ->
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(40.dp, Alignment.Top),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = modifier
+                .background(
+                    colors.white,
+                    shape = RoundedCornerShape(6.dp)
+                )
+                .padding(all = 26.dp)
+        ) {
+            Column(
+                horizontalAlignment = Alignment.Start,
+                verticalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterVertically)
+            ) {
+
+                Text(
+                    text = titleText,
+                    color = colors.black,
+                    style = typography.titleBold3,
+                )
+
+                Text(
+                    text = contentText,
+                    color = colors.gray500,
+                    style = typography.bodyRegular2
+                )
+            }
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically)
+            ) {
+
+                ExpoEnableButton(
+                    text = buttonText,
+                    onClick = onConfirmClick,
+                    textColor = colors.error,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .border(
+                            width = 1.dp,
+                            color = colors.error,
+                            shape = RoundedCornerShape(6.dp)
+                        )
+                )
+
+                ExpoEnableButton(
+                    text = "취소",
+                    onClick = onCancelClick,
+                    textColor = colors.gray700,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .border(
+                            width = 1.dp,
+                            color = colors.gray700,
+                            shape = RoundedCornerShape(6.dp)
+                        )
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun UserDialogPreview() {
+    UserDialog(
+        onCancelClick = { /*TODO*/ },
+        onConfirmClick = { /*TODO*/ },
+        titleText = "정말로 로그아웃 하시겠습니까?",
+        contentText = "로그아웃 했을 경우 다시 로그인 해야하는 경우가 발생합니다",
+        buttonText = "로그아웃"
+    )
+}

--- a/feature/user/src/main/java/com/school_of_company/user/view/component/UserDialog.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/component/UserDialog.kt
@@ -61,10 +61,13 @@ internal fun UserDialog(
                 verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically)
             ) {
 
-                ExpoEnableButton(
+                UserEffectButton(
                     text = buttonText,
                     onClick = onConfirmClick,
-                    textColor = colors.error,
+                    defaultTextColor = colors.error,
+                    defaultBackgroundColor = colors.white,
+                    clickedTextColor = colors.white,
+                    clickedBackgroundColor = colors.error,
                     modifier = Modifier
                         .fillMaxWidth()
                         .border(
@@ -74,10 +77,13 @@ internal fun UserDialog(
                         )
                 )
 
-                ExpoEnableButton(
+                UserEffectButton(
                     text = "취소",
                     onClick = onCancelClick,
-                    textColor = colors.gray700,
+                    defaultTextColor = colors.gray700,
+                    defaultBackgroundColor = colors.white,
+                    clickedTextColor = colors.white,
+                    clickedBackgroundColor = colors.gray700,
                     modifier = Modifier
                         .fillMaxWidth()
                         .border(

--- a/feature/user/src/main/java/com/school_of_company/user/view/component/UserEffectButton.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/component/UserEffectButton.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -15,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import kotlinx.coroutines.delay
 
 @Composable
 fun UserEffectButton(
@@ -26,10 +28,15 @@ fun UserEffectButton(
     clickedBackgroundColor: Color = Color.Red,
     onClick: () -> Unit,
 ) {
-    ExpoAndroidTheme { colors, typography ->
+    ExpoAndroidTheme { _, typography ->
 
         val interactionSource = remember { MutableInteractionSource() }
         var isClicked by remember { mutableStateOf(false) }
+
+        LaunchedEffect(isClicked) {
+            delay(1000)
+            isClicked = false
+        }
 
         Button(
             modifier = modifier,

--- a/feature/user/src/main/java/com/school_of_company/user/view/component/UserEffectButton.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/component/UserEffectButton.kt
@@ -34,7 +34,7 @@ fun UserEffectButton(
         var isClicked by remember { mutableStateOf(false) }
 
         LaunchedEffect(isClicked) {
-            delay(1000)
+            delay(500)
             isClicked = false
         }
 

--- a/feature/user/src/main/java/com/school_of_company/user/view/component/UserEffectButton.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/component/UserEffectButton.kt
@@ -1,0 +1,55 @@
+package com.school_of_company.user.view.component
+
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+fun UserEffectButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    defaultTextColor: Color = Color.Black,
+    defaultBackgroundColor: Color = Color.White,
+    clickedTextColor: Color = Color.White,
+    clickedBackgroundColor: Color = Color.Red,
+    onClick: () -> Unit,
+) {
+    ExpoAndroidTheme { colors, typography ->
+
+        val interactionSource = remember { MutableInteractionSource() }
+        var isClicked by remember { mutableStateOf(false) }
+
+        Button(
+            modifier = modifier,
+            interactionSource = interactionSource,
+            contentPadding = PaddingValues(vertical = 16.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = if (isClicked) clickedBackgroundColor else defaultBackgroundColor,
+                contentColor = if (isClicked) clickedTextColor else defaultTextColor,
+            ),
+            shape = RoundedCornerShape(6.dp),
+            onClick = {
+                isClicked = true
+                onClick()
+            },
+        ) {
+            Text(
+                text = text,
+                style = typography.bodyBold2,
+                color = if (isClicked) clickedTextColor else defaultTextColor
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 💡 개요
- 로그아웃, 탈퇴하기 버튼을 누르면 바로 로그아웃 및 탈퇴가 되어버려 사용자 입장에서는 조금은 불편한 상황이 나올 수 있도 있다고 생각했습니다.
## 📃 작업내용
- 유저 스크린에서 로그아웃, 탈퇴하기를 눌렀을때 바로 통신이 되는 것이 아닌 팝을 띄워 다시 물어볼 수 있도록 수정하였습니다.
   - UserDialog 제작   
   - 추가로 navigationPopUpToLogin() 함수를 사용하였기때문에 로그아웃하고 로그인 화면으로 네비게이션시 백스택이 남지 않습니다.
 
   https://github.com/user-attachments/assets/5a47fa04-356e-4fa5-82ab-d163b261496c

## 🔀 변경사항
![스크린샷 2025-01-18 오후 10 28 43](https://github.com/user-attachments/assets/0e479dbd-dcfe-49f9-a32f-3e62ab5dd337)

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 버튼 텍스트 색상 사용자 정의 기능 추가
	- 로그아웃 및 회원 탈퇴 확인 대화상자 도입
	- 참가자 관리 화면의 실시간 데이터 표시 기능 개선
	- 참가자 카테고리 선택을 위한 드롭다운 메뉴 추가
	- 교육생 목록 및 테이블 구성 요소 추가
	- 사용자 효과 버튼 추가

- **버그 수정**
	- 사용자 액션 실수 방지를 위한 확인 대화상자 구현

- **사용자 경험 개선**
	- 버튼 텍스트 색상 동적 설정 지원
	- 중요한 작업 전 사용자 확인 절차 추가
	- 참가자 관리 화면의 UI 반응성 및 상호작용 개선
	- 아이콘 렌더링 개선
	- 프로그램 세부정보 화면의 패딩 통일성 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->