### PR TITLE
🔀 :: (#455) - 로그인 화면으로 이동시 현재 남아있는 백스택이 모두 삭제될 수 있도록하여 기존에 생기던 로그아웃시 네비게이션 버그를 해결하였습니다.

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/ui/ExpoAppState.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/ui/ExpoAppState.kt
@@ -87,6 +87,6 @@ class ExpoAppState(
 // 로그인 화면으로 이동할 때 네비게이션 백스택을 비우고 이동하는 함수입니다.
 fun NavController.navigationPopUpToLogin(loginRoute: String) {
     this.navigate(loginRoute) {
-        popUpTo(loginRoute) { inclusive = true }
+        popUpTo(0) { inclusive = true }
     }
 }


### PR DESCRIPTION
## 💡 개요
- 로그인 화면으로 이동할때 백스택을 모두 지워야하지만 이는 기존의 로그인 화면의 스택을 지우는 동작을 하도록 되어있었습니다.
## 📃 작업내용
- 로그인 화면으로 이동시 현재 남아있는 백스택이 모두 삭제될 수 있도록하여 기존에 생기던 로그아웃시 네비게이션 버그를 해결하였습니다.
   - 로그인 화면 자체를 제거한 후 다시 로그인 화면으로 이동이 되도록 원래 코드가 짜져있어 로그인 화면이 계속 재생성되어 깜빡이는 현상이 있었습니다. -> popUpTo(0)으로 해주어 로그인 화면으로 이동시 모든 백스택이 제거되도록 하였습니다.
   - before

      https://github.com/user-attachments/assets/1e51fd0f-3053-471b-bd9c-24be93a8e651

   - after

       https://github.com/user-attachments/assets/517b0e65-7020-4c82-ac18-2b25a0d94779

## 🔀 변경사항
- chore ExpoAppState
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **리팩토링**
  - 앱의 내비게이션 동작을 개선하여, 로그인 화면으로 이동할 때 기존에 방문한 모든 화면 기록이 완전히 초기화됩니다. 이 업데이트는 사용자 인터페이스에 즉각적인 영향을 주며, 앱 사용 시 원활한 화면 전환과 명확한 내비게이션 구조를 제공합니다. 사용자는 이전 탐색 경로의 잔재 없이 깔끔한 상태에서 새로운 세션을 시작할 수 있게 됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->