### PR TITLE
🔀 :: (#447) - 안드로이드 시스템바와 실제 서비스 화면이 서로 곂쳐지지않도록하여 사용자 입장을 개선하였습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -1,5 +1,8 @@
 package com.school_of_company.expo_android.navigation
 
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -7,11 +10,14 @@ import androidx.navigation.compose.NavHost
 import com.school_of_company.common.exception.*
 import com.school_of_company.design_system.R
 import com.school_of_company.expo.navigation.expoAddressSearchScreen
+import com.school_of_company.expo.navigation.expoCreateRoute
 import com.school_of_company.expo.navigation.expoCreateScreen
+import com.school_of_company.expo.navigation.expoCreatedRoute
 import com.school_of_company.expo.navigation.expoCreatedScreen
 import com.school_of_company.expo.navigation.expoDetailScreen
 import com.school_of_company.expo.navigation.expoModifyScreen
 import com.school_of_company.expo.navigation.expoScreen
+import com.school_of_company.expo.navigation.homeRoute
 import com.school_of_company.expo.navigation.navigateToExpoAddressSearch
 import com.school_of_company.expo.navigation.navigateToExpoDetail
 import com.school_of_company.expo.navigation.navigateToExpoModify
@@ -38,6 +44,7 @@ import com.school_of_company.standard.navigation.standardProgramParticipantScree
 import com.school_of_company.training.navigation.navigateToTrainingProgramParticipant
 import com.school_of_company.training.navigation.trainingProgramParticipantScreen
 import com.school_of_company.ui.toast.makeToast
+import com.school_of_company.user.navigation.profileRoute
 import com.school_of_company.user.navigation.profileScreen
 
 @Composable
@@ -68,7 +75,11 @@ fun ExpoNavHost(
     NavHost(
         navController = navController,
         startDestination = startDestination,
-        modifier = modifier,
+        modifier = if (navController.currentDestination?.route in listOf(homeRoute, expoCreateRoute, expoCreatedRoute, profileRoute)) {
+            modifier
+        } else {
+            modifier.windowInsetsPadding(WindowInsets.navigationBars)
+        }
     ) {
 
         signInScreen(

--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -47,6 +47,13 @@ import com.school_of_company.ui.toast.makeToast
 import com.school_of_company.user.navigation.profileRoute
 import com.school_of_company.user.navigation.profileScreen
 
+private val ROUTES_WITHOUT_NAV_PADDING = listOf(
+    homeRoute,
+    expoCreateRoute,
+    expoCreatedRoute,
+    profileRoute
+)
+
 @Composable
 fun ExpoNavHost(
     modifier: Modifier = Modifier,
@@ -75,7 +82,7 @@ fun ExpoNavHost(
     NavHost(
         navController = navController,
         startDestination = startDestination,
-        modifier = if (navController.currentDestination?.route in listOf(homeRoute, expoCreateRoute, expoCreatedRoute, profileRoute)) {
+        modifier = if (navController.currentDestination?.route in ROUTES_WITHOUT_NAV_PADDING) {
             modifier
         } else {
             modifier.windowInsetsPadding(WindowInsets.navigationBars)


### PR DESCRIPTION
## 💡 개요
- 실제 서비스 화면에서 안드로이드에 기본으로 존재하는 시스템바에 화면이 가려지는 문제가 있어 해당 부분에 padding을 주어 시스템바와 화면이 곂쳐지지 않도록 수정이 필요해보였습니다.
## 📃 작업내용
- 안드로이드 시스템바와 실제 서비스 화면이 서로 곂쳐지지않도록하여 사용자 입장을 개선하였습니다.
   - Modifier의 WindowInsets를 활용하여 안드로이드 시스템바와 실제 화면이 서로 안곂치도록 하였습니다.
   - topLevelDestination에서는 이미 적용이 되어있어 currentDestination을 활용하여 현재 사용자가 보고 있는 화면을 추적하고 TopLevelDestination Route에서는 적용되지 않도록 하였습니다.
   - before

       https://github.com/user-attachments/assets/a4f7a424-729c-4f6c-9afe-49ddfcf0d269

   - after
  
        https://github.com/user-attachments/assets/5e80f353-dfab-432b-90d8-2c2b1b47de9b

## 🔀 변경사항
- chore ExpoNavHost
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 특정 화면에 따라 앱의 레이아웃 여백이 동적으로 조정되어, 네비게이션 바와 콘텐츠 간의 간격이 보다 적절하게 관리됩니다.
  - 프로필 화면을 포함한 주요 경로에서 일관되고 향상된 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->