### PR TITLE
🔀 :: (#443) - 뒤로가기 버튼을 빠르게 두번 클릭하면 액티비티가 종료되도록하여 사용자 입장을 개선하였습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/MainActivity.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.school_of_company.expo_android
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -15,6 +17,9 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    private var backPressedTime: Long = 0
+    private val BACK_PRESSED_DURATION: Long = 2000L
+
     private val viewModel: AppViewModel by viewModels()
 
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
@@ -40,5 +45,17 @@ class MainActivity : ComponentActivity() {
                 windowSizeClass = calculateWindowSizeClass(activity = this),
             )
         }
+
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                val currentTime = System.currentTimeMillis()
+                if (currentTime - backPressedTime < BACK_PRESSED_DURATION) {
+                    finishAffinity()
+                } else {
+                    Toast.makeText(this@MainActivity, "한 번 더 누르면 종료됩니다.", Toast.LENGTH_SHORT).show()
+                    backPressedTime = currentTime
+                }
+            }
+        })
     }
 }


### PR DESCRIPTION
## 💡 개요
- 뒤로가기를 제어할 방법을 생각..
## 📃 작업내용
- 뒤로가기 버튼을 빠르게 두번 클릭하면 액티비티가 종료되도록하여 사용자 입장을 개선하였습니다.
   - onBackPressedDispatcher를 사용하여 뒤로가기 버튼을 제어할 수 있도록 하였습니다.
   - currentTime - backPressedTime을 계산하여 2초내에 사용자가 뒤로가기 버튼을 연속해서 클릭하면 액티비티가 종료되도록 하였습니다.

       https://github.com/user-attachments/assets/a1ff2092-874c-4a72-b3d1-f8cf93e707c5

## 🔀 변경사항
- chore MainActivity
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 뒤로 가기 버튼을 한 번 누르면 종료 확인 메시지가 표시되고, 두 번 연속 누를 경우 앱이 종료되도록 개선되었습니다.
  - 이로써 실수로 인한 앱 종료를 방지하여 사용자 경험을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->