### PR TITLE
🔀 :: (#445) - 박람회 자세히 보기 화면을 디자인 변경사항에 따라 수정하였습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -1,5 +1,8 @@
 package com.school_of_company.expo_android.navigation
 
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -7,11 +10,14 @@ import androidx.navigation.compose.NavHost
 import com.school_of_company.common.exception.*
 import com.school_of_company.design_system.R
 import com.school_of_company.expo.navigation.expoAddressSearchScreen
+import com.school_of_company.expo.navigation.expoCreateRoute
 import com.school_of_company.expo.navigation.expoCreateScreen
+import com.school_of_company.expo.navigation.expoCreatedRoute
 import com.school_of_company.expo.navigation.expoCreatedScreen
 import com.school_of_company.expo.navigation.expoDetailScreen
 import com.school_of_company.expo.navigation.expoModifyScreen
 import com.school_of_company.expo.navigation.expoScreen
+import com.school_of_company.expo.navigation.homeRoute
 import com.school_of_company.expo.navigation.navigateToExpoAddressSearch
 import com.school_of_company.expo.navigation.navigateToExpoDetail
 import com.school_of_company.expo.navigation.navigateToExpoModify
@@ -38,6 +44,7 @@ import com.school_of_company.standard.navigation.standardProgramParticipantScree
 import com.school_of_company.training.navigation.navigateToTrainingProgramParticipant
 import com.school_of_company.training.navigation.trainingProgramParticipantScreen
 import com.school_of_company.ui.toast.makeToast
+import com.school_of_company.user.navigation.profileRoute
 import com.school_of_company.user.navigation.profileScreen
 
 @Composable
@@ -68,7 +75,11 @@ fun ExpoNavHost(
     NavHost(
         navController = navController,
         startDestination = startDestination,
-        modifier = modifier,
+        modifier = if (navController.currentDestination?.route in listOf(homeRoute, expoCreateRoute, expoCreatedRoute, profileRoute)) {
+            modifier
+        } else {
+            modifier.windowInsetsPadding(WindowInsets.navigationBars)
+        }
     ) {
 
         signInScreen(

--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -1,8 +1,5 @@
 package com.school_of_company.expo_android.navigation
 
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -10,14 +7,11 @@ import androidx.navigation.compose.NavHost
 import com.school_of_company.common.exception.*
 import com.school_of_company.design_system.R
 import com.school_of_company.expo.navigation.expoAddressSearchScreen
-import com.school_of_company.expo.navigation.expoCreateRoute
 import com.school_of_company.expo.navigation.expoCreateScreen
-import com.school_of_company.expo.navigation.expoCreatedRoute
 import com.school_of_company.expo.navigation.expoCreatedScreen
 import com.school_of_company.expo.navigation.expoDetailScreen
 import com.school_of_company.expo.navigation.expoModifyScreen
 import com.school_of_company.expo.navigation.expoScreen
-import com.school_of_company.expo.navigation.homeRoute
 import com.school_of_company.expo.navigation.navigateToExpoAddressSearch
 import com.school_of_company.expo.navigation.navigateToExpoDetail
 import com.school_of_company.expo.navigation.navigateToExpoModify
@@ -75,11 +69,7 @@ fun ExpoNavHost(
     NavHost(
         navController = navController,
         startDestination = startDestination,
-        modifier = if (navController.currentDestination?.route in listOf(homeRoute, expoCreateRoute, expoCreatedRoute, profileRoute)) {
-            modifier
-        } else {
-            modifier.windowInsetsPadding(WindowInsets.navigationBars)
-        }
+        modifier = modifier
     ) {
 
         signInScreen(

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/button/EffectButton.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/button/EffectButton.kt
@@ -18,6 +18,8 @@ import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import kotlinx.coroutines.delay
 
+private const val CLICK_EFFECT_DURATION = 100L
+
 @Composable
 fun EffectButton(
     modifier: Modifier = Modifier,
@@ -34,7 +36,7 @@ fun EffectButton(
         var isClicked by remember { mutableStateOf(false) }
 
         LaunchedEffect(isClicked) {
-            delay(100)
+            delay(CLICK_EFFECT_DURATION)
             isClicked = false
         }
 

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/button/EffectButton.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/button/EffectButton.kt
@@ -34,7 +34,7 @@ fun EffectButton(
         var isClicked by remember { mutableStateOf(false) }
 
         LaunchedEffect(isClicked) {
-            delay(500)
+            delay(100)
             isClicked = false
         }
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -36,7 +36,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.rememberAsyncImagePainter
 import com.school_of_company.design_system.R
-import com.school_of_company.design_system.component.button.ExpoButton
+import com.school_of_company.design_system.component.button.EffectButton
 import com.school_of_company.design_system.component.button.ExpoEnableButton
 import com.school_of_company.design_system.component.button.ExpoEnableDetailButton
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
@@ -46,7 +46,6 @@ import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.expo.view.component.ExpoDetailModifyDialog
 import com.school_of_company.expo.view.component.HomeKakaoMap
-import com.school_of_company.expo.view.component.MessageDialog
 import com.school_of_company.expo.viewmodel.ExpoViewModel
 import com.school_of_company.expo.viewmodel.uistate.GetCoordinatesToAddressUiState
 import com.school_of_company.expo.viewmodel.uistate.GetExpoInformationUiState
@@ -127,6 +126,7 @@ private fun ExpoDetailScreen(
     val (openDialog, isOpenDialog) = rememberSaveable { mutableStateOf(false) }
     val (openModifyDialog, isOpenModifyDialog) = rememberSaveable { mutableStateOf(false) }
     val (openFormModifyDialog, isOpenFormModifyDialog) = rememberSaveable { mutableStateOf(false) }
+    val (openFormCreateDialog, isOpenFormCreateDialog) = rememberSaveable { mutableStateOf(false) }
 
     ExpoAndroidTheme { colors, typography ->
         when {
@@ -329,34 +329,84 @@ private fun ExpoDetailScreen(
                                     .padding(top = 38.dp)
                             ) {
 
-                                ExpoButton(
-                                    text = "프로그램",
-                                    color = colors.main,
-                                    onClick = { onProgramClick(id) },
+                                EffectButton(
+                                    text = "문자 보내기",
+                                    defaultBackgroundColor = colors.white,
+                                    defaultTextColor = colors.main,
+                                    clickedTextColor = colors.white,
+                                    clickedBackgroundColor = colors.main,
+                                    onClick = { isOpenDialog(true) },
                                     modifier = Modifier
                                         .weight(1f)
-                                        .padding(
-                                            vertical = 15.dp,
-                                            horizontal = 41.5.dp
+                                        .border(
+                                            width = 1.dp,
+                                            color = colors.main,
+                                            shape = RoundedCornerShape(6.dp)
                                         )
                                 )
 
-                                ExpoButton(
+                                EffectButton(
+                                    text = "통계 확인하기",
+                                    defaultBackgroundColor = colors.white,
+                                    defaultTextColor = colors.main,
+                                    clickedTextColor = colors.white,
+                                    clickedBackgroundColor = colors.main,
+                                    onClick = {  }, // todo : Navigate To Statistics Screen Logic
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .border(
+                                            width = 1.dp,
+                                            color = colors.main,
+                                            shape = RoundedCornerShape(6.dp)
+                                        )
+                                )
+                            }
+
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(
+                                    16.dp,
+                                    Alignment.CenterHorizontally
+                                ),
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+
+                                EffectButton(
+                                    text = "프로그램",
+                                    defaultBackgroundColor = colors.white,
+                                    defaultTextColor = colors.main,
+                                    clickedTextColor = colors.white,
+                                    clickedBackgroundColor = colors.main,
+                                    onClick = { onProgramClick(id) },
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .border(
+                                            width = 1.dp,
+                                            color = colors.main,
+                                            shape = RoundedCornerShape(6.dp)
+                                        )
+                                )
+
+                                EffectButton(
                                     text = "조회하기",
-                                    color = colors.main,
+                                    defaultBackgroundColor = colors.white,
+                                    defaultTextColor = colors.main,
+                                    clickedTextColor = colors.white,
+                                    clickedBackgroundColor = colors.main,
                                     onClick = { onCheckClick(id) },
                                     modifier = Modifier
                                         .weight(1f)
-                                        .padding(
-                                            vertical = 15.dp,
-                                            horizontal = 41.5.dp
+                                        .border(
+                                            width = 1.dp,
+                                            color = colors.main,
+                                            shape = RoundedCornerShape(6.dp)
                                         )
                                 )
                             }
 
                             ExpoEnableDetailButton(
-                                text = "문자 보내기",
-                                onClick = { isOpenDialog(true) },
+                                text = "폼 생성하기",
+                                onClick = { isOpenFormCreateDialog(true) },
                                 modifier = Modifier.fillMaxWidth()
                             )
 
@@ -421,16 +471,19 @@ private fun ExpoDetailScreen(
 
     if (openDialog) {
         Dialog(onDismissRequest = { isOpenDialog(false) }) {
-            MessageDialog(
-                onCancelClick = { isOpenDialog(false) },
-                onParticipantClick = {
+            ExpoDetailModifyDialog(
+                titleText = "누구에게 문자를 전송하시겠습니까?",
+                startButtonText = "참가자",
+                endButtonText = "연수자",
+                onStartClick = {
                     isOpenDialog(false)
                     onMessageClick(Authority.ROLE_STANDARD.name)
                 },
-                onTraineeClick = {
+                onEndClick = {
                     isOpenDialog(false)
                     onMessageClick(Authority.ROLE_TRAINEE.name)
-                }
+                },
+                onDismissClick = { isOpenDialog(false) }
             )
         }
     }
@@ -469,6 +522,25 @@ private fun ExpoDetailScreen(
                     // todo : Add Navigation STANDARD Form Screen Logic
                 },
                 onDismissClick = { isOpenFormModifyDialog(false) }
+            )
+        }
+    }
+
+    if (openFormCreateDialog) {
+        Dialog(onDismissRequest = { isOpenFormCreateDialog(false) }) {
+            ExpoDetailModifyDialog(
+                titleText = "어떤 폼을 생성하시겠습니까?",
+                startButtonText = "참가자",
+                endButtonText = "연수자",
+                onStartClick = {
+                    isOpenFormCreateDialog(false)
+                    // todo : Navigate To Create Form Screen Logic - STANDARD
+                },
+                onEndClick = {
+                    isOpenFormCreateDialog(false)
+                    // todo : Navigate To Create Form Screen Logic - TRAINEE
+                },
+                onDismissClick = { isOpenFormCreateDialog(false) }
             )
         }
     }


### PR DESCRIPTION
## 💡 개요
- 박람회 자세히 보기 화면에 디자인 변경 사항이 있어 이를 수정할 필요가 있었습니다.
## 📃 작업내용
- 박람회 자세히 보기 화면을 디자인 변경 사항에 따라 수정하였습니다.
   - EffectButton에서 이팩트 효과가 실행된 후 다시 원래 상태로 돌아오는 과정에서 딜레이가 0.5초로 설정을 했었지만 부자연스러워 0.1초로 설정하여 이팩트 동작을 더 자연스럽게 개선하였습니다.

       https://github.com/user-attachments/assets/a925471c-7293-4a5d-973d-22002ab12f50

## 🔀 변경사항
- chore ExpoDetailScreen
- chore EffectButton
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expo 상세 화면에 "문자 보내기" 및 "통계 확인하기" 버튼이 추가되어 기능과 디자인이 개선되었습니다.
  - 버튼의 반응 속도가 향상되어 빠른 시각적 피드백을 경험할 수 있습니다.
  - 새 폼 생성 대화창이 도입되어 참가자와 연수자 옵션 선택 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->