### PR TITLE
🔀 :: (#453) - 로그인 이후 홈 화면으로 이동할때 로그인 화면의 스택을 삭제하여 홈 화면에서 다시 로그인 화면으로 이동되는 문제를 해결하였습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -91,7 +91,7 @@ fun ExpoNavHost(
 
         signInScreen(
             onSignUpClick = navController::navigationToSignUp,
-            onSignInClick = { navController.navigateToHomeAndClearLogin() },
+            onSignInClick = navController::navigateToHomeAndClearLogin,
             onErrorToast = makeErrorToast
         )
 

--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -21,8 +21,8 @@ import com.school_of_company.expo.navigation.homeRoute
 import com.school_of_company.expo.navigation.navigateToExpoAddressSearch
 import com.school_of_company.expo.navigation.navigateToExpoDetail
 import com.school_of_company.expo.navigation.navigateToExpoModify
-import com.school_of_company.expo.navigation.navigateToHome
 import com.school_of_company.expo_android.ui.ExpoAppState
+import com.school_of_company.expo_android.ui.navigateToHomeAndClearLogin
 import com.school_of_company.expo_android.ui.navigationPopUpToLogin
 import com.school_of_company.form.navigation.formCreateScreen
 import com.school_of_company.program.navigation.navigateQrScanner
@@ -91,7 +91,7 @@ fun ExpoNavHost(
 
         signInScreen(
             onSignUpClick = navController::navigationToSignUp,
-            onSignInClick = navController::navigateToHome,
+            onSignInClick = { navController.navigateToHomeAndClearLogin() },
             onErrorToast = makeErrorToast
         )
 

--- a/app/src/main/java/com/school_of_company/expo_android/ui/ExpoAppState.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/ui/ExpoAppState.kt
@@ -100,10 +100,3 @@ fun NavController.navigateToHomeAndClearLogin() {
         popUpTo(sigInRoute) { inclusive = true }
     }
 }
-
-// 로그인을 한 이후 홈 화면으로 이동할 때 네비게이션 백스택을 비우고 이동하는 함수입니다.
-fun NavController.navigateToHomeAndClearLogin() {
-    this.navigate(homeRoute) {
-        popUpTo(sigInRoute) { inclusive = true }
-    }
-}

--- a/app/src/main/java/com/school_of_company/expo_android/ui/ExpoAppState.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/ui/ExpoAppState.kt
@@ -14,10 +14,13 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navOptions
+import com.school_of_company.expo.navigation.homeRoute
 import com.school_of_company.expo.navigation.navigateToExpoCreate
 import com.school_of_company.expo.navigation.navigateToExpoCreated
 import com.school_of_company.expo.navigation.navigateToHome
 import com.school_of_company.expo_android.navigation.TopLevelDestination
+import com.school_of_company.navigation.sigInRoute
+import com.school_of_company.signup.navigation.signUpRoute
 import com.school_of_company.user.navigation.navigateToProfile
 import kotlinx.coroutines.CoroutineScope
 
@@ -88,5 +91,11 @@ class ExpoAppState(
 fun NavController.navigationPopUpToLogin(loginRoute: String) {
     this.navigate(loginRoute) {
         popUpTo(0) { inclusive = true }
+    }
+}
+
+fun NavController.navigateToHomeAndClearLogin() {
+    this.navigate(homeRoute) {
+        popUpTo(sigInRoute) { inclusive = true }
     }
 }

--- a/app/src/main/java/com/school_of_company/expo_android/ui/ExpoAppState.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/ui/ExpoAppState.kt
@@ -94,6 +94,7 @@ fun NavController.navigationPopUpToLogin(loginRoute: String) {
     }
 }
 
+// 로그인을 한 이후 홈 화면으로 이동할 때 네비게이션 백스택을 비우고 이동하는 함수입니다.
 fun NavController.navigateToHomeAndClearLogin() {
     this.navigate(homeRoute) {
         popUpTo(sigInRoute) { inclusive = true }


### PR DESCRIPTION
## 💡 개요
- 로그인을 한 이후에 홈 화면으로 이동할때 로그인 화면 스택이 남아 뒤로가기를 하면 다시 로그인 화면으로 넘어가는 문제가 있어 해결해야합니다.
## 📃 작업내용
- 로그인 이후 홈 화면으로 이동할때 로그인 화면의 스택을 삭제하여 홈 화면에서 다시 로그인 화면으로 이동되는 문제를 해결하였습니다.
   - 로그인 화면에서 홈 화면으로 이동할 때 네비게이션 백스택을 비우고 이동하는 함수를 구현하여 해결하였습니다. (navigationPopUpToLogin)
   - before

       https://github.com/user-attachments/assets/44fbf959-a7cd-491c-91d0-e433173f5adc

   - after
   
       https://github.com/user-attachments/assets/a38bb9f2-7b7a-4239-bd08-a8c50084cbd2

## 🔀 변경사항
- chore NavHost
- chore ExpoAppState
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 로그인 후 홈 화면으로 전환될 때, 이전 로그인 상태가 자동으로 정리되는 기능이 추가되었습니다. 이 업데이트는 사용자에게 보다 깔끔하고 매끄러운 네비게이션 경험을 제공하며, 이전 로그인 데이터로 인해 발생할 수 있는 불필요한 잔여 효과를 방지합니다. 결과적으로 로그인 과정이 개선되어 앱 내 전환이 원활해집니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->