### PR TITLE
🔀 :: (#450) 폼생성화면과 액스포 자세히 보기 화면을 연결했습니다

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -25,6 +25,7 @@ import com.school_of_company.expo.navigation.navigateToHome
 import com.school_of_company.expo_android.ui.ExpoAppState
 import com.school_of_company.expo_android.ui.navigationPopUpToLogin
 import com.school_of_company.form.navigation.formCreateScreen
+import com.school_of_company.form.navigation.navigationToFormCreate
 import com.school_of_company.program.navigation.navigateQrScanner
 import com.school_of_company.program.navigation.qrScannerScreen
 import com.school_of_company.navigation.navigateToSignIn
@@ -117,6 +118,7 @@ fun ExpoNavHost(
                 navController.navigateToProgramDetailProgram(id)
             },
             onMessageClick = navController::navigateToSmsSendMessage,
+            navigationToFormCreate = navController::navigationToFormCreate,
             onErrorToast = makeErrorToast,
         )
 

--- a/core/model/src/main/java/com/school_of_company/model/enum/ParticipantType.kt
+++ b/core/model/src/main/java/com/school_of_company/model/enum/ParticipantType.kt
@@ -1,4 +1,4 @@
-package com.school_of_company.form.enum
+package com.school_of_company.model.enum
 
 enum class ParticipantType {
     TRAINEE,

--- a/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
@@ -70,6 +70,7 @@ fun NavGraphBuilder.expoDetailScreen(
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit,
     onMessageClick: (String, String) -> Unit,
+    navigationToFormCreate: (String, String, String) -> Unit,
     onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
 ) {
     composable(route = "$expoDetailRoute/{id}") { backStackEntry ->
@@ -81,6 +82,7 @@ fun NavGraphBuilder.expoDetailScreen(
             onModifyClick = onModifyClick,
             onProgramClick = onProgramClick,
             onMessageClick = onMessageClick,
+            navigationToFormCreate = navigationToFormCreate,
             onErrorToast = onErrorToast,
         )
     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -52,6 +52,7 @@ import com.school_of_company.expo.viewmodel.uistate.GetExpoInformationUiState
 import com.school_of_company.expo.viewmodel.uistate.GetStandardProgramListUiState
 import com.school_of_company.expo.viewmodel.uistate.GetTrainingProgramListUiState
 import com.school_of_company.model.enum.Authority
+import com.school_of_company.model.enum.ParticipantType
 import com.school_of_company.ui.util.formatServerDate
 
 @Composable

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -101,7 +101,13 @@ internal fun ExpoDetailRoute(
         onCheckClick = onCheckClick,
         onModifyClick = onModifyClick,
         onProgramClick = onProgramClick,
-        navigationToFormCreate = { type -> navigationToFormCreate(id,coverImage,type) },
+        navigationToFormCreate = { type ->
+            navigationToFormCreate(
+                id,
+                coverImage,
+                type,
+            )
+        },
     )
 
     LaunchedEffect(Unit) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -64,12 +64,14 @@ internal fun ExpoDetailRoute(
     onProgramClick: (String) -> Unit,
     onMessageClick: (String, String) -> Unit,
     onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
+    navigationToFormCreate: (String, String, String) -> Unit,
     viewModel: ExpoViewModel = hiltViewModel(),
 ) {
     val getExpoInformationUiState by viewModel.getExpoInformationUiState.collectAsStateWithLifecycle()
     val getTrainingProgramUiState by viewModel.getTrainingProgramListUiState.collectAsStateWithLifecycle()
     val getStandardProgramUiState by viewModel.getStandardProgramListUiState.collectAsStateWithLifecycle()
     val getCoordinatesToAddressUiState by viewModel.getCoordinatesToAddressUiState.collectAsStateWithLifecycle()
+    val coverImage by viewModel.coverImage.collectAsStateWithLifecycle()
 
     LaunchedEffect(getCoordinatesToAddressUiState) {
         when (getCoordinatesToAddressUiState) {
@@ -98,7 +100,8 @@ internal fun ExpoDetailRoute(
         },
         onCheckClick = onCheckClick,
         onModifyClick = onModifyClick,
-        onProgramClick = onProgramClick
+        onProgramClick = onProgramClick,
+        navigationToFormCreate = { type -> navigationToFormCreate(id,coverImage,type) },
     )
 
     LaunchedEffect(Unit) {
@@ -122,6 +125,7 @@ private fun ExpoDetailScreen(
     onCheckClick: (String) -> Unit,
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit,
+    navigationToFormCreate: (String) -> Unit,
 ) {
     val (openDialog, isOpenDialog) = rememberSaveable { mutableStateOf(false) }
     val (openModifyDialog, isOpenModifyDialog) = rememberSaveable { mutableStateOf(false) }
@@ -534,11 +538,11 @@ private fun ExpoDetailScreen(
                 endButtonText = "연수자",
                 onStartClick = {
                     isOpenFormCreateDialog(false)
-                    // todo : Navigate To Create Form Screen Logic - STANDARD
+                    navigationToFormCreate("STANDARD")
                 },
                 onEndClick = {
                     isOpenFormCreateDialog(false)
-                    // todo : Navigate To Create Form Screen Logic - TRAINEE
+                    navigationToFormCreate("TRAINEE")
                 },
                 onDismissClick = { isOpenFormCreateDialog(false) }
             )
@@ -550,16 +554,17 @@ private fun ExpoDetailScreen(
 @Composable
 private fun HomeDetailScreenPreview() {
     ExpoDetailScreen(
+        id = "",
+        getExpoInformationUiState = GetExpoInformationUiState.Loading,
+        getTrainingProgramUiState = GetTrainingProgramListUiState.Loading,
+        getStandardProgramUiState = GetStandardProgramListUiState.Loading,
+        getCoordinatesToAddressUiState = GetCoordinatesToAddressUiState.Loading,
         scrollState = ScrollState(0),
         onBackClick = {},
         onMessageClick = {},
         onCheckClick = {},
         onModifyClick = {},
         onProgramClick = {},
-        getExpoInformationUiState = GetExpoInformationUiState.Loading,
-        getTrainingProgramUiState = GetTrainingProgramListUiState.Loading,
-        getStandardProgramUiState = GetStandardProgramListUiState.Loading,
-        id = "",
-        getCoordinatesToAddressUiState = GetCoordinatesToAddressUiState.Loading
+        navigationToFormCreate = { _ -> }
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -544,11 +544,11 @@ private fun ExpoDetailScreen(
                 endButtonText = "연수자",
                 onStartClick = {
                     isOpenFormCreateDialog(false)
-                    navigationToFormCreate("STANDARD")
+                    navigationToFormCreate(ParticipantType.STANDARD.name)
                 },
                 onEndClick = {
                     isOpenFormCreateDialog(false)
-                    navigationToFormCreate("TRAINEE")
+                    navigationToFormCreate(ParticipantType.TRAINEE.name)
                 },
                 onDismissClick = { isOpenFormCreateDialog(false) }
             )

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -175,6 +175,17 @@ internal class ExpoViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), listOf())
 
+    val coverImage:StateFlow<String> = getExpoInformationUiState
+        .map { state ->
+            when(state) {
+                is GetExpoInformationUiState.Success -> {
+                    state.data.coverImage ?: ""
+                }
+                else -> ""
+            }
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), "")
+
     internal fun getExpoInformation(expoId: String) = viewModelScope.launch {
         getExpoInformationUseCase(expoId = expoId)
             .asResult()

--- a/feature/form/src/main/java/com/school_of_company/form/navigation/FormNavigation.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/navigation/FormNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.school_of_company.form.view.FormCreateRoute
+import android.net.Uri
 
 const val formCreateRoute = "form_create_route"
 
@@ -14,8 +15,9 @@ fun NavController.navigationToFormCreate(
     participantType: String,
     navOptions: NavOptions? = null
 ) {
+    val encodedImage = Uri.encode(informationImage)
     this.navigate(
-        route = "$formCreateRoute/$id/$informationImage/$participantType",
+        route = "$formCreateRoute/$id/$encodedImage/$participantType",
         navOptions
     )
 }
@@ -26,7 +28,8 @@ fun NavGraphBuilder.formCreateScreen(
 ) {
     composable(route = "$formCreateRoute/{id}/{informationImage}/{participantType}") { backStackEntry ->
         val id = backStackEntry.arguments?.getString("id") ?: ""
-        val informationImage = backStackEntry.arguments?.getString("informationImage") ?: ""
+        val encodedImage = backStackEntry.arguments?.getString("informationImage") ?: ""
+        val informationImage = Uri.decode(encodedImage) // URL 디코딩
         val participantType = backStackEntry.arguments?.getString("participantType") ?: ""
 
         FormCreateRoute(


### PR DESCRIPTION
## 💡 개요

폼생성화면과 액스포 자세히 보기 화면을 연결했습니다

https://github.com/user-attachments/assets/236af9b1-7d26-407f-8265-3d901f16eb0f

## 📃 작업내용

expoDetailScreen에 navigationToFormCreate 파라미터를 추가하고 폼생성 다이얼로그와 연결했습니다
expoViewModel에서 coverImage 를 uiState와 상관없이 불러올수 있게 변수를 추가했습니다
navigationToFormCreate 가 route 로 url 을 넘겨줌으로 uri 인코딩을 활용해서 오류 해결을했습니다

## 🔀 변경사항

expoNavHost
expoNavigation 
expoDetailScreen
expoViewModel
FormNavigation

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - Expo 상세 화면에서 폼 생성 화면으로 원활하게 이동할 수 있는 네비게이션 기능이 추가되었습니다.
  - 폼 생성 시 필요한 이미지 정보가 안전하게 인코딩/디코딩되어, 보다 안정적인 정보 전달과 사용자 경험을 제공합니다.
  - Expo 상세 화면에서 커버 이미지 정보를 추가하여 폼 생성 시 활용할 수 있도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->