### PR TITLE
🔀 :: (#458) - 폼 드롭다운의 디자인 변경사항을 적용했습니다

### DIFF
--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
@@ -448,6 +448,7 @@ fun TransparentTextField(
     placeholder: String,
     value: String,
     textStyle: TextStyle,
+    placeholderTextStyle: TextStyle? = null,
     updateTextValue: (String) -> Unit,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
 ) {
@@ -474,7 +475,7 @@ fun TransparentTextField(
                 if (value.isEmpty()) {
                     Text(
                         text = placeholder,
-                        style = textStyle,
+                        style = placeholderTextStyle ?: textStyle,
                     )
                 }
             }
@@ -579,7 +580,12 @@ fun ExpoOutlinedTextFieldPreview() {
 
             NoneLimitedLengthTextField(value = "", placeholder = "", updateTextValue = {})
 
-            TransparentTextField(value = "배경없는 textField", placeholder = "", updateTextValue = {}, textStyle = ExpoTypography.bodyBold2.copy(fontWeight = FontWeight.W600))
+            TransparentTextField(
+                value = "배경없는 textField",
+                placeholder = "",
+                updateTextValue = {},
+                textStyle = ExpoTypography.bodyBold2.copy(fontWeight = FontWeight.W600)
+            )
         }
     }
 }

--- a/feature/form/src/main/java/com/school_of_company/form/enum/FormType.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/enum/FormType.kt
@@ -6,6 +6,5 @@ enum class FormType(val iconRes: Int, val typeName: String) {
     SENTENCE(iconRes = R.drawable.ic_long_content, typeName = "문장형"),
     CHECKBOX(iconRes = R.drawable.ic_check_box, typeName = "체크박스"),
     DROPDOWN(iconRes = R.drawable.ic_drop_down, typeName = "드롭다운"),
-    IMAGE(iconRes = R.drawable.ic_image, typeName = "이미지"),
     MULTIPLE(iconRes = R.drawable.ic_two_circle, typeName = "객관식 질문"),
 }

--- a/feature/form/src/main/java/com/school_of_company/form/view/component/FormCard.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/component/FormCard.kt
@@ -129,15 +129,6 @@ internal fun FormCard(
                             },
                         )
 
-                        FormType.IMAGE -> FormImageItem(
-                            modifier = Modifier.fillMaxWidth(),
-                            onXClick = {
-                                val newList =
-                                    formData.itemList.toMutableList().apply { removeAt(index) }
-                                onFormDataChange(formIndex, formData.copy(itemList = newList))
-                            },
-                        )
-
                         FormType.MULTIPLE -> FormMultiPleItem(
                             modifier = Modifier.fillMaxWidth(),
                             itemIndex = index,
@@ -158,7 +149,6 @@ internal fun FormCard(
                 }
                 if (formData.otherJson) {
                     when (FormType.valueOf(formData.formType)) {
-                        FormType.IMAGE,
                         FormType.SENTENCE -> onFormDataChange(
                             formIndex,
                             formData.copy(otherJson = false)

--- a/feature/form/src/main/java/com/school_of_company/form/view/component/FormCard.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/component/FormCard.kt
@@ -64,7 +64,8 @@ internal fun FormCard(
                     TransparentTextField(
                         placeholder = "제목 입력",
                         value = formData.title,
-                        textStyle = typography.bodyBold2.copy(color = colors.black),
+                        textStyle = typography.captionBold2.copy(color = colors.black),
+                        placeholderTextStyle = typography.captionBold2.copy(color = colors.gray500),
                         updateTextValue = { onFormDataChange(formIndex, formData.copy(title = it)) }
                     )
 

--- a/feature/form/src/main/java/com/school_of_company/form/view/component/FormDropDown.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/component/FormDropDown.kt
@@ -140,7 +140,7 @@ internal fun FormDropDown(
 @Composable
 private fun FormDropDownPreview() {
     var currentItem = remember {
-        mutableStateOf(FormType.IMAGE)
+        mutableStateOf(FormType.SENTENCE)
     }
     FormDropDown(
         onItemClick = { currentItem.value = it },

--- a/feature/form/src/main/java/com/school_of_company/form/view/component/FormDropDown.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/component/FormDropDown.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -37,7 +38,8 @@ internal fun FormDropDown(
     currentItem: FormType,
     onItemClick: (FormType) -> Unit,
 ) {
-    val expanded = rememberSaveable { mutableStateOf(false) }
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    var isSelected by rememberSaveable { mutableStateOf(false) }
 
     ExpoAndroidTheme { colors, typography ->
         Column(modifier = modifier) {
@@ -52,7 +54,7 @@ internal fun FormDropDown(
                         color = colors.white,
                         shape = RoundedCornerShape(size = 6.dp),
                     )
-                    .expoClickable { expanded.value = true }
+                    .expoClickable { expanded = true }
                     .padding(
                         horizontal = 8.dp,
                         vertical = 12.dp,
@@ -63,17 +65,19 @@ internal fun FormDropDown(
                 Icon(
                     painter = painterResource(currentItem.iconRes),
                     contentDescription = null,
-                    tint = colors.gray500
+                    tint = if (isSelected) colors.main
+                    else colors.gray500
                 )
 
                 Text(
                     text = currentItem.typeName,
                     style = typography.captionRegular1,
                     fontWeight = FontWeight.W400,
-                    color = colors.gray400,
+                    color = if (isSelected) colors.main
+                    else colors.gray500
                 )
 
-                if (expanded.value) {
+                if (expanded) {
                     UpArrowIcon(tint = colors.gray500)
                 } else {
                     DownArrowIcon(tint = colors.gray500)
@@ -93,8 +97,8 @@ internal fun FormDropDown(
                     )
                     .padding(16.dp),
                 shadowElevation = 12.dp,
-                expanded = expanded.value,
-                onDismissRequest = { expanded.value = false },
+                expanded = expanded,
+                onDismissRequest = { expanded = false },
             ) {
                 Column(verticalArrangement = Arrangement.spacedBy(space = 22.dp)) {
                     FormType.values()
@@ -109,7 +113,8 @@ internal fun FormDropDown(
                                 modifier = Modifier
                                     .expoClickable(interactionSource = interactionSource) {
                                         onItemClick(filteredItem)
-                                        expanded.value = false
+                                        expanded = false
+                                        isSelected = true
                                     },
                                 verticalAlignment = Alignment.CenterVertically
                             ) {

--- a/feature/form/src/main/java/com/school_of_company/form/view/component/FormDropDown.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/component/FormDropDown.kt
@@ -47,7 +47,7 @@ internal fun FormDropDown(
                 modifier = modifier
                     .border(
                         width = 1.dp,
-                        color = colors.gray500,
+                        color = colors.gray100,
                         shape = RoundedCornerShape(size = 6.dp),
                     )
                     .background(


### PR DESCRIPTION
## 💡 개요

https://github.com/user-attachments/assets/f443294b-deef-42f4-a22c-f975de30c6aa

## 📃 작업내용

FormType enum의 Image 삭제 
드롭다운의 아이템을 직접 선택했을때 main color 가 나오도록 수정

## 🔀 변경사항

chore FormType
chore FormCard
chore FormDropDown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 드롭다운 메뉴의 선택 시 색상과 시각적 피드백이 개선되어 보다 직관적인 인터페이스를 제공합니다.
	- 플레이스홀더 텍스트 스타일을 사용자 정의할 수 있는 새로운 선택적 매개변수가 추가되었습니다.
- **리팩토링**
	- 양식 구성에서 이미지 옵션이 제거되어 사용 가능한 항목들이 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->