### PR TITLE
🔀 :: (#405) - UserScreen의 회원가입 요청 리스트가 화면 높이의 최대치 이상까지 많아진다면 버튼의 UI가 밀려 없어지는 문제가 있어 리스트 컴포넌트와 합쳐 해결하였습니다.

### DIFF
--- a/feature/user/src/main/java/com/school_of_company/user/view/UserScreen.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/UserScreen.kt
@@ -44,9 +44,7 @@ import com.school_of_company.design_system.icon.LogoutIcon
 import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.user.view.component.SignUpRequestList
-import com.school_of_company.user.view.component.UserAllowButton
 import com.school_of_company.user.view.component.UserBottomSheet
-import com.school_of_company.user.view.component.UserDeleteButton
 import com.school_of_company.user.view.component.UserDialog
 import com.school_of_company.user.viewmodel.UserViewModel
 import com.school_of_company.user.viewmodel.uistate.AllowAdminRequestUiState
@@ -470,49 +468,18 @@ private fun UserScreen(
             ) {
                 when (getAdminRequestAllowListUiState) {
                     is GetAdminRequestAllowListUiState.Success -> {
-                        Column {
-                            SignUpRequestList(
-                                item = getAdminRequestAllowListUiState.data.toImmutableList(),
-                                horizontalScrollState = scrollState,
-                                selectedIndex = selectedId,
-                                onClick = { id ->
-                                    setSelectedId(if (selectedId == id) 0L else id)
-                                }
-                            )
-
-                            Spacer(modifier = Modifier.height(48.dp))
-
-                            Row(
-                                horizontalArrangement = Arrangement.spacedBy(
-                                    16.dp,
-                                    Alignment.CenterHorizontally
-                                ),
-                                verticalAlignment = Alignment.CenterVertically,
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                UserAllowButton(
-                                    enabled = selectedId != 0L,
-                                    onClick = {
-                                        if (selectedId == 0L) {
-                                            onErrorToast(null, R.string.check_sign_up_request_list_item)
-                                        } else {
-                                            successCallBack(selectedId)
-                                        }
-                                    },
-                                )
-
-                                UserDeleteButton(
-                                    enabled = selectedId != 0L,
-                                    onClick = {
-                                        if (selectedId == 0L) {
-                                            onErrorToast(null, R.string.check_sign_up_request_list_item)
-                                        } else {
-                                            deleteCallBack(selectedId)
-                                        }
-                                    },
-                                )
-                            }
-                        }
+                        SignUpRequestList(
+                            item = getAdminRequestAllowListUiState.data.toImmutableList(),
+                            horizontalScrollState = scrollState,
+                            selectedIndex = selectedId,
+                            onClick = { id ->
+                                setSelectedId(if (selectedId == id) 0L else id)
+                            },
+                            selectedId = selectedId,
+                            deleteCallBack = { deleteCallBack(selectedId) },
+                            successCallBack = { successCallBack(selectedId) },
+                            onErrorToast = onErrorToast
+                        )
                     }
 
                     is GetAdminRequestAllowListUiState.Error -> {

--- a/feature/user/src/main/java/com/school_of_company/user/view/component/SignUpRequestList.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/component/SignUpRequestList.kt
@@ -23,14 +23,14 @@ import kotlinx.collections.immutable.persistentListOf
 @Composable
 internal fun SignUpRequestList(
     modifier: Modifier = Modifier,
+    horizontalScrollState: ScrollState,
+    item: ImmutableList<AdminRequestAllowListResponseEntity> = persistentListOf(),
     selectedIndex: Long,
     selectedId: Long,
+    onClick: (Long) -> Unit,
     deleteCallBack: (Long) -> Unit,
     successCallBack: (Long) -> Unit,
     onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
-    item: ImmutableList<AdminRequestAllowListResponseEntity> = persistentListOf(),
-    horizontalScrollState: ScrollState,
-    onClick: (Long) -> Unit,
 ) {
     ExpoAndroidTheme { colors, _ ->
         LazyColumn(

--- a/feature/user/src/main/java/com/school_of_company/user/view/component/SignUpRequestList.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/component/SignUpRequestList.kt
@@ -2,13 +2,19 @@ package com.school_of_company.user.view.component
 
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.R
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.entity.admin.AdminRequestAllowListResponseEntity
 import kotlinx.collections.immutable.ImmutableList
@@ -18,6 +24,10 @@ import kotlinx.collections.immutable.persistentListOf
 internal fun SignUpRequestList(
     modifier: Modifier = Modifier,
     selectedIndex: Long,
+    selectedId: Long,
+    deleteCallBack: (Long) -> Unit,
+    successCallBack: (Long) -> Unit,
+    onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
     item: ImmutableList<AdminRequestAllowListResponseEntity> = persistentListOf(),
     horizontalScrollState: ScrollState,
     onClick: (Long) -> Unit,
@@ -36,6 +46,41 @@ internal fun SignUpRequestList(
                     horizontalScrollState = horizontalScrollState,
                     onClick = onClick,
                 )
+            }
+
+            item {
+                Spacer(modifier = Modifier.height(48.dp))
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(
+                        16.dp,
+                        Alignment.CenterHorizontally
+                    ),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    UserAllowButton(
+                        enabled = selectedId != 0L,
+                        onClick = {
+                            if (selectedId == 0L) {
+                                onErrorToast(null, R.string.check_sign_up_request_list_item)
+                            } else {
+                                successCallBack(selectedId)
+                            }
+                        },
+                    )
+
+                    UserDeleteButton(
+                        enabled = selectedId != 0L,
+                        onClick = {
+                            if (selectedId == 0L) {
+                                onErrorToast(null, R.string.check_sign_up_request_list_item)
+                            } else {
+                                deleteCallBack(selectedId)
+                            }
+                        },
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## 💡 개요
- UserScreen의 회원가입 요청 리스트가 화면 높이의 최대치 이상까지 많아진다면 버튼의 UI가 밀려 없어지는 문제가 있었습니다.
## 📃 작업내용
- UserScreen의 회원가입 요청 리스트가 화면 높이의 최대치 이상까지 많아진다면 버튼의 UI가 밀려 없어지는 문제가 있어 리스트 컴포넌트와 합쳐 해결하였습니다.
   - UserAllow(Delete)Button + SignUpRequestList
## 🔀 변경사항
- chore UserScreen
- chore SignUpRequestList
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- 지금은 회원가입 요청이 많지 않아 해당 문제가 보이지 않아 영상 녹화는 따로 하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 가입 요청 목록 인터페이스가 개선되어, 사용자가 직접 요청 항목을 선택한 후 승인 및 삭제 작업을 수행할 수 있게 되었습니다.
  - 선택된 항목이 없을 경우, 오류 알림 메시지로 안내가 제공되어 사용자 경험이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->