### PR TITLE
🔀 :: (#417) - Ci가 성공 상태일때 리뷰하는 팀원을 맨션할 수 있도록 하였습니다.

### DIFF
--- a/.github/workflows/expo_ci.yml
+++ b/.github/workflows/expo_ci.yml
@@ -51,7 +51,7 @@ jobs:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}
           image: ${{ secrets.SUCCESS_IMAGE }}
-          description: 뀨
+          description: @이명훈 @문혜성
           color: 65280
           url: "https://github.com/sarisia/actions-status-discord"
           username: Expo-CI Bot

--- a/.github/workflows/expo_ci.yml
+++ b/.github/workflows/expo_ci.yml
@@ -50,8 +50,9 @@ jobs:
           title: ✅ Expo-Android-CI Success! ✅
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}
+          content: "<@${{ secrets.ID1 }}> <@${{ secrets.ID2 }}> CI 성공하였습니다. 확인부탁드립니다."
           image: ${{ secrets.SUCCESS_IMAGE }}
-          description: @이명훈 @문혜성
+          description: 뀨
           color: 65280
           url: "https://github.com/sarisia/actions-status-discord"
           username: Expo-CI Bot

--- a/.github/workflows/expo_ci.yml
+++ b/.github/workflows/expo_ci.yml
@@ -50,9 +50,8 @@ jobs:
           title: ✅ Expo-Android-CI Success! ✅
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}
-#          content: "@${{ secrets.ID1 }} @${{ secrets.ID2 }} CI 성공하였습니다. 확인부탁드립니다."
           image: ${{ secrets.SUCCESS_IMAGE }}
-          description: @문혜성 @이명훈
+          description: "<@${{ secrets.ID1 }}> <@${{ secrets.ID2 }}>"
           color: 65280
           url: "https://github.com/sarisia/actions-status-discord"
           username: Expo-CI Bot

--- a/.github/workflows/expo_ci.yml
+++ b/.github/workflows/expo_ci.yml
@@ -50,7 +50,7 @@ jobs:
           title: ✅ Expo-Android-CI Success! ✅
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}
-          content: "<@${{ secrets.ID1 }}> <@${{ secrets.ID2 }}> CI 성공하였습니다. 확인부탁드립니다."
+          content: "@${{ secrets.ID1 }} @${{ secrets.ID2 }} CI 성공하였습니다. 확인부탁드립니다."
           image: ${{ secrets.SUCCESS_IMAGE }}
           description: 뀨
           color: 65280

--- a/.github/workflows/expo_ci.yml
+++ b/.github/workflows/expo_ci.yml
@@ -50,9 +50,9 @@ jobs:
           title: ✅ Expo-Android-CI Success! ✅
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}
-          content: "@${{ secrets.ID1 }} @${{ secrets.ID2 }} CI 성공하였습니다. 확인부탁드립니다."
+#          content: "@${{ secrets.ID1 }} @${{ secrets.ID2 }} CI 성공하였습니다. 확인부탁드립니다."
           image: ${{ secrets.SUCCESS_IMAGE }}
-          description: 뀨
+          description: @문혜성 @이명훈
           color: 65280
           url: "https://github.com/sarisia/actions-status-discord"
           username: Expo-CI Bot


### PR DESCRIPTION
## 💡 개요
- Ci가 성공하였을때마다 맨션을 직접 작성해주어야하는 불편함이 있어 성공 했을때 자동으로 입력이 될 수 있도록 합니다.
## 📃 작업내용
- Ci가 성공 상태일때 리뷰하는 팀원을 맨션할 수 있도록 하였습니다.

    <img width="462" alt="스크린샷 2025-02-09 오후 9 58 25" src="https://github.com/user-attachments/assets/d3c8d61f-148f-488b-a0ca-3be486cc2700" />

## 🔀 변경사항
- chore expo_ci
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- CI 알림 메시지를 업데이트하여 성공 및 실패 알림에 팀원 멘션을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->