### PR TITLE
🔀 :: (#409) - expo detail screen address update

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -96,6 +96,7 @@ fun ExpoNavHost(
                 navController.navigateToProgramDetailProgram(id)
             },
             onMessageClick = navController::navigateToSmsSendMessage,
+            onErrorToast = makeErrorToast,
         )
 
         smsSendMessageScreen(

--- a/core/data/src/main/java/com/school_of_company/data/repository/juso/AddressRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/juso/AddressRepositoryImpl.kt
@@ -4,7 +4,6 @@ import com.school_of_company.model.model.juso.JusoModel
 import com.school_of_company.network.datasource.juso.AddressDataSource
 import com.school_of_company.network.mapper.juso.toModel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transform
 import javax.inject.Inject
 

--- a/core/data/src/main/java/com/school_of_company/data/repository/juso/AddressRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/juso/AddressRepositoryImpl.kt
@@ -19,7 +19,7 @@ class AddressRepositoryImpl @Inject constructor(
             countPerPage = countPerPage,
             currentPage = currentPage,
             keyword = keyword
-        ).transform { response ->
-            emit(response.results.juso?.map { juso -> juso.toModel() } ?: emptyList())
+        ).transform { list ->
+            emit(list.results.juso?.map { juso -> juso.toModel() } ?: emptyList())
         }
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/juso/AddressRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/juso/AddressRepositoryImpl.kt
@@ -20,7 +20,7 @@ class AddressRepositoryImpl @Inject constructor(
             countPerPage = countPerPage,
             currentPage = currentPage,
             keyword = keyword
-        ).transform {
-            emit(it.results.juso?.map { juso -> juso.toModel() } ?: emptyList())
+        ).transform { response ->
+            emit(response.results.juso?.map { juso -> juso.toModel() } ?: emptyList())
         }
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/juso/AddressRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/juso/AddressRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.school_of_company.network.datasource.juso.AddressDataSource
 import com.school_of_company.network.mapper.juso.toModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.transform
 import javax.inject.Inject
 
 class AddressRepositoryImpl @Inject constructor(
@@ -19,7 +20,7 @@ class AddressRepositoryImpl @Inject constructor(
             countPerPage = countPerPage,
             currentPage = currentPage,
             keyword = keyword
-        ).map {
-            it.results.juso?.map { juso -> juso.toModel() } ?: emptyList()
+        ).transform {
+            emit(it.results.juso?.map { juso -> juso.toModel() } ?: emptyList())
         }
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/juso/AddressRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/juso/AddressRepositoryImpl.kt
@@ -4,7 +4,7 @@ import com.school_of_company.model.model.juso.JusoModel
 import com.school_of_company.network.datasource.juso.AddressDataSource
 import com.school_of_company.network.mapper.juso.toModel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class AddressRepositoryImpl @Inject constructor(
@@ -19,7 +19,7 @@ class AddressRepositoryImpl @Inject constructor(
             countPerPage = countPerPage,
             currentPage = currentPage,
             keyword = keyword
-        ).transform {
+        ).map {
             it.results.juso?.map { juso -> juso.toModel() } ?: emptyList()
         }
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepository.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepository.kt
@@ -1,8 +1,10 @@
 package com.school_of_company.data.repository.kakao
 
+import com.school_of_company.model.model.kakao.KakaoGeocodingModel
 import com.school_of_company.model.model.kakao.KakaoGetCoordinatesModel
 import kotlinx.coroutines.flow.Flow
 
 interface KakaoRepository {
     fun getCoordinates(address: String, size: Int): Flow<KakaoGetCoordinatesModel>
+    fun getAddress(x: String, y: String): Flow<KakaoGeocodingModel>
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepository.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepository.kt
@@ -1,8 +1,8 @@
 package com.school_of_company.data.repository.kakao
 
-import com.school_of_company.model.model.kakao.KakaoAddressModel
+import com.school_of_company.model.model.kakao.KakaoGetCoordinatesModel
 import kotlinx.coroutines.flow.Flow
 
 interface KakaoRepository {
-    fun getCoordinates(address: String, size: Int): Flow<KakaoAddressModel>
+    fun getCoordinates(address: String, size: Int): Flow<KakaoGetCoordinatesModel>
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepositoryImpl.kt
@@ -16,13 +16,13 @@ class KakaoRepositoryImpl @Inject constructor(
         return kakaoLocalDataSource.getCoordinates(
             address = address,
             size = size
-        ).transform { emit(it.toModel()) }
+        ).transform { response -> emit(response.toModel()) }
     }
 
     override fun getAddress(x: String, y: String): Flow<KakaoGeocodingModel> {
         return kakaoLocalDataSource.getAddress(
             x = x,
             y = y,
-        ).transform { emit(it.toModel()) }
+        ).transform { response -> (response.toModel()) }
     }
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepositoryImpl.kt
@@ -1,17 +1,16 @@
 package com.school_of_company.data.repository.kakao
 
-import com.school_of_company.model.model.kakao.KakaoAddressModel
+import com.school_of_company.model.model.kakao.KakaoGetCoordinatesModel
 import com.school_of_company.network.datasource.kakao.KakaoLocalDataSource
 import com.school_of_company.network.mapper.kakao.toModel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transform
 import javax.inject.Inject
 
 class KakaoRepositoryImpl @Inject constructor(
     private val kakaoLocalDataSource: KakaoLocalDataSource,
 ) : KakaoRepository {
-    override fun getCoordinates(address: String, size: Int): Flow<KakaoAddressModel> {
+    override fun getCoordinates(address: String, size: Int): Flow<KakaoGetCoordinatesModel> {
         return kakaoLocalDataSource.getCoordinates(
             address = address,
             size = size

--- a/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.school_of_company.model.model.kakao.KakaoGetCoordinatesModel
 import com.school_of_company.network.datasource.kakao.KakaoLocalDataSource
 import com.school_of_company.network.mapper.kakao.toModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.transform
 import javax.inject.Inject
 
@@ -15,13 +16,13 @@ class KakaoRepositoryImpl @Inject constructor(
         return kakaoLocalDataSource.getCoordinates(
             address = address,
             size = size
-        ).transform { it.toModel() }
+        ).map { it.toModel() }
     }
 
     override fun getAddress(x: String, y: String): Flow<KakaoGeocodingModel> {
         return kakaoLocalDataSource.getAddress(
             x = x,
             y = y,
-        ).transform { it.toModel() }
+        ).map { it.toModel() }
     }
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepositoryImpl.kt
@@ -16,13 +16,13 @@ class KakaoRepositoryImpl @Inject constructor(
         return kakaoLocalDataSource.getCoordinates(
             address = address,
             size = size
-        ).map { it.toModel() }
+        ).transform { emit(it.toModel()) }
     }
 
     override fun getAddress(x: String, y: String): Flow<KakaoGeocodingModel> {
         return kakaoLocalDataSource.getAddress(
             x = x,
             y = y,
-        ).map { it.toModel() }
+        ).transform { emit(it.toModel()) }
     }
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.school_of_company.data.repository.kakao
 
+import com.school_of_company.model.model.kakao.KakaoGeocodingModel
 import com.school_of_company.model.model.kakao.KakaoGetCoordinatesModel
 import com.school_of_company.network.datasource.kakao.KakaoLocalDataSource
 import com.school_of_company.network.mapper.kakao.toModel
@@ -14,6 +15,13 @@ class KakaoRepositoryImpl @Inject constructor(
         return kakaoLocalDataSource.getCoordinates(
             address = address,
             size = size
+        ).transform { it.toModel() }
+    }
+
+    override fun getAddress(x: String, y: String): Flow<KakaoGeocodingModel> {
+        return kakaoLocalDataSource.getAddress(
+            x = x,
+            y = y,
         ).transform { it.toModel() }
     }
 }

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -89,6 +89,9 @@
 
     <string name="expo_image_fail">박람회 이미지가 유효하지 않습니다.</string>
 
+    <string name="convert_coordinates_to_address_fail">좌표를 주소로 변환하는 과정에서 오류가 발생했습니다.</string>
+    <string name="convert_coordinates_to_address_success">좌표를 주소로 성공적으로 변환했습니다.</string>
+
     <string name="get_address_success">주소검색을 성공했습니다</string>
     <string name="get_address_fail">주소검색을 실패했습니다.</string>
 

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/kakao/GetAddressUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/kakao/GetAddressUseCase.kt
@@ -1,0 +1,16 @@
+package com.school_of_company.domain.usecase.kakao
+
+import com.school_of_company.data.repository.kakao.KakaoRepository
+import com.school_of_company.model.model.kakao.KakaoGeocodingModel
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetAddressUseCase @Inject constructor(
+    private val repository: KakaoRepository
+) {
+    operator fun invoke(x: String, y: String): Flow<KakaoGeocodingModel> =
+        repository.getAddress(
+            x = x,
+            y = y
+        )
+}

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/kakao/GetCoordinatesToAddressUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/kakao/GetCoordinatesToAddressUseCase.kt
@@ -5,7 +5,7 @@ import com.school_of_company.model.model.kakao.KakaoGeocodingModel
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class GetAddressUseCase @Inject constructor(
+class GetCoordinatesToAddressUseCase @Inject constructor(
     private val repository: KakaoRepository
 ) {
     operator fun invoke(x: String, y: String): Flow<KakaoGeocodingModel> =

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/kakao/GetCoordinatesUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/kakao/GetCoordinatesUseCase.kt
@@ -1,7 +1,7 @@
 package com.school_of_company.domain.usecase.kakao
 
 import com.school_of_company.data.repository.kakao.KakaoRepository
-import com.school_of_company.model.model.kakao.KakaoAddressModel
+import com.school_of_company.model.model.kakao.KakaoGetCoordinatesModel
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
@@ -12,7 +12,7 @@ class GetCoordinatesUseCase @Inject constructor(
         private const val DEFAULT_SIZE = 1
     }
 
-    operator fun invoke(address: String): Flow<KakaoAddressModel> =
+    operator fun invoke(address: String): Flow<KakaoGetCoordinatesModel> =
         repository.getCoordinates(
             address = address,
             size = DEFAULT_SIZE

--- a/core/model/src/main/java/com/school_of_company/model/model/kakao/KakaoGeocodingModel.kt
+++ b/core/model/src/main/java/com/school_of_company/model/model/kakao/KakaoGeocodingModel.kt
@@ -1,0 +1,5 @@
+package com.school_of_company.model.model.kakao
+
+data class KakaoGeocodingModel(
+    val addressName: String,
+)

--- a/core/model/src/main/java/com/school_of_company/model/model/kakao/KakaoGetCoordinatesModel.kt
+++ b/core/model/src/main/java/com/school_of_company/model/model/kakao/KakaoGetCoordinatesModel.kt
@@ -1,8 +1,7 @@
 package com.school_of_company.model.model.kakao
 
-data class KakaoAddressModel(
+data class KakaoGetCoordinatesModel(
     val addressName: String,
     val x: String, // 경도
     val y: String, // 위도
 )
-

--- a/core/network/src/main/java/com/school_of_company/network/api/KakaoAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/KakaoAPI.kt
@@ -1,7 +1,7 @@
 package com.school_of_company.network.api
 
-import com.school_of_company.network.dto.kakao.KakaoAddressResponse
 import com.school_of_company.network.dto.kakao.KakaoGeocodingResponse
+import com.school_of_company.network.dto.kakao.KakaoGetCoordinatesResponse
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Query
@@ -14,7 +14,7 @@ interface KakaoAPI {
         @Header("Content-Type") contentType: String = "application/json;charset=UTF-8",
         @Query("query") address: String,
         @Query("size") size: Int,
-    ): KakaoAddressResponse
+    ): KakaoGetCoordinatesResponse
 
     @GET("geo/coord2address.json")
     suspend fun getAddress(

--- a/core/network/src/main/java/com/school_of_company/network/api/KakaoAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/KakaoAPI.kt
@@ -5,7 +5,7 @@ import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Query
 
-interface KakaoLocalAPI {
+interface KakaoAPI {
 
     @GET("search/address.json")
     suspend fun getCoordinates(

--- a/core/network/src/main/java/com/school_of_company/network/api/KakaoAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/KakaoAPI.kt
@@ -10,7 +10,6 @@ interface KakaoAPI {
 
     @GET("search/address.json")
     suspend fun getCoordinates(
-        @Header("Authorization") apiKey: String,
         @Header("Content-Type") contentType: String = "application/json;charset=UTF-8",
         @Query("query") address: String,
         @Query("size") size: Int,
@@ -18,7 +17,6 @@ interface KakaoAPI {
 
     @GET("geo/coord2address.json")
     suspend fun getAddress(
-        @Header("Authorization") apiKey: String,
         @Header("Content-Type") contentType: String = "application/json;charset=UTF-8",
         @Query("x") x: String,
         @Query("y") y: String,

--- a/core/network/src/main/java/com/school_of_company/network/api/KakaoAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/KakaoAPI.kt
@@ -1,7 +1,7 @@
 package com.school_of_company.network.api
 
-import com.school_of_company.network.dto.kakao.KakaoGeocodingResponse
 import com.school_of_company.network.dto.kakao.KakaoGetCoordinatesResponse
+import com.school_of_company.network.dto.kakao.KakaoGetAddressResponse
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Query
@@ -22,5 +22,5 @@ interface KakaoAPI {
         @Header("Content-Type") contentType: String = "application/json;charset=UTF-8",
         @Query("x") x: String,
         @Query("y") y: String,
-    ): KakaoGeocodingResponse
+    ): KakaoGetAddressResponse
 }

--- a/core/network/src/main/java/com/school_of_company/network/api/KakaoAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/KakaoAPI.kt
@@ -1,6 +1,7 @@
 package com.school_of_company.network.api
 
 import com.school_of_company.network.dto.kakao.KakaoAddressResponse
+import com.school_of_company.network.dto.kakao.KakaoGeocodingResponse
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Query
@@ -14,4 +15,12 @@ interface KakaoAPI {
         @Query("query") address: String,
         @Query("size") size: Int,
     ): KakaoAddressResponse
+
+    @GET("geo/coord2address.json")
+    suspend fun getAddress(
+        @Header("Authorization") apiKey: String,
+        @Header("Content-Type") contentType: String = "application/json;charset=UTF-8",
+        @Query("x") x: String,
+        @Query("y") y: String,
+    ): KakaoGeocodingResponse
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSource.kt
@@ -1,10 +1,10 @@
 package com.school_of_company.network.datasource.kakao
 
-import com.school_of_company.network.dto.kakao.KakaoAddressResponse
 import com.school_of_company.network.dto.kakao.KakaoGeocodingResponse
+import com.school_of_company.network.dto.kakao.KakaoGetCoordinatesResponse
 import kotlinx.coroutines.flow.Flow
 
 interface KakaoLocalDataSource {
-    fun getCoordinates(address: String, size: Int): Flow<KakaoAddressResponse>
     fun getAddress(x: String, y: String): Flow<KakaoGeocodingResponse>
+    fun getCoordinates(address: String, size: Int): Flow<KakaoGetCoordinatesResponse>
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSource.kt
@@ -1,8 +1,10 @@
 package com.school_of_company.network.datasource.kakao
 
 import com.school_of_company.network.dto.kakao.KakaoAddressResponse
+import com.school_of_company.network.dto.kakao.KakaoGeocodingResponse
 import kotlinx.coroutines.flow.Flow
 
 interface KakaoLocalDataSource {
     fun getCoordinates(address: String, size: Int): Flow<KakaoAddressResponse>
+    fun getAddress(x: String, y: String): Flow<KakaoGeocodingResponse>
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSource.kt
@@ -1,10 +1,10 @@
 package com.school_of_company.network.datasource.kakao
 
-import com.school_of_company.network.dto.kakao.KakaoGeocodingResponse
+import com.school_of_company.network.dto.kakao.KakaoGetAddressResponse
 import com.school_of_company.network.dto.kakao.KakaoGetCoordinatesResponse
 import kotlinx.coroutines.flow.Flow
 
 interface KakaoLocalDataSource {
-    fun getAddress(x: String, y: String): Flow<KakaoGeocodingResponse>
+    fun getAddress(x: String, y: String): Flow<KakaoGetAddressResponse>
     fun getCoordinates(address: String, size: Int): Flow<KakaoGetCoordinatesResponse>
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSourceImpl.kt
@@ -2,8 +2,8 @@ package com.school_of_company.network.datasource.kakao
 
 import com.school_of_company.network.BuildConfig
 import com.school_of_company.network.api.KakaoAPI
-import com.school_of_company.network.dto.kakao.KakaoAddressResponse
 import com.school_of_company.network.dto.kakao.KakaoGeocodingResponse
+import com.school_of_company.network.dto.kakao.KakaoGetCoordinatesResponse
 import com.school_of_company.network.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -11,7 +11,7 @@ import javax.inject.Inject
 class KakaoLocalDataSourceImpl @Inject constructor(
     private val service: KakaoAPI
 ) : KakaoLocalDataSource {
-    override fun getCoordinates(address: String, size: Int): Flow<KakaoAddressResponse> =
+    override fun getCoordinates(address: String, size: Int): Flow<KakaoGetCoordinatesResponse> =
         performApiRequest {
             service.getCoordinates(
                 apiKey = "KakaoAK ${BuildConfig.KAKAO_REST_KEY}",

--- a/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSourceImpl.kt
@@ -2,8 +2,8 @@ package com.school_of_company.network.datasource.kakao
 
 import com.school_of_company.network.BuildConfig
 import com.school_of_company.network.api.KakaoAPI
-import com.school_of_company.network.dto.kakao.KakaoGeocodingResponse
 import com.school_of_company.network.dto.kakao.KakaoGetCoordinatesResponse
+import com.school_of_company.network.dto.kakao.KakaoGetAddressResponse
 import com.school_of_company.network.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -20,7 +20,7 @@ class KakaoLocalDataSourceImpl @Inject constructor(
             )
         }
 
-    override fun getAddress(x: String, y: String): Flow<KakaoGeocodingResponse> =
+    override fun getAddress(x: String, y: String): Flow<KakaoGetAddressResponse> =
         performApiRequest {
             service.getAddress(
                 apiKey = "KakaoAK ${BuildConfig.KAKAO_REST_KEY}",

--- a/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSourceImpl.kt
@@ -1,14 +1,14 @@
 package com.school_of_company.network.datasource.kakao
 
 import com.school_of_company.network.BuildConfig
-import com.school_of_company.network.api.KakaoLocalAPI
+import com.school_of_company.network.api.KakaoAPI
 import com.school_of_company.network.dto.kakao.KakaoAddressResponse
 import com.school_of_company.network.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class KakaoLocalDataSourceImpl @Inject constructor(
-    private val service: KakaoLocalAPI
+    private val service: KakaoAPI
 ) : KakaoLocalDataSource {
     override fun getCoordinates(address: String, size: Int): Flow<KakaoAddressResponse> =
         performApiRequest {

--- a/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.school_of_company.network.datasource.kakao
 import com.school_of_company.network.BuildConfig
 import com.school_of_company.network.api.KakaoAPI
 import com.school_of_company.network.dto.kakao.KakaoAddressResponse
+import com.school_of_company.network.dto.kakao.KakaoGeocodingResponse
 import com.school_of_company.network.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -16,6 +17,15 @@ class KakaoLocalDataSourceImpl @Inject constructor(
                 apiKey = "KakaoAK ${BuildConfig.KAKAO_REST_KEY}",
                 address = address,
                 size = size,
+            )
+        }
+
+    override fun getAddress(x: String, y: String): Flow<KakaoGeocodingResponse> =
+        performApiRequest {
+            service.getAddress(
+                apiKey = "KakaoAK ${BuildConfig.KAKAO_REST_KEY}",
+                x = x,
+                y = y,
             )
         }
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/kakao/KakaoLocalDataSourceImpl.kt
@@ -1,9 +1,8 @@
 package com.school_of_company.network.datasource.kakao
 
-import com.school_of_company.network.BuildConfig
 import com.school_of_company.network.api.KakaoAPI
-import com.school_of_company.network.dto.kakao.KakaoGetCoordinatesResponse
 import com.school_of_company.network.dto.kakao.KakaoGetAddressResponse
+import com.school_of_company.network.dto.kakao.KakaoGetCoordinatesResponse
 import com.school_of_company.network.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -14,7 +13,6 @@ class KakaoLocalDataSourceImpl @Inject constructor(
     override fun getCoordinates(address: String, size: Int): Flow<KakaoGetCoordinatesResponse> =
         performApiRequest {
             service.getCoordinates(
-                apiKey = "KakaoAK ${BuildConfig.KAKAO_REST_KEY}",
                 address = address,
                 size = size,
             )
@@ -23,7 +21,6 @@ class KakaoLocalDataSourceImpl @Inject constructor(
     override fun getAddress(x: String, y: String): Flow<KakaoGetAddressResponse> =
         performApiRequest {
             service.getAddress(
-                apiKey = "KakaoAK ${BuildConfig.KAKAO_REST_KEY}",
                 x = x,
                 y = y,
             )

--- a/core/network/src/main/java/com/school_of_company/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/school_of_company/network/di/NetworkModule.kt
@@ -11,7 +11,7 @@ import com.school_of_company.network.api.AuthAPI
 import com.school_of_company.network.api.ExpoAPI
 import com.school_of_company.network.api.FormAPI
 import com.school_of_company.network.api.ImageAPI
-import com.school_of_company.network.api.KakaoLocalAPI
+import com.school_of_company.network.api.KakaoAPI
 import com.school_of_company.network.api.ParticipantAPI
 import com.school_of_company.network.api.SmsAPI
 import com.school_of_company.network.api.StandardAPI
@@ -177,8 +177,8 @@ object NetworkModule {
         retrofit.create(FormAPI::class.java)
 
     @Provides
-    fun provideKakaoLocalAPI(@KakaoUrl retrofit: Retrofit): KakaoLocalAPI =
-        retrofit.create(KakaoLocalAPI::class.java)
+    fun provideKakaoAPI(@KakaoUrl retrofit: Retrofit): KakaoAPI =
+        retrofit.create(KakaoAPI::class.java)
 
     @Provides
     fun provideAddressAPI(@AddressUrl retrofit: Retrofit): AddressAPI =

--- a/core/network/src/main/java/com/school_of_company/network/dto/kakao/KakaoAddressResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/kakao/KakaoAddressResponse.kt
@@ -5,20 +5,20 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class KakaoAddressResponse(
-    @Json(name = "meta") val meta: Meta,
-    @Json(name = "documents") val documents: List<Document>,
+    @Json(name = "meta") val meta: KakaoMeta,
+    @Json(name = "documents") val documents: List<KakaoDocument>,
 )
 
 @JsonClass(generateAdapter = true)
-data class Meta(
+data class KakaoMeta(
     @Json(name = "total_count") val totalCount: Int,
     @Json(name = "pageable_count") val pageableCount: Int,
     @Json(name = "is_end") val isEnd: Boolean,
 )
 
 @JsonClass(generateAdapter = true)
-data class Document(
+data class KakaoDocument(
     @Json(name = "address_name") val addressName: String,
-    @Json(name = "x") val x: String, // 경도
-    @Json(name = "y") val y: String, // 위도
+    @Json(name = "x") val longitude: String, // 경도
+    @Json(name = "y") val latitude: String, // 위도
 )

--- a/core/network/src/main/java/com/school_of_company/network/dto/kakao/KakaoGeocodingResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/kakao/KakaoGeocodingResponse.kt
@@ -6,18 +6,18 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class KakaoGeocodingResponse(
     @Json(name = "meta") val meta: GeocodingMeta,
-    @Json(name = "documents") val documents: List<GeocodingDocument>
+    @Json(name = "documents") val documents: List<GeocodingDocument>,
 )
 
 @JsonClass(generateAdapter = true)
 data class GeocodingMeta(
-    @Json(name = "total_count") val totalCount: Int
+    @Json(name = "total_count") val totalCount: Int,
 )
 
 @JsonClass(generateAdapter = true)
 data class GeocodingDocument(
     @Json(name = "address") val address: Address?,
-    @Json(name = "road_address") val roadAddress: RoadAddress?
+    @Json(name = "road_address") val roadAddress: RoadAddress?,
 )
 
 @JsonClass(generateAdapter = true)
@@ -28,7 +28,7 @@ data class Address(
     @Json(name = "region_3depth_name") val region3depthName: String,
     @Json(name = "mountain_yn") val mountainYn: String,
     @Json(name = "main_address_no") val mainAddressNo: String,
-    @Json(name = "sub_address_no") val subAddressNo: String
+    @Json(name = "sub_address_no") val subAddressNo: String,
 )
 
 @JsonClass(generateAdapter = true)
@@ -42,5 +42,5 @@ data class RoadAddress(
     @Json(name = "main_building_no") val mainBuildingNo: String,
     @Json(name = "sub_building_no") val subBuildingNo: String,
     @Json(name = "building_name") val buildingName: String?,
-    @Json(name = "zone_no") val zoneNo: String
+    @Json(name = "zone_no") val zoneNo: String,
 )

--- a/core/network/src/main/java/com/school_of_company/network/dto/kakao/KakaoGeocodingResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/kakao/KakaoGeocodingResponse.kt
@@ -1,0 +1,46 @@
+package com.school_of_company.network.dto.kakao
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class KakaoGeocodingResponse(
+    @Json(name = "meta") val meta: GeocodingMeta,
+    @Json(name = "documents") val documents: List<GeocodingDocument>
+)
+
+@JsonClass(generateAdapter = true)
+data class GeocodingMeta(
+    @Json(name = "total_count") val totalCount: Int
+)
+
+@JsonClass(generateAdapter = true)
+data class GeocodingDocument(
+    @Json(name = "address") val address: Address?,
+    @Json(name = "road_address") val roadAddress: RoadAddress?
+)
+
+@JsonClass(generateAdapter = true)
+data class Address(
+    @Json(name = "address_name") val addressName: String,
+    @Json(name = "region_1depth_name") val region1depthName: String,
+    @Json(name = "region_2depth_name") val region2depthName: String,
+    @Json(name = "region_3depth_name") val region3depthName: String,
+    @Json(name = "mountain_yn") val mountainYn: String,
+    @Json(name = "main_address_no") val mainAddressNo: String,
+    @Json(name = "sub_address_no") val subAddressNo: String
+)
+
+@JsonClass(generateAdapter = true)
+data class RoadAddress(
+    @Json(name = "address_name") val addressName: String,
+    @Json(name = "region_1depth_name") val region1depthName: String,
+    @Json(name = "region_2depth_name") val region2depthName: String,
+    @Json(name = "region_3depth_name") val region3depthName: String,
+    @Json(name = "road_name") val roadName: String,
+    @Json(name = "underground_yn") val undergroundYn: String,
+    @Json(name = "main_building_no") val mainBuildingNo: String,
+    @Json(name = "sub_building_no") val subBuildingNo: String,
+    @Json(name = "building_name") val buildingName: String?,
+    @Json(name = "zone_no") val zoneNo: String
+)

--- a/core/network/src/main/java/com/school_of_company/network/dto/kakao/KakaoGetAddressResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/kakao/KakaoGetAddressResponse.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-data class KakaoGeocodingResponse(
+data class KakaoGetAddressResponse(
     @Json(name = "meta") val meta: GeocodingMeta,
     @Json(name = "documents") val documents: List<GeocodingDocument>,
 )

--- a/core/network/src/main/java/com/school_of_company/network/dto/kakao/KakaoGetCoordinatesResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/kakao/KakaoGetCoordinatesResponse.kt
@@ -19,6 +19,6 @@ data class KakaoMeta(
 @JsonClass(generateAdapter = true)
 data class KakaoDocument(
     @Json(name = "address_name") val addressName: String,
-    @Json(name = "x") val longitude: String, // 경도
-    @Json(name = "y") val latitude: String, // 위도
+    @Json(name = "x") val x: String, // 경도
+    @Json(name = "y") val y: String, // 위도
 )

--- a/core/network/src/main/java/com/school_of_company/network/dto/kakao/KakaoGetCoordinatesResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/kakao/KakaoGetCoordinatesResponse.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-data class KakaoAddressResponse(
+data class KakaoGetCoordinatesResponse(
     @Json(name = "meta") val meta: KakaoMeta,
     @Json(name = "documents") val documents: List<KakaoDocument>,
 )

--- a/core/network/src/main/java/com/school_of_company/network/mapper/kakao/kakaoAddressResponseMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/kakao/kakaoAddressResponseMapper.kt
@@ -1,16 +1,16 @@
 package com.school_of_company.network.mapper.kakao
 
-import com.school_of_company.model.model.kakao.KakaoAddressModel
-import com.school_of_company.network.dto.kakao.KakaoAddressResponse
+import com.school_of_company.model.model.kakao.KakaoGetCoordinatesModel
+import com.school_of_company.network.dto.kakao.KakaoGetCoordinatesResponse
 
-fun KakaoAddressResponse.toModel(): KakaoAddressModel {
-    val document = documents.firstOrNull() ?: return KakaoAddressModel(
+fun KakaoGetCoordinatesResponse.toModel(): KakaoGetCoordinatesModel {
+    val document = documents.firstOrNull() ?: return KakaoGetCoordinatesModel(
         addressName = "Unknown",
         x = "0.0",
         y = "0.0"
     )
 
-    return KakaoAddressModel(
+    return KakaoGetCoordinatesModel(
         addressName = document.addressName,
         x = document.x,
         y = document.y

--- a/core/network/src/main/java/com/school_of_company/network/mapper/kakao/kakaoGeocodingResponseMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/kakao/kakaoGeocodingResponseMapper.kt
@@ -1,0 +1,12 @@
+package com.school_of_company.network.mapper.kakao
+
+import com.school_of_company.model.model.kakao.KakaoGeocodingModel
+import com.school_of_company.network.dto.kakao.KakaoGetAddressResponse
+
+fun KakaoGetAddressResponse.toModel(): KakaoGeocodingModel {
+    val document = documents.firstOrNull() ?: return KakaoGeocodingModel(
+        addressName = "Unknown",
+    )
+
+    return KakaoGeocodingModel(addressName = document.address?.addressName ?: "Unknown")
+}

--- a/core/network/src/main/java/com/school_of_company/network/util/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/school_of_company/network/util/AuthInterceptor.kt
@@ -38,7 +38,7 @@ class AuthInterceptor @Inject constructor(
             }
 
             // kakao api 에 대해서는 KakaoRestApiKey 를 추가합니다
-            path in listOf("/search", "/geo") && method in listOf(GET) -> {
+            Regex("/(search|geo)").containsMatchIn(path) && method in listOf(GET) -> {
                 request.newBuilder().addHeader("Authorization", "KakaoAK ${BuildConfig.KAKAO_REST_KEY}").build()
             }
 

--- a/core/network/src/main/java/com/school_of_company/network/util/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/school_of_company/network/util/AuthInterceptor.kt
@@ -1,6 +1,7 @@
 package com.school_of_company.network.util
 
 import com.school_of_company.datastore.datasource.AuthTokenDataSource
+import com.school_of_company.network.BuildConfig
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
@@ -36,9 +37,9 @@ class AuthInterceptor @Inject constructor(
                 request
             }
 
-            // kakao api 에 대해서는 토큰을 추가하지 않습니다
-            path.contains("/search") && method in listOf(GET) -> {
-                request
+            // kakao api 에 대해서는 KakaoRestApiKey 를 추가합니다
+            path in listOf("/search", "/geo") && method in listOf(GET) -> {
+                request.newBuilder().addHeader("Authorization", "KakaoAK ${BuildConfig.KAKAO_REST_KEY}").build()
             }
 
             // "/sms"의 경로에 대해서는 토큰을 추가하지 않습니다.

--- a/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
@@ -64,6 +64,7 @@ fun NavGraphBuilder.expoDetailScreen(
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit,
     onMessageClick: (String, String) -> Unit,
+    onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
 ) {
     composable(route = "$expoDetailRoute/{id}") { backStackEntry ->
         val id = backStackEntry.arguments?.getString("id") ?: ""
@@ -74,6 +75,7 @@ fun NavGraphBuilder.expoDetailScreen(
             onModifyClick = onModifyClick,
             onProgramClick = onProgramClick,
             onMessageClick = onMessageClick,
+            onErrorToast = onErrorToast,
         )
     }
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -140,8 +140,8 @@ internal fun ExpoCreateRoute(
                         description = viewModel.introduce_title.value,
                         location = viewModel.location.value,
                         coverImage = (imageUpLoadUiState as ImageUpLoadUiState.Success).data.imageURL,
-                        x = viewModel.coordinateX.value,
-                        y = viewModel.coordinateY.value,
+                        x = viewModel.coordinateX.value.toDoubleOrNull()?.let { "%.6f".format(it) } ?: "0.000000",
+                        y = viewModel.coordinateY.value.toDoubleOrNull()?.let { "%.6f".format(it) } ?: "0.000000",
                         addStandardProRequestDto = standardProgramTextState,
                         addTrainingProRequestDto = trainingProgramTextState
                     )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -521,7 +521,7 @@ private fun ExpoCreateScreen(
                             modifier = Modifier.fillMaxWidth()
                         ) {
                             ExpoLocationIconTextField(
-                                placeholder = "장소를 입력해주세요.",
+                                placeholder = "위치를 알려주세요.",
                                 isDisabled = false,
                                 onValueChange = onLocationChange,
                                 onButtonClicked = searchLocation,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -45,6 +45,7 @@ import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.expo.view.component.HomeKakaoMap
 import com.school_of_company.expo.viewmodel.ExpoViewModel
+import com.school_of_company.expo.viewmodel.uistate.GetCoordinatesToAddressUiState
 import com.school_of_company.expo.viewmodel.uistate.GetExpoInformationUiState
 import com.school_of_company.expo.viewmodel.uistate.GetStandardProgramListUiState
 import com.school_of_company.expo.viewmodel.uistate.GetTrainingProgramListUiState
@@ -67,10 +68,21 @@ internal fun ExpoDetailRoute(
     val getExpoInformationUiState by viewModel.getExpoInformationUiState.collectAsStateWithLifecycle()
     val getTrainingProgramUiState by viewModel.getTrainingProgramListUiState.collectAsStateWithLifecycle()
     val getStandardProgramUiState by viewModel.getStandardProgramListUiState.collectAsStateWithLifecycle()
+    val convertCoordinatesToAddressState by viewModel.convertCoordinatesToAddressResult.collectAsStateWithLifecycle()
+    val getCoordinatesToAddressUiState by viewModel.getCoordinatesToAddressUiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(getCoordinatesToAddressUiState) {
+        when (getCoordinatesToAddressUiState) {
+            is GetCoordinatesToAddressUiState.Loading -> Unit
+            is GetCoordinatesToAddressUiState.Success -> onErrorToast(null, R.string.convert_coordinates_to_address_success)
+            is GetCoordinatesToAddressUiState.Error -> onErrorToast(null, R.string.convert_coordinates_to_address_fail)
+        }
+    }
 
     ExpoDetailScreen(
         modifier = modifier,
         id = id,
+        convertCoordinatesToAddressState = convertCoordinatesToAddressState,
         getExpoInformationUiState = getExpoInformationUiState,
         getTrainingProgramUiState = getTrainingProgramUiState,
         getStandardProgramUiState = getStandardProgramUiState,
@@ -92,6 +104,7 @@ internal fun ExpoDetailRoute(
 private fun ExpoDetailScreen(
     modifier: Modifier = Modifier,
     id: String,
+    convertCoordinatesToAddressState: String,
     getExpoInformationUiState: GetExpoInformationUiState,
     getTrainingProgramUiState: GetTrainingProgramListUiState,
     getStandardProgramUiState: GetStandardProgramListUiState,
@@ -268,7 +281,7 @@ private fun ExpoDetailScreen(
                             )
 
                             Text(
-                                text = "주소 : 광주광역시 광산구 312",
+                                text = convertCoordinatesToAddressState,
                                 style = typography.bodyRegular2,
                                 color = colors.gray400,
                             )
@@ -431,6 +444,7 @@ private fun HomeDetailScreenPreview() {
         getExpoInformationUiState = GetExpoInformationUiState.Loading,
         getTrainingProgramUiState = GetTrainingProgramListUiState.Loading,
         getStandardProgramUiState = GetStandardProgramListUiState.Loading,
-        id = ""
+        id = "",
+        convertCoordinatesToAddressState = ""
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -275,13 +275,13 @@ private fun ExpoDetailScreen(
                             )
 
                             Text(
-                                text = "장소 : ${getExpoInformationUiState.data.location}",
+                                text = convertCoordinatesToAddressState,
                                 style = typography.bodyRegular2,
                                 color = colors.gray400,
                             )
 
                             Text(
-                                text = convertCoordinatesToAddressState,
+                                text = "상세주소 : ${getExpoInformationUiState.data.location}",
                                 style = typography.bodyRegular2,
                                 color = colors.gray400,
                             )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -68,7 +68,6 @@ internal fun ExpoDetailRoute(
     val getExpoInformationUiState by viewModel.getExpoInformationUiState.collectAsStateWithLifecycle()
     val getTrainingProgramUiState by viewModel.getTrainingProgramListUiState.collectAsStateWithLifecycle()
     val getStandardProgramUiState by viewModel.getStandardProgramListUiState.collectAsStateWithLifecycle()
-    val convertCoordinatesToAddressState by viewModel.convertCoordinatesToAddressResult.collectAsStateWithLifecycle()
     val getCoordinatesToAddressUiState by viewModel.getCoordinatesToAddressUiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(getCoordinatesToAddressUiState) {
@@ -82,10 +81,10 @@ internal fun ExpoDetailRoute(
     ExpoDetailScreen(
         modifier = modifier,
         id = id,
-        convertCoordinatesToAddressState = convertCoordinatesToAddressState,
         getExpoInformationUiState = getExpoInformationUiState,
         getTrainingProgramUiState = getTrainingProgramUiState,
         getStandardProgramUiState = getStandardProgramUiState,
+        getCoordinatesToAddressUiState = getCoordinatesToAddressUiState,
         onBackClick = onBackClick,
         onMessageClick = { authority -> onMessageClick(id, authority) },
         onCheckClick = onCheckClick,
@@ -104,16 +103,16 @@ internal fun ExpoDetailRoute(
 private fun ExpoDetailScreen(
     modifier: Modifier = Modifier,
     id: String,
-    convertCoordinatesToAddressState: String,
     getExpoInformationUiState: GetExpoInformationUiState,
     getTrainingProgramUiState: GetTrainingProgramListUiState,
     getStandardProgramUiState: GetStandardProgramListUiState,
+    getCoordinatesToAddressUiState: GetCoordinatesToAddressUiState,
     scrollState: ScrollState = rememberScrollState(),
     onBackClick: () -> Unit,
     onMessageClick: (String) -> Unit,
     onCheckClick: (String) -> Unit,
     onModifyClick: (String) -> Unit,
-    onProgramClick: (String) -> Unit
+    onProgramClick: (String) -> Unit,
 ) {
     val (openDialog, isOpenDialog) = rememberSaveable { mutableStateOf(false) }
 
@@ -273,9 +272,14 @@ private fun ExpoDetailScreen(
                                 color = colors.gray600,
                                 fontWeight = FontWeight(600),
                             )
+                            val addressMessage = when (getCoordinatesToAddressUiState) {
+                                is GetCoordinatesToAddressUiState.Error -> "오류 발생"
+                                is GetCoordinatesToAddressUiState.Loading -> "로딩중입니다.."
+                                is GetCoordinatesToAddressUiState.Success -> "주소 : ${getCoordinatesToAddressUiState.data.addressName}"
+                            }
 
                             Text(
-                                text = convertCoordinatesToAddressState,
+                                text = addressMessage,
                                 style = typography.bodyRegular2,
                                 color = colors.gray400,
                             )
@@ -445,6 +449,6 @@ private fun HomeDetailScreenPreview() {
         getTrainingProgramUiState = GetTrainingProgramListUiState.Loading,
         getStandardProgramUiState = GetStandardProgramListUiState.Loading,
         id = "",
-        convertCoordinatesToAddressState = ""
+        getCoordinatesToAddressUiState = GetCoordinatesToAddressUiState.Loading
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -61,6 +61,7 @@ internal fun ExpoDetailRoute(
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit,
     onMessageClick: (String, String) -> Unit,
+    onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
     viewModel: ExpoViewModel = hiltViewModel(),
 ) {
     val getExpoInformationUiState by viewModel.getExpoInformationUiState.collectAsStateWithLifecycle()

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -268,7 +268,7 @@ private fun ExpoDetailScreen(
 
                         Column(verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Bottom)) {
                             Text(
-                                text = "장소 지도",
+                                text = "장소",
                                 style = typography.bodyRegular2,
                                 color = colors.gray600,
                                 fontWeight = FontWeight(600),

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -192,6 +192,7 @@ internal class ExpoViewModel @Inject constructor(
                             onIntroduceTitleChange(it.description)
                             onLocationChange(it.location)
                             onCoverImageChange(it.coverImage)
+                            convertXYToJibun(x = it.x, y = it.y)
                         }
                     }
                     is Result.Error -> _getExpoInformationUiState.value = GetExpoInformationUiState.Error(result.exception)
@@ -446,7 +447,7 @@ internal class ExpoViewModel @Inject constructor(
             }
     }
 
-    internal fun convertXYToJibun(x: String, y: String) = viewModelScope.launch {
+    private fun convertXYToJibun(x: String, y: String) = viewModelScope.launch {
         getCoordinatesToAddressUseCase(x = x, y = y)
             .asResult()
             .collectLatest { result ->

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -157,16 +157,6 @@ internal class ExpoViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
 
-    val convertCoordinatesToAddressResult: StateFlow<String> = getCoordinatesToAddressUiState
-        .map { state ->
-            when (state) {
-                is GetCoordinatesToAddressUiState.Loading -> "로딩중.."
-                is GetCoordinatesToAddressUiState.Success -> "주소 : ${state.data.addressName}"
-                is GetCoordinatesToAddressUiState.Error, -> "오류 발생"
-            }
-        }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "로딩중..")
-
     val addressList: StateFlow<List<JusoModel>> = getAddressUiState
         .map { state ->
             when (state) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -157,6 +157,16 @@ internal class ExpoViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
 
+    val convertCoordinatesToAddressState: StateFlow<String> = getCoordinatesToAddressUiState
+        .map { state ->
+            when (state) {
+                is GetCoordinatesToAddressUiState.Loading -> "로딩중.."
+                is GetCoordinatesToAddressUiState.Success -> "주소 : ${state.data.addressName}"
+                is GetCoordinatesToAddressUiState.Error, -> "오류 발생"
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "로딩중..")
+
     val addressList: StateFlow<List<JusoModel>> = getAddressUiState
         .map { state ->
             when (state) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -157,7 +157,7 @@ internal class ExpoViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0)
 
-    val convertCoordinatesToAddressState: StateFlow<String> = getCoordinatesToAddressUiState
+    val convertCoordinatesToAddressResult: StateFlow<String> = getCoordinatesToAddressUiState
         .map { state ->
             when (state) {
                 is GetCoordinatesToAddressUiState.Loading -> "로딩중.."

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetCoordinatesToAddressUiState.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetCoordinatesToAddressUiState.kt
@@ -1,0 +1,9 @@
+package com.school_of_company.expo.viewmodel.uistate
+
+import com.school_of_company.model.model.kakao.KakaoGeocodingModel
+
+sealed interface GetCoordinatesToAddressUiState {
+    object Loading : GetCoordinatesToAddressUiState
+    data class Success(val data: KakaoGeocodingModel) : GetCoordinatesToAddressUiState
+    data class Error(val exception: Throwable) : GetCoordinatesToAddressUiState
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetCoordinatesUiState.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetCoordinatesUiState.kt
@@ -1,9 +1,9 @@
 package com.school_of_company.expo.viewmodel.uistate
 
-import com.school_of_company.model.model.kakao.KakaoAddressModel
+import com.school_of_company.model.model.kakao.KakaoGetCoordinatesModel
 
 sealed interface GetCoordinatesUiState {
     object Loading : GetCoordinatesUiState
-    data class Success(val data: KakaoAddressModel) : GetCoordinatesUiState
+    data class Success(val data: KakaoGetCoordinatesModel) : GetCoordinatesUiState
     data class Error(val exception: Throwable) : GetCoordinatesUiState
 }


### PR DESCRIPTION
### 💡 개요  
Expo 생성 시 XY 좌표를 주소로 변환하는 기능 추가 및 Kakao API 개선  

![image](https://github.com/user-attachments/assets/7bdd3fa8-7903-446b-93c0-e0ba7ab95689)

### 📃 작업내용  
- **Expo 생성 시 XY 좌표를 주소로 변환하도록 수정**  
  - `convertXYToJibun` 함수 추가  
  - `getExpoInformation` 함수가 성공했을 때 `convertXYToJibun` 실행  
  - `convertCoordinatesToAddressResult`를 주소 입력 부분에서 활용  
- **좌표 값 소수점 6자리까지 반영하도록 수정**  
- **Kakao API 관련 개선**  
  - `KakaoGeocodingResponse` → `KakaoGetAddressResponse`로 변경  
  - `KakaoRepository` 및 `KakaoLocalDataSource`에 `getAddress` API 추가  
  - Kakao API 판별식을 `Regex`를 이용한 방식으로 변경  
  - `AuthInterceptor`에서 Kakao API의 rest api key를 처리하도록 수정  

### 🔀 변경사항  
- Expo 생성 시 XY 좌표가 자동으로 주소로 변환됨  
- 좌표 값(`coordinateX`, `coordinateY`)을 소수점 6자리까지만 반영  
- Kakao API의 응답 모델 및 API 구조 변경  

### 🍴 사용방법  
- Expo 생성 시 XY 좌표가 자동으로 주소로 변환됨  
- 입력된 좌표 값이 최대 소수점 6자리까지만 저장됨  
- Kakao API 인증 헤더가 `AuthInterceptor`에서 자동 처리됨  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 네비게이션 스크린에서 오류 발생 시 일관되고 즉각적인 알림 메시지가 제공되어 사용자 피드백이 향상되었습니다.
	- 좌표를 주소로 변환하는 기능이 개선되어, 좌표 값이 소수점 여섯자리로 정밀하게 포맷되며, 성공 및 오류 여부를 명확하게 안내합니다.
	- 주소 및 좌표 검색 관련 통신 로직이 업데이트되어 전반적인 기능 신뢰성과 경험이 개선되었습니다.
	- 새로운 UI 상태 관리 기능이 추가되어 좌표 변환 과정의 로딩, 성공, 오류 상태를 명확하게 표현합니다.
	- Kakao API와의 통신을 위한 새로운 메서드가 추가되어 주소 및 좌표 검색 기능이 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->