### PR TITLE
🔀 :: (#381) - 등록된 박람회 부분에서 리스트가 fillMaxHeight의 상태가 되면 버튼의 Ui가 뭉개져 사라지는 문제를 해결하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -137,19 +138,16 @@ private fun ExpoCreatedScreen(
                     when (getExpoListUiState) {
                         is GetExpoListUiState.Loading -> Unit
                         is GetExpoListUiState.Success -> {
-                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally,) {
                                 CreatedExpoList(
                                     selectedIndex = selectedIndex,
-                                    scrollState = scrollState,
                                     expoList = getExpoListUiState.data.toPersistentList(),
+                                    scrollState = scrollState,
                                     onItemClick = { isSelected, index ->
                                         setSelectedIndex(if (isSelected) -1 else index)
                                     },
-                                )
-                                Spacer(modifier = Modifier.height(32.dp))
-                                ExpoCreatedDeleteButton(
-                                    enabled = selectedIndex != -1,
-                                    onClick = { deleteSelectedExpo(selectedIndex) }
+                                    deleteSelectedExpo = deleteSelectedExpo,
+                                    enbaled = selectedIndex != -1
                                 )
                             }
                         }
@@ -195,7 +193,39 @@ private fun ExpoCreatedScreenPreview() {
                     startedDay = "2024-11-23",
                     finishedDay = "2024-11-23",
                     coverImage = null,
-                )
+                ),
+                ExpoListResponseEntity(
+                    id = "2",
+                    title = "제목",
+                    description = "묘사",
+                    startedDay = "2024-11-23",
+                    finishedDay = "2024-11-23",
+                    coverImage = null,
+                ),
+                ExpoListResponseEntity(
+                    id = "2",
+                    title = "제목",
+                    description = "묘사",
+                    startedDay = "2024-11-23",
+                    finishedDay = "2024-11-23",
+                    coverImage = null,
+                ),
+                ExpoListResponseEntity(
+                    id = "2",
+                    title = "제목",
+                    description = "묘사",
+                    startedDay = "2024-11-23",
+                    finishedDay = "2024-11-23",
+                    coverImage = null,
+                ),
+                ExpoListResponseEntity(
+                    id = "2",
+                    title = "제목",
+                    description = "묘사",
+                    startedDay = "2024-11-23",
+                    finishedDay = "2024-11-23",
+                    coverImage = null,
+                ),
             )
         ),
         expoListSize = 100,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -24,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
 import com.google.accompanist.swiperefresh.SwipeRefreshState
@@ -60,6 +62,12 @@ internal fun ExpoCreatedRoute(
 
     LaunchedEffect("initCreatedExpo") {
         expoViewModel.getExpoList()
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            expoViewModel.resetDeleteExpoInformationState()
+        }
     }
 
     LaunchedEffect(deleteExpoInformationUiState) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -25,7 +24,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.google.accompanist.swiperefresh.SwipeRefresh
 import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
 import com.google.accompanist.swiperefresh.SwipeRefreshState
@@ -34,7 +32,6 @@ import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.uistate.empty.ShowEmptyState
 import com.school_of_company.design_system.component.uistate.error.ShowErrorState
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
-import com.school_of_company.expo.view.component.ExpoCreatedDeleteButton
 import com.school_of_company.expo.view.component.ExpoCreatedTable
 import com.school_of_company.expo.view.component.ExpoCreatedTopCard
 import com.school_of_company.expo.viewmodel.ExpoViewModel
@@ -155,7 +152,7 @@ private fun ExpoCreatedScreen(
                                         setSelectedIndex(if (isSelected) -1 else index)
                                     },
                                     deleteSelectedExpo = deleteSelectedExpo,
-                                    enbaled = selectedIndex != -1
+                                    enabled = selectedIndex != -1
                                 )
                             }
                         }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
