### PR TITLE
🔀 :: (#397) - 박람회 프로필 정보를 불러오는 기능을 구현하기 위해 네트워크 세팅을 하였습니다.

### DIFF
--- a/core/data/src/main/java/com/school_of_company/data/repository/admin/AdminRepository.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/admin/AdminRepository.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.data.repository.admin
 
+import com.school_of_company.model.entity.admin.AdminInformationResponseEntity
 import com.school_of_company.model.entity.admin.AdminRequestAllowListResponseEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -8,4 +9,5 @@ interface AdminRepository {
     fun allowAdmin(adminId: Long) : Flow<Unit>
     fun rejectAdmin(adminId: Long) : Flow<Unit>
     fun serviceWithdrawal() : Flow<Unit>
+    fun getAdminInformation(): Flow<AdminInformationResponseEntity>
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/admin/AdminRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/admin/AdminRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.data.repository.admin
 
+import com.school_of_company.model.entity.admin.AdminInformationResponseEntity
 import com.school_of_company.model.entity.admin.AdminRequestAllowListResponseEntity
 import com.school_of_company.network.datasource.admin.AdminDataSource
 import com.school_of_company.network.mapper.admin.response.toEntity
@@ -26,5 +27,11 @@ class AdminRepositoryImpl @Inject constructor(
 
     override fun serviceWithdrawal(): Flow<Unit> {
         return dataSource.serviceWithdrawal()
+    }
+
+    override fun getAdminInformation(): Flow<AdminInformationResponseEntity> {
+        return dataSource.getAdminInformation().transform { response ->
+            emit(response.toEntity())
+        }
     }
 }

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/admin/GetAdminInformationUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/admin/GetAdminInformationUseCase.kt
@@ -1,0 +1,13 @@
+package com.school_of_company.domain.usecase.admin
+
+import com.school_of_company.data.repository.admin.AdminRepository
+import com.school_of_company.model.entity.admin.AdminInformationResponseEntity
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetAdminInformationUseCase @Inject constructor(
+    private val repository: AdminRepository
+) {
+    operator fun invoke(): Flow<AdminInformationResponseEntity> =
+        repository.getAdminInformation()
+}

--- a/core/model/src/main/java/com/school_of_company/model/entity/admin/AdminInformationResponseEntity.kt
+++ b/core/model/src/main/java/com/school_of_company/model/entity/admin/AdminInformationResponseEntity.kt
@@ -1,0 +1,7 @@
+package com.school_of_company.model.entity.admin
+
+data class AdminInformationResponseEntity(
+    val name: String,
+    val nickname: String,
+    val email: String,
+)

--- a/core/network/src/main/java/com/school_of_company/network/api/AdminAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/AdminAPI.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.network.api
 
+import com.school_of_company.network.dto.admin.response.AdminInformationResponse
 import com.school_of_company.network.dto.admin.response.AdminRequestAllowListResponse
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -23,4 +24,7 @@ interface AdminAPI {
 
     @DELETE("/admin")
     suspend fun serviceWithdrawal()
+
+    @GET("/admin/my")
+    suspend fun getAdminInformation(): AdminInformationResponse
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/admin/AdminDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/admin/AdminDataSource.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.network.datasource.admin
 
+import com.school_of_company.network.dto.admin.response.AdminInformationResponse
 import com.school_of_company.network.dto.admin.response.AdminRequestAllowListResponse
 import kotlinx.coroutines.flow.Flow
 
@@ -8,4 +9,5 @@ interface AdminDataSource {
     fun allowAdmin(adminId: Long): Flow<Unit>
     fun rejectAdmin(adminId: Long): Flow<Unit>
     fun serviceWithdrawal(): Flow<Unit>
+    fun getAdminInformation(): Flow<AdminInformationResponse>
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/admin/AdminDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/admin/AdminDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.school_of_company.network.datasource.admin
 
 import com.school_of_company.network.api.AdminAPI
+import com.school_of_company.network.dto.admin.response.AdminInformationResponse
 import com.school_of_company.network.dto.admin.response.AdminRequestAllowListResponse
 import com.school_of_company.network.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
@@ -20,4 +21,7 @@ class AdminDataSourceImpl @Inject constructor(
 
     override fun serviceWithdrawal(): Flow<Unit> =
         performApiRequest { service.serviceWithdrawal() }
+
+    override fun getAdminInformation(): Flow<AdminInformationResponse> =
+        performApiRequest { service.getAdminInformation() }
 }

--- a/core/network/src/main/java/com/school_of_company/network/dto/admin/response/AdminInformationResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/admin/response/AdminInformationResponse.kt
@@ -1,0 +1,11 @@
+package com.school_of_company.network.dto.admin.response
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class AdminInformationResponse(
+    @Json(name = "name") val name: String,
+    @Json(name = "nickname") val nickname: String,
+    @Json(name = "email") val email: String,
+)

--- a/core/network/src/main/java/com/school_of_company/network/mapper/admin/response/AdminInformationResponseMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/admin/response/AdminInformationResponseMapper.kt
@@ -1,0 +1,11 @@
+package com.school_of_company.network.mapper.admin.response
+
+import com.school_of_company.model.entity.admin.AdminInformationResponseEntity
+import com.school_of_company.network.dto.admin.response.AdminInformationResponse
+
+fun AdminInformationResponse.toEntity(): AdminInformationResponseEntity =
+    AdminInformationResponseEntity(
+        name = this.name,
+        nickname = this.nickname,
+        email = this.email
+    )

--- a/feature/user/src/main/java/com/school_of_company/user/viewmodel/uistate/GetAdminInformationUiState.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/viewmodel/uistate/GetAdminInformationUiState.kt
@@ -1,0 +1,9 @@
+package com.school_of_company.user.viewmodel.uistate
+
+import com.school_of_company.model.entity.admin.AdminInformationResponseEntity
+
+sealed interface GetAdminInformationUiState {
+    object Loading : GetAdminInformationUiState
+    data class Success(val data: AdminInformationResponseEntity) : GetAdminInformationUiState
+    data class Error(val exception: Throwable) : GetAdminInformationUiState
+}


### PR DESCRIPTION
## 💡 개요
- 박람회 프로필 정보는 불러오는 기능을 구현하기전에 먼저 네트워크 세팅을 해줄 필요가 있었습니다.
## 📃 작업내용
- 박람회 프로필 정보를 불러오는 기능을 구현하기 위해 네트워크 세팅을 하였습니다.
   - GetAdminInformation Dto, Entity, Mapper 생성
   - DataSource에 추가
   - Repository에 추가
   - GetAdminInformationUseCase 생성
   - GetAdminInformationUiState 생성
   - UserViewModel에 추가
## 🔀 변경사항
![스크린샷 2025-01-31 오후 4 41 40](https://github.com/user-attachments/assets/d838a49b-b8fc-4e53-ab69-a5df031cfb74)

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 관리자 정보를 조회할 수 있는 새로운 기능 추가
	- 사용자 뷰모델에서 관리자 정보 상태를 관리하는 기능 도입

- **개선 사항**
	- 관리자 정보 조회를 위한 API 엔드포인트 구현
	- 관리자 정보 데이터 모델 및 매퍼 추가

- **기술적 변경**
	- 관리자 정보 조회를 위한 유스케이스 및 데이터 소스 개발
	- 비동기 흐름(Flow)을 활용한 데이터 처리 방식 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->