### PR TITLE
🔀 :: (#401) - button enable disable changes apply

### DIFF
--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.component.button.state.ButtonState
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
-import com.school_of_company.design_system.theme.color.ExpoColor
 
 @Composable
 fun ExpoButton(

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.component.button.state.ButtonState
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.design_system.theme.color.ExpoColor
 
 @Composable
 fun ExpoButton(
@@ -153,6 +154,52 @@ fun ExpoEnableDetailButton(
                 text = text,
                 style = typography.bodyBold2,
                 color = colors.main
+            )
+        }
+    }
+}
+
+@Composable
+fun ExpoToggleColorButton(
+    modifier: Modifier = Modifier,
+    text: String,
+    state: ButtonState = ButtonState.Enable,
+    enabledColor: Color = ExpoColor.main,
+    disabledColor: Color = ExpoColor.gray300,
+    onClick: () -> Unit,
+) {
+    val enabledState: (buttonState: ButtonState) -> Boolean = {
+        when (it) {
+            ButtonState.Enable -> true
+            ButtonState.Disable -> false
+        }
+    }
+
+    ExpoAndroidTheme { colors, typography ->
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .background(
+                    color = if (enabledState(state)) {
+                        enabledColor
+                    } else {
+                        disabledColor
+                    },
+                    shape = RoundedCornerShape(6.dp),
+                )
+                .expoClickable(
+                    enabled = enabledState(state),
+                    onClick = onClick,
+                    rippleColor = colors.white
+                )
+                .then(modifier)
+        ) {
+            Text(
+                text = text,
+                style = typography.bodyBold2,
+                fontWeight = FontWeight.SemiBold,
+                color = colors.white
             )
         }
     }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
@@ -159,52 +159,6 @@ fun ExpoEnableDetailButton(
     }
 }
 
-@Composable
-fun ExpoToggleColorButton(
-    modifier: Modifier = Modifier,
-    text: String,
-    state: ButtonState = ButtonState.Enable,
-    enabledColor: Color = ExpoColor.main,
-    disabledColor: Color = ExpoColor.gray300,
-    onClick: () -> Unit,
-) {
-    val enabledState: (buttonState: ButtonState) -> Boolean = {
-        when (it) {
-            ButtonState.Enable -> true
-            ButtonState.Disable -> false
-        }
-    }
-
-    ExpoAndroidTheme { colors, typography ->
-        Row(
-            horizontalArrangement = Arrangement.spacedBy(10.dp, Alignment.CenterHorizontally),
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier
-                .background(
-                    color = if (enabledState(state)) {
-                        enabledColor
-                    } else {
-                        disabledColor
-                    },
-                    shape = RoundedCornerShape(6.dp),
-                )
-                .expoClickable(
-                    enabled = enabledState(state),
-                    onClick = onClick,
-                    rippleColor = colors.white
-                )
-                .then(modifier)
-        ) {
-            Text(
-                text = text,
-                style = typography.bodyBold2,
-                fontWeight = FontWeight.SemiBold,
-                color = colors.white
-            )
-        }
-    }
-}
-
 @Preview
 @Composable
 private fun ExpoButtonPreview() {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -55,7 +55,7 @@ import coil.compose.rememberAsyncImagePainter
 import com.school_of_company.common.regex.isValidDateSequence
 import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.bottomsheet.SettingBottomSheet
-import com.school_of_company.design_system.component.button.ExpoStateButton
+import com.school_of_company.design_system.component.button.ExpoToggleColorButton
 import com.school_of_company.design_system.component.button.state.ButtonState
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
@@ -487,7 +487,7 @@ private fun ExpoCreateScreen(
 
                     Spacer(modifier = Modifier.height(28.dp))
 
-                    ExpoStateButton(
+                    ExpoToggleColorButton(
                         text = "생성하기",
                         state = if (
                             modifyTitleState.isNotEmpty() &&

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -82,7 +82,7 @@ import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformatio
 
 @Composable
 internal fun ExpoCreateRoute(
-    modifier: Modifier=Modifier,
+    modifier: Modifier = Modifier,
     onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
     viewModel: ExpoViewModel = hiltViewModel()
 ) {
@@ -163,7 +163,7 @@ internal fun ExpoCreateRoute(
 
 
     ExpoCreateScreen(
-        modifier= modifier,
+        modifier = modifier,
         startedDateState = startedDateState,
         endedDateState = endedDateState,
         modifyTitleState = modifyTitleState,
@@ -504,10 +504,12 @@ private fun ExpoCreateScreen(
                         } else {
                             ButtonState.Disable
                         },
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        onExpoCreateCallBack()
-                    }
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(14.dp),
+                        onClick = onExpoCreateCallBack
+                    )
+
 
                     Spacer(modifier = Modifier.height(48.dp))
                 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -55,7 +55,7 @@ import coil.compose.rememberAsyncImagePainter
 import com.school_of_company.common.regex.isValidDateSequence
 import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.bottomsheet.SettingBottomSheet
-import com.school_of_company.design_system.component.button.ExpoToggleColorButton
+import com.school_of_company.design_system.component.button.ExpoStateButton
 import com.school_of_company.design_system.component.button.state.ButtonState
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
@@ -487,7 +487,7 @@ private fun ExpoCreateScreen(
 
                     Spacer(modifier = Modifier.height(28.dp))
 
-                    ExpoToggleColorButton(
+                    ExpoStateButton(
                         text = "생성하기",
                         state = if (
                             modifyTitleState.isNotEmpty() &&


### PR DESCRIPTION
## 💡 개요

![image](https://github.com/user-attachments/assets/f391a0eb-0285-4e9f-9774-2ca8b47aad11)

![image](https://github.com/user-attachments/assets/1e396d36-c90f-4873-92bd-8d3832b834c7)

## 📃 작업내용

[💄 :: 생성하기 버튼을 ExpoStateButton 으로 변경](https://github.com/School-of-Company/Expo-Android/pull/403/commits/dfaa3a9d53da322749de175e0aeee63fdc2273af)

## 🔀 변경사항

박랑회 생성하기 페이지의 button 을 ExpoStateButton으로 변경했습니다

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.