### PR TITLE
🔀 :: (#325) - 바텀시트를 사용하는 부분에서 상태 호이스팅을 할 수 있도록 마이그레이션을 하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -212,6 +213,7 @@ internal fun ExpoCreateRoute(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ExpoCreateScreen(
     modifier: Modifier = Modifier,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -269,6 +270,7 @@ internal fun ExpoModifyRoute(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ExpoModifyScreen(
     modifier: Modifier = Modifier,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -65,6 +66,7 @@ internal fun ExpoRoute(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ExpoScreen(
     modifier: Modifier = Modifier,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoBottomSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.ripple
@@ -31,9 +32,9 @@ internal fun HomeBottomSheet(
     modifier: Modifier = Modifier,
     onRecentClick: () -> Unit,
     onOldClick: () -> Unit,
-    onCancelClick: () -> Unit
+    onCancelClick: () -> Unit,
+    sheetState: SheetState = rememberModalBottomSheetState()
 ) {
-    val sheetState = rememberModalBottomSheetState()
 
     ExpoAndroidTheme { colors, _ ->
 
@@ -109,12 +110,13 @@ private fun HomeBottomSheetOptions(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
 private fun HomeBottomSheetPreview() {
     HomeBottomSheet(
         onRecentClick = {},
         onOldClick = {},
-        onCancelClick = {}
+        onCancelClick = {},
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -60,9 +61,9 @@ internal fun ExpoSettingBottomSheet(
     onTrainingSettingChange: (TrainingDtoModel) -> Unit,
     onButtonClick: () -> Unit,
     focusManager: FocusManager = LocalFocusManager.current,
-    isTraining: Boolean = true
+    isTraining: Boolean = true,
+    sheetState: SheetState = rememberModalBottomSheetState()
 ) {
-    val sheetState = rememberModalBottomSheetState()
     var currentItem by remember { mutableStateOf(trainingSettingItem) }
 
     ExpoAndroidTheme { colors, typography ->
@@ -244,6 +245,7 @@ fun CustomCheckBox(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
 private fun ExpoTrainingSettingBottomSheetPreview() {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -44,8 +45,8 @@ internal fun ExpoStandardSettingBottomSheet(
     onTrainingSettingChange: (StandardRequestModel) -> Unit,
     onButtonClick: () -> Unit,
     focusManager: FocusManager = LocalFocusManager.current,
+    sheetState: SheetState = rememberModalBottomSheetState()
 ) {
-    val sheetState = rememberModalBottomSheetState()
     var currentItem by remember { mutableStateOf(trainingSettingItem) }
 
     ExpoAndroidTheme { colors, typography ->
@@ -150,6 +151,7 @@ internal fun ExpoStandardSettingBottomSheet(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
 private fun ExpoStandardSettingBottomSheetPreview() {

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeList.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeList.kt
@@ -30,7 +30,7 @@ internal fun ProgramTraineeList(
         ) {
             itemsIndexed(item) { index, item ->
                 ProgramTraineeListItem(
-                    index = index,
+                    index = index + 1,
                     data = item,
                     horizontalScrollState = scrollState
                 )

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeListItem.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeListItem.kt
@@ -3,6 +3,7 @@ package com.school_of_company.program.view.component
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.entity.trainee.TraineeResponseEntity
@@ -59,18 +61,22 @@ internal fun ProgramTraineeListItem(
             )
 
             Text(
-                text = if (data.applicationType == "FIELD") "현장 신청" else "사전 신청",
-                style = typography.captionRegular2,
-                color = colors.black,
-                modifier = Modifier.requiredWidthIn(100.dp)
-            )
-
-            Text(
                 text = data.phoneNumber,
                 style = typography.captionRegular2,
                 color = colors.black,
                 modifier = Modifier.requiredWidthIn(130.dp)
             )
+
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier.requiredWidthIn(116.dp)
+            ) {
+                Text(
+                    text = if (data.applicationType == "FIELD") "현장" else "사전",
+                    style = typography.captionRegular2,
+                    color = colors.black,
+                )
+            }
         }
     }
 }

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeTable.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeTable.kt
@@ -61,17 +61,17 @@ internal fun ProgramTraineeTable(
                 )
 
                 Text(
-                    text = "신청 방법",
-                    style = typography.captionBold1,
-                    color = colors.gray600,
-                    modifier = Modifier.requiredWidthIn(100.dp)
-                )
-
-                Text(
                     text = "휴대폰 번호",
                     style = typography.captionBold1,
                     color = colors.gray600,
                     modifier = Modifier.requiredWidthIn(130.dp)
+                )
+
+                Text(
+                    text = "현장 및 사전",
+                    style = typography.captionBold1,
+                    color = colors.gray600,
+                    modifier = Modifier.requiredWidthIn(100.dp)
                 )
             }
         }

--- a/feature/user/src/main/java/com/school_of_company/user/view/UserScreen.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/UserScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -126,6 +127,7 @@ internal fun UserRoute(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun UserScreen(
     modifier: Modifier = Modifier,
@@ -489,9 +491,4 @@ private fun UserScreen(
             )
         }
     }
-}
-
-@Preview
-@Composable
-private fun UserScreenPreview() {
 }

--- a/feature/user/src/main/java/com/school_of_company/user/view/component/UserBottomSheet.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/component/UserBottomSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.ripple
@@ -30,9 +31,9 @@ internal fun UserBottomSheet(
     modifier: Modifier = Modifier,
     onLogoutClick: () -> Unit,
     onWithdrawClick: () -> Unit,
-    onCancelClick: () -> Unit
+    onCancelClick: () -> Unit,
+    sheetState: SheetState = rememberModalBottomSheetState()
 ) {
-    val sheetState = rememberModalBottomSheetState()
 
     ExpoAndroidTheme { colors, _ ->
 


### PR DESCRIPTION
## 💡 개요
- 프로젝트의 바텀시트의 코드에서 상태 호이스팅을 할 수 있도록 마이그레이션이 필요해보였습니다.
## 📃 작업내용
- 프로젝트의 바텀시트의 코드에서 sheetState를 상태 호이스팅하여 보다 상태관리를 효율적으로 할 수 있도록 마이그레이션 하였습니다.
   - sheetState가 UserBottomSheet 내부에서 관리되던 상태에서 호출하는 상위 컴포저블로 상태 관리가 옮겨지는 것 
   - before
     
     <img width="326" alt="스크린샷 2025-01-19 오전 1 42 10" src="https://github.com/user-attachments/assets/5fc8087a-2dbb-4344-ae1c-ce25f049a8cf" />

   - after
   
     <img width="312" alt="스크린샷 2025-01-19 오전 1 41 46" src="https://github.com/user-attachments/assets/7e27d7c0-f2c8-4cef-9cb3-86140ae3d6e5" />

## 🔀 변경사항
![스크린샷 2025-01-19 오전 1 41 07](https://github.com/user-attachments/assets/94a74972-076f-48d4-be88-9d0790e1eb48)

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **새로운 기능**
	- Material3 라이브러리의 실험적 API 사용을 위한 최적화 작업 수행
	- 다양한 화면 및 컴포넌트에서 하단 시트(Bottom Sheet) 상태 관리 기능 개선
	- 스크롤 상태 관리 기능 추가

- **개선 사항**
	- 사용자 화면의 스크롤 상태 제어 기능 향상
	- 컴포넌트 간 상태 관리의 유연성 증대
	- 프로그램 수강생 목록에서 인덱스 표시 방식 변경

- **기타**
	- 일부 미리보기(Preview) 기능 제거
	- 프로그램 수강생 목록 항목의 텍스트 표시 방식 변경
	- 프로그램 수강생 테이블의 텍스트 및 레이아웃 수정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->