### PR TITLE
🔀 :: (#368) - api latitude longitude update

### DIFF
--- a/core/model/src/main/java/com/school_of_company/model/model/expo/ExpoRequestAndResponseModel.kt
+++ b/core/model/src/main/java/com/school_of_company/model/model/expo/ExpoRequestAndResponseModel.kt
@@ -7,6 +7,6 @@ data class ExpoRequestAndResponseModel(
     val finishedDay: String, // yyyy-mm-dd
     val location: String,
     val coverImage: String?,
-    val x: Float,
-    val y: Float
+    val x: String,
+    val y: String
 )

--- a/core/model/src/main/java/com/school_of_company/model/param/expo/ExpoCreateRequestParam.kt
+++ b/core/model/src/main/java/com/school_of_company/model/param/expo/ExpoCreateRequestParam.kt
@@ -7,8 +7,8 @@ data class ExpoAllRequestParam(
     val finishedDay: String, // yyyy-mm-dd
     val location: String,
     val coverImage: String?,
-    val x: Float,
-    val y: Float,
+    val x: String,
+    val y: String,
     val addStandardProRequestDto: List<StandardProRequestParam>,
     val addTrainingProRequestDto: List<TrainingProRequestParam>,
 )

--- a/core/model/src/main/java/com/school_of_company/model/param/expo/ExpoModifyRequestParam.kt
+++ b/core/model/src/main/java/com/school_of_company/model/param/expo/ExpoModifyRequestParam.kt
@@ -7,8 +7,8 @@ data class ExpoModifyRequestParam(
     val finishedDay: String, // yyyy-mm-dd
     val location: String,
     val coverImage: String?,
-    val x: Float,
-    val y: Float,
+    val x: String,
+    val y: String,
     val updateStandardProRequestDto: List<StandardProIdRequestParam>,
     val updateTrainingProRequestDto: List<TrainingProIdRequestParam>,
 )

--- a/core/network/src/main/java/com/school_of_company/network/dto/expo/request/ExpoCreateRequest.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/expo/request/ExpoCreateRequest.kt
@@ -11,8 +11,8 @@ data class ExpoAllRequest(
     @Json(name = "finishedDay") val finishedDay: String, // yyyy-mm-dd
     @Json(name = "location") val location: String,
     @Json(name = "coverImage") val coverImage: String?,
-    @Json(name = "x") val x: Float,
-    @Json(name = "y") val y: Float,
+    @Json(name = "x") val x: String,
+    @Json(name = "y") val y: String,
     @Json(name = "addStandardProRequestDto") val addStandardProRequestDto: List<StandardProRequestDto>,
     @Json(name = "addTrainingProRequestDto") val addTrainingProRequestDto: List<TrainingProRequestDto>,
 )

--- a/core/network/src/main/java/com/school_of_company/network/dto/expo/request/ExpoModifyRequest.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/expo/request/ExpoModifyRequest.kt
@@ -11,8 +11,8 @@ data class ExpoModifyRequest(
     @Json(name = "finishedDay") val finishedDay: String, // yyyy-mm-dd
     @Json(name = "location") val location: String,
     @Json(name = "coverImage") val coverImage: String?,
-    @Json(name = "x") val x: Float,
-    @Json(name = "y") val y: Float,
+    @Json(name = "x") val x: String,
+    @Json(name = "y") val y: String,
     @Json(name = "updateStandardProRequestDto") val updateStandardProRequestDto: List<StandardProIdRequestDto>,
     @Json(name = "updateTrainingProRequestDto") val updateTrainingProRequestDto: List<TrainingProIdRequestDto>,
 )

--- a/core/network/src/main/java/com/school_of_company/network/dto/expo/response/ExpoResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/expo/response/ExpoResponse.kt
@@ -11,6 +11,6 @@ data class ExpoResponse(
     @Json(name = "finishedDay") val finishedDay: String, // yyyy-mm-dd
     @Json(name = "location") val location: String,
     @Json(name = "coverImage") val coverImage: String?,
-    @Json(name = "x") val x: Float,
-    @Json(name = "y") val y: Float
+    @Json(name = "x") val x: String,
+    @Json(name = "y") val y: String
 )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -132,8 +132,8 @@ internal fun ExpoCreateRoute(
                         description = viewModel.introduce_title.value,
                         location = viewModel.location.value,
                         coverImage = (imageUpLoadUiState as ImageUpLoadUiState.Success).data.imageURL,
-                        x = 37.511734f,
-                        y = 127.05905f,
+                        x = "37.511734",
+                        y = "127.05905",
                         addStandardProRequestDto = standardProgramTextState,
                         addTrainingProRequestDto = trainingProgramTextState
                     )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -143,8 +143,8 @@ internal fun ExpoModifyRoute(
                         description = viewModel.introduce_title.value,
                         location = viewModel.location.value,
                         coverImage = (imageUpLoadUiState as ImageUpLoadUiState.Success).data.imageURL,
-                        x = 37.511734f,
-                        y = 127.05905f,
+                        x = "37.511734",
+                        y = "127.05905",
                         updateStandardProRequestDto = standardProgramTextState,
                         updateTrainingProRequestDto = trainingProgramTextState
                     )


### PR DESCRIPTION
## 💡 개요
API에서 위도(latitude)와 경도(longitude) 값을 Float 타입에서 String 타입으로 변경하였습니다. 
이를 통해 위도 및 경도의 표현 범위 및 정밀도를 보완하였습니다.

## 🔀 변경사항
- 위도와 경도의 타입 변경으로 인해 총 16줄 

## 🍴 사용방법
 위도와 경도 값 전달 시 기존 Float가 아닌 String 타입으로 전달해야 합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **변경 사항**
	- 엑스포 관련 모델, 요청, 응답 클래스의 `x`와 `y` 속성 타입을 `Float`에서 `String`으로 변경
	- 엑스포 생성 및 수정 화면에서 좌표 값을 문자열로 처리하도록 업데이트
	- 좌표 데이터 표현 방식 변경으로 인한 전반적인 데이터 처리 로직 수정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->