### PR TITLE
🔀 :: (#411) - 박람회 자세히 보기 화면의 버튼 디자인이 변경되어 이를 수정하였습니다.

### DIFF
--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
@@ -102,6 +102,7 @@ fun ExpoEnableButton(
     modifier: Modifier = Modifier,
     text: String,
     textColor: Color = Color.Black,
+    backgroundColor: Color = Color.White,
     onClick: () -> Unit,
 ) {
     ExpoAndroidTheme { colors, typography ->
@@ -113,7 +114,7 @@ fun ExpoEnableButton(
             interactionSource = interactionSource,
             contentPadding = PaddingValues(vertical = 16.dp),
             colors = ButtonDefaults.buttonColors(
-                containerColor = colors.white,
+                containerColor = backgroundColor,
                 contentColor = colors.white,
             ),
             shape = RoundedCornerShape(6.dp),

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -327,26 +328,15 @@ private fun ExpoDetailScreen(
                             ExpoEnableDetailButton(
                                 text = "문자 보내기",
                                 onClick = { isOpenDialog(true) },
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .border(
-                                        width = 1.dp,
-                                        color = colors.main,
-                                        shape = RoundedCornerShape(6.dp)
-                                    )
+                                modifier = Modifier.fillMaxWidth()
                             )
 
                             ExpoEnableButton(
                                 text = "수정하기",
                                 onClick = { onModifyClick(id) },
-                                textColor = colors.main,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .border(
-                                        width = 1.dp,
-                                        color = colors.main,
-                                        shape = RoundedCornerShape(6.dp)
-                                    )
+                                textColor = colors.gray700,
+                                backgroundColor = colors.gray100,
+                                modifier = Modifier.fillMaxWidth()
                             )
                         }
 
@@ -417,7 +407,7 @@ private fun ExpoDetailScreen(
     }
 }
 
-@ExpoPreviews
+@Preview
 @Composable
 private fun HomeDetailScreenPreview() {
     ExpoDetailScreen(


### PR DESCRIPTION
## 💡 개요
- 박람회 자세히 보기 화면 버튼 디자인이 수정되어 이를 반영할 필요가 있었습니다.
## 📃 작업내용
- 박람회 자세히 보기 화면의 버튼 디자인이 변경되어 이를 수정하였습니다.
    - 두개의 버튼에서 border 값을 삭제하고, 배경색을 변경하였습니다.
    - before
   
       <img width="250" alt="스크린샷 2025-02-05 오전 1 48 03" src="https://github.com/user-attachments/assets/d22dfed9-32fb-4db9-8c1e-1a74166c57b6" />

    - after
   
       <img width="250" alt="스크린샷 2025-02-05 오전 1 47 28" src="https://github.com/user-attachments/assets/64525f67-65eb-4329-9fe8-f7c42cf922ef" />

## 🔀 변경사항
- chore ExpoButton(ExpoEnableButton)
- chore ExpoDetailScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 버튼의 배경색을 사용자 지정 가능하도록 개선되어 다양한 디자인 구성이 가능합니다.
  
- **Style**
  - 상세 화면 버튼의 스타일이 단순화되어 일관된 디자인과 개선된 시각 효과를 제공합니다.
  - 미리보기 설정이 표준화되어 UI 검토 및 활용이 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->