### PR TITLE
🔀 :: (#399) - 박람회를 생성하는 도중 다른 네비게이션으로 이동 후 다시 리컴포지션 되었을때 이미지의 데이터가 사라지는 이슈가 있어 이를 해결하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -107,7 +107,7 @@ internal fun ExpoCreateRoute(
     val trainingProgramTextState by viewModel.trainingProgramTextState.collectAsStateWithLifecycle()
     val standardProgramTextState by viewModel.standardProgramTextState.collectAsStateWithLifecycle()
 
-    var selectedImageUri by remember { mutableStateOf<Uri?>(null) }
+    var selectedImageUri by rememberSaveable { mutableStateOf<Uri?>(null) }
 
     val context = LocalContext.current
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -103,7 +102,7 @@ internal fun ExpoModifyRoute(
     val trainingProgramTextState by viewModel.trainingProgramModifyTextState.collectAsStateWithLifecycle()
     val standardProgramTextState by viewModel.standardProgramModifyTextState.collectAsStateWithLifecycle()
 
-    var selectedImageUri by remember { mutableStateOf<Uri?>(null) }
+    var selectedImageUri by rememberSaveable { mutableStateOf<Uri?>(null) }
 
     val context = LocalContext.current
 


### PR DESCRIPTION
## 💡 개요
- 박람회를 생성하는 도중 다른 네비게이션으로 이동 후 다시 리컴포지션 되었을때 이미지의 데이터가 사라지는 이슈가 있어 해결이 필요했습니다.
## 📃 작업내용
- 박람회를 생성하는 도중 다른 네비게이션으로 이동 후 다시 리컴포지션 되었을때 이미지의 데이터가 사라지는 이슈가 있어 이를 해결하였습니다.
   - remember 말고 rememberSaveable 함수를 사용하여 화면을 회전하거나 네비게이션으로 이동해도 유지가 될 수 있도록 하였습니다.
## 🔀 변경사항
- chore ExpoCreateScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 화면 회전 등 구성 변경 시 이미지 선택 상태가 유지되어, 사용 중 선택한 이미지가 사라지지 않습니다.
	- 설정 메뉴(하단 시트) 상태도 구성 변경 후 보존되어 더 안정적인 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->