@@ -21,11 +21,11 @@ import kotlinx.collections.immutable.persistentListOf
 internal fun CreatedExpoList(
     modifier: Modifier = Modifier,
     scrollState: ScrollState,
+    enabled: Boolean,
     selectedIndex: Int,
     expoList: ImmutableList<ExpoListResponseEntity>,
-    onItemClick: (Boolean, Int) -> Unit,
-    enabled: Boolean,
     deleteSelectedExpo: (Int) -> Unit,
+    onItemClick: (Boolean, Int) -> Unit,
 ) {
     LazyColumn(
         modifier = modifier,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
@@ -24,7 +24,7 @@ internal fun CreatedExpoList(
     selectedIndex: Int,
     expoList: ImmutableList<ExpoListResponseEntity>,
     onItemClick: (Boolean, Int) -> Unit,
-    enbaled: Boolean,
+    enabled: Boolean,
     deleteSelectedExpo: (Int) -> Unit,
 ) {
     LazyColumn(
@@ -47,7 +47,7 @@ internal fun CreatedExpoList(
             Spacer(modifier = Modifier.height(12.dp))
 
             ExpoCreatedDeleteButton(
-                enabled = enbaled,
+                enabled = enabled,
                 onClick = { deleteSelectedExpo(selectedIndex) },
             )
 
@@ -74,6 +74,6 @@ fun CreatedExpoListPreview() {
         selectedIndex = 1,
         scrollState = ScrollState(1),
         deleteSelectedExpo = {},
-        enbaled = false
+        enabled = false
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoList.kt
@@ -1,13 +1,18 @@
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.expo.view.component.CreatedExpoListItem
+import com.school_of_company.expo.view.component.ExpoCreatedDeleteButton
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -19,10 +24,13 @@ internal fun CreatedExpoList(
     selectedIndex: Int,
     expoList: ImmutableList<ExpoListResponseEntity>,
     onItemClick: (Boolean, Int) -> Unit,
+    enbaled: Boolean,
+    deleteSelectedExpo: (Int) -> Unit,
 ) {
     LazyColumn(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(20.dp)
+        verticalArrangement = Arrangement.spacedBy(20.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         itemsIndexed(expoList) { index, item ->
             CreatedExpoListItem(
@@ -33,6 +41,17 @@ internal fun CreatedExpoList(
                 index = index,
                 onClick = { onItemClick(selectedIndex == index, index) }
             )
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(12.dp))
+
+            ExpoCreatedDeleteButton(
+                enabled = enbaled,
+                onClick = { deleteSelectedExpo(selectedIndex) },
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
         }
     }
 }
@@ -53,6 +72,8 @@ fun CreatedExpoListPreview() {
         ),
         onItemClick = { _, _ -> },
         selectedIndex = 1,
-        scrollState = ScrollState(1)
+        scrollState = ScrollState(1),
+        deleteSelectedExpo = {},
+        enbaled = false
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -262,6 +262,10 @@ internal class ExpoViewModel @Inject constructor(
             }
     }
 
+   internal fun resetDeleteExpoInformationState() {
+       _deleteExpoInformationUiState.value = DeleteExpoInformationUiState.Loading
+   }
+
     internal fun getExpoList() = viewModelScope.launch {
         _swipeRefreshLoading.value = true
         getExpoListUseCase()


### PR DESCRIPTION
## 💡 개요
- 등록된 박람회 부분에서 리스트가 fillMaxHeight의 상태가 되면 버튼의 Ui가 뭉개져 사라지는 문제를 해결할 필요가 있었습니다.
## 📃 작업내용
- 등록된 박람회 부분에서 리스트가 fillMaxHeight의 상태가 되면 버튼의 Ui가 뭉개져 사라지는 문제를 해결하였습니다.
   - 스크린단에서 UiState의 Success 상태에서 함께 처리하던 Button을 ExpoCreatedList 컴포넌트 안으로 넘겨 LazyColumn에 아이템으로 추가하여 같은 범위안에 존재할 수 있도록 하여 해결하였습니다.
   - before

      https://github.com/user-attachments/assets/bc8e19b0-1835-4243-a419-9bed14d2b12f

   - after
   
      https://github.com/user-attachments/assets/4e94172d-c57b-4a8b-9818-ffb51449b016

## 🔀 변경사항
- chore ExpoCreatedScreen
- chore ExpoViewModel
- chore ExpoCreatedList
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- 등록된 박람회의 데이터가 많이 존재하지 않아 앱에서는 둘의 차이를 확인하기 어려워 프리뷰로 영상녹화를 하였습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 엑스포 삭제 기능 강화
	- 엑스포 생성 화면의 상태 관리 개선

- **버그 수정**
	- 삭제 버튼의 활성화 상태 수정
	- UI 레이아웃의 정렬 및 간격 조정

- **리팩토링**
	- 엑스포 뷰모델의 상태 초기화 메서드 추가
	- 컴포넌트 간 상호작용 로직 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->