### PR TITLE
🔀 :: (#407) - 참가자 검색 부분에 검색하기 버튼을 클릭함에 따라 검색을 구현하는 화면이 아닌, 입력이 감지됨에 따라 검색될 수 있도록 리팩터링을 하였습니다.

### DIFF
--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -176,7 +177,7 @@ private fun ProgramDetailParticipantManagementScreen(
 ) {
     var participantTextState by rememberSaveable { mutableStateOf("사전 행사 참가자") }
     var isDropdownExpanded by rememberSaveable { mutableStateOf(false) }
-    var selectedItem by rememberSaveable { mutableStateOf<Int?>(0) }
+    var selectedItem by rememberSaveable { mutableIntStateOf(0) }
 
 
     ExpoAndroidTheme { colors, typography ->

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -57,6 +57,7 @@ import com.school_of_company.program.viewmodel.ProgramViewModel
 import com.school_of_company.program.viewmodel.uistate.ParticipantResponseListUiState
 import com.school_of_company.program.viewmodel.uistate.TraineeResponseListUiState
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.delay
 
 @Composable
 internal fun ProgramDetailParticipantManagementRoute(
@@ -89,6 +90,32 @@ internal fun ProgramDetailParticipantManagementRoute(
         )
 
         viewModel.getTraineeList(expoId = id)
+    }
+
+    LaunchedEffect(preParticipantName) {
+        delay(300L)
+        viewModel.getParticipantInformationList(
+            expoId = id,
+            type = ParticipantEnum.PRE,
+            name = preParticipantName
+        )
+    }
+
+    LaunchedEffect(fieldParticipantName) {
+        delay(300L)
+        viewModel.getParticipantInformationList(
+            expoId = id,
+            type = ParticipantEnum.FIELD,
+            name = fieldParticipantName
+        )
+    }
+
+    LaunchedEffect(traineeName) {
+        delay(300L)
+        viewModel.getTraineeList(
+            expoId = id,
+            name = traineeName
+        )
     }
 
     ProgramDetailParticipantManagementScreen(
@@ -369,6 +396,46 @@ private fun ProgramDetailParticipantManagementScreen(
                 }
             }
 
+            Spacer(modifier = Modifier.height(18.dp))
+
+            ExpoNoneLabelTextField(
+                placeholder = "참가자 이름을 입력해주세요.",
+                isError = false,
+                isDisabled = false,
+                errorText = "",
+                value = when (selectedItem) {
+                    0 -> preParticipantName
+                    1 -> fieldParticipantName
+                    2 -> traineeName
+                    else -> ""
+                },
+                onValueChange = when (selectedItem) {
+                    0 -> onPreParticipantNameChange
+                    1 -> onFieldParticipantNameChange
+                    2 -> onTraineeNameChange
+                    else -> ({})
+                },
+                trailingIcon = {
+                    SearchIcon(
+                        tint = colors.black,
+                        modifier = Modifier.clickable {
+                            when (selectedItem) {
+                                0 -> getAheadParticipantList(preParticipantName)
+                                1 -> getFieldParticipantList(fieldParticipantName)
+                                2 -> getTraineeList(traineeName)
+                            }
+                        }
+                    )
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(44.dp)
+                    .padding(horizontal = 16.dp)
+            )
+
+
+            Spacer(modifier = Modifier.height(16.dp))
+
             SwipeRefresh(
                 state = swipeRefreshState,
                 onRefresh = {
@@ -391,35 +458,7 @@ private fun ProgramDetailParticipantManagementScreen(
                         when (participantAheadResponseListUiState) {
                             is ParticipantResponseListUiState.Loading -> Unit
                             is ParticipantResponseListUiState.Success -> {
-
                                 Column {
-                                    Spacer(modifier = Modifier.height(18.dp))
-
-                                    ExpoNoneLabelTextField(
-                                        placeholder = "참가자 이름을 입력해주세요.",
-                                        isError = false,
-                                        isDisabled = false,
-                                        errorText = "",
-                                        value = preParticipantName,
-                                        onValueChange = onPreParticipantNameChange,
-                                        trailingIcon = {
-                                            SearchIcon(
-                                                tint = colors.black,
-                                                modifier = Modifier.clickable {
-                                                    getAheadParticipantList(
-                                                        preParticipantName
-                                                    )
-                                                }
-                                            )
-                                        },
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .height(44.dp)
-                                            .padding(horizontal = 16.dp)
-                                    )
-
-                                    Spacer(modifier = Modifier.height(16.dp))
-
                                     ProgramDetailParticipantTable(scrollState = scrollState)
 
                                     ProgramDetailParticipantManagementList(
@@ -450,33 +489,6 @@ private fun ProgramDetailParticipantManagementScreen(
                             is ParticipantResponseListUiState.Loading -> Unit
                             is ParticipantResponseListUiState.Success -> {
                                 Column {
-                                    Spacer(modifier = Modifier.height(18.dp))
-
-                                    ExpoNoneLabelTextField(
-                                        placeholder = "참가자 이름을 입력해주세요.",
-                                        isError = false,
-                                        isDisabled = false,
-                                        errorText = "",
-                                        value = fieldParticipantName,
-                                        onValueChange = onFieldParticipantNameChange,
-                                        trailingIcon = {
-                                            SearchIcon(
-                                                tint = colors.black,
-                                                modifier = Modifier.clickable {
-                                                    getFieldParticipantList(
-                                                        fieldParticipantName
-                                                    )
-                                                }
-                                            )
-                                        },
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .height(44.dp)
-                                            .padding(horizontal = 16.dp)
-                                    )
-
-                                    Spacer(modifier = Modifier.height(16.dp))
-
                                     ProgramDetailParticipantTable(scrollState = scrollState)
 
                                     ProgramDetailParticipantManagementList(
@@ -494,10 +506,12 @@ private fun ProgramDetailParticipantManagementScreen(
                             }
 
                             is ParticipantResponseListUiState.Empty -> {
+
                                 ShowEmptyState(
                                     emptyMessage = "현장 행사 참가자가 존재하지 않습니다..",
                                     scrollState = scrollState
                                 )
+
                             }
                         }
                     }
@@ -507,35 +521,6 @@ private fun ProgramDetailParticipantManagementScreen(
                             is TraineeResponseListUiState.Loading -> Unit
                             is TraineeResponseListUiState.Success -> {
                                 Column {
-                                    Spacer(modifier = Modifier.height(18.dp))
-
-
-                                    ExpoNoneLabelTextField(
-                                        placeholder = "참가자 이름을 입력해주세요.",
-                                        isError = false,
-                                        isDisabled = false,
-                                        errorText = "",
-                                        value = traineeName,
-                                        onValueChange = onTraineeNameChange,
-                                        trailingIcon = {
-                                            SearchIcon(
-                                                tint = colors.black,
-                                                modifier = Modifier.clickable {
-                                                    getTraineeList(
-                                                        traineeName
-                                                    )
-                                                }
-                                            )
-                                        },
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .height(44.dp)
-                                            .padding(horizontal = 16.dp)
-                                    )
-
-
-                                    Spacer(modifier = Modifier.height(16.dp))
-
                                     ProgramTraineeTable(scrollState = scrollState)
 
                                     ProgramTraineeList(


### PR DESCRIPTION
## 💡 개요
- 참가자 검색 부분에 검색하기 버튼을 클릭함에 따라 검색을 구현하는 화면이 아닌, 입력이 감지됨에 따라 검색될 수 있도록 할 필요가 있었습니다.
## 📃 작업내용
- 참가자 검색 부분에 검색하기 버튼을 클릭함에 따라 검색을 구현하는 화면이 아닌, 입력이 감지됨에 따라 검색될 수 있도록 리팩터링을 하였습니다.
   - viewModel에 요청을 직접 보내는 부분이나 입력을 받는 부분에서 Coroutine Flow를 이용하여 Debounce를 처리하지 않고, 컴포즈에서 값을 저장하고 LaunchedEffect에서 몇 초간 딜레이를 주고 함수를 호출하는 방식을 사용하여 Debounce와 같은 원리로 작동할 수 있도록 하였습니다.
   - 텍스트 필드 컴포넌트에서 text 변수를 derivedStateOf를 사용하여 외부 value에 의존하도록 변경했습니다.
   - FocusRequester를 사용하여 통신이 성공하여 리컴포지션이 되어도 텍스트 필드의 포커스가 유지될 수 있도록 하였습니다.

      https://github.com/user-attachments/assets/b348a75e-295a-47f2-88f8-70bdd91c57c0

## 🔀 변경사항
chore ExpoTextField - ExpoNoneLabelTextField
chore ProgramDetailParticipantManagementRoute
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **리팩터**
	- 텍스트 입력 상자의 포커스 처리 및 상태 관리가 개선되어 보다 간결하고 효율적으로 동작합니다.

- **신규 기능**
	- 참가자 관리 화면에 통합된 텍스트 입력 컴포넌트를 도입해, 사용자 입력에 따른 참가자 정보 업데이트 및 즉각적인 피드백을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->