### PR TITLE
🔀 :: (#441) - 자동 로그인이 동작하는 과정에서 바로 homeRoute로 넘어가는 것이 아니라 signInRoute를 거쳐서가는 문제를 해결하였습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/MainActivity.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/MainActivity.kt
@@ -28,6 +28,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
 
         setContent {
+            if (viewModel.appLoginState.value is AppLoginState.Loading) return@setContent
+
             val startDestination = when (viewModel.appLoginState.value) {
                 is AppLoginState.Success -> homeRoute
                 else -> sigInRoute


### PR DESCRIPTION
## 💡 개요
- 자동 로그인이 동작하는 과정에서 바로 homeRoute로 넘어가는 것이 아니라 signInRoute를 거쳐서가는 문제가 있습니다.
## 📃 작업내용
- 자동 로그인이 동작하는 과정에서 바로 homeRoute로 넘어가는 것이 아니라 signInRoute를 거쳐서가는 문제를 해결하였습니다.
    - 위 문제가 일어나는 이유는 appViewModel에서 tokenRefresh() 동작을 비동기적으로 처리한 것이였습니다. -> viewModel에서 처음에 tokenRefresh를 onCreate() 될때 비동기적으로 처리하게 되면 startDestination이 기본적으로 signInRoute으로 설정된 상태가 됩니다. 때문에 tokenRefresh에서 로딩이후 Success 동작을 할때 먼저 설정된 signInRoute를 따고 homeRoute로 넘갔습니다.
    - 간단하게 Loading 상태일때 setContent(이 안에 startDestination을 결정하는 코드가 포함)가 동작되지 않고 스플래시 화면이 유지되고 Success가 되면 setContent가 실행 될 수 있도록 하였습니다.
    - before

       https://github.com/user-attachments/assets/55fb3d1a-fb87-4d99-975e-aa31aca1d038

    - after
    
       https://github.com/user-attachments/assets/c0195cc1-1d63-4eaa-a181-5436031c85de

## 🔀 변경사항
- chore MainActivity
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩터링**
  - 앱 초기 실행 시 로그인 상태가 로딩 중일 때 불필요한 화면 전환을 생략하여, 사용자가 보다 원활한 초기 경험을 할 수 있도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->