### PR TITLE
🔀 :: (#452) - 폼 수정화면 퍼블리싱과 수정기능 구현을 했습니다

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -120,20 +120,8 @@ fun ExpoNavHost(
                 navController.navigateToProgramDetailProgram(id)
             },
             onMessageClick = navController::navigateToSmsSendMessage,
-            navigationToFormCreate = { id, informationImage, participantType ->
-                navController.navigationToCreateForm(
-                    id,
-                    informationImage,
-                    participantType,
-                )
-            },
-            navigationToFormModify = { id, informationImage, participantType ->
-                navController.navigationToModifyForm(
-                    id,
-                    informationImage,
-                    participantType,
-                )
-            },
+            navigationToFormCreate = navController::navigationToCreateForm,
+            navigationToFormModify = navController::navigationToModifyForm,
             onErrorToast = makeErrorToast,
         )
 

--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -24,8 +24,9 @@ import com.school_of_company.expo.navigation.navigateToExpoModify
 import com.school_of_company.expo.navigation.navigateToHome
 import com.school_of_company.expo_android.ui.ExpoAppState
 import com.school_of_company.expo_android.ui.navigationPopUpToLogin
-import com.school_of_company.form.navigation.formCreateScreen
-import com.school_of_company.form.navigation.navigationToFormCreate
+import com.school_of_company.form.enum.FormActionType
+import com.school_of_company.form.navigation.formScreen
+import com.school_of_company.form.navigation.navigationToForm
 import com.school_of_company.program.navigation.navigateQrScanner
 import com.school_of_company.program.navigation.qrScannerScreen
 import com.school_of_company.navigation.navigateToSignIn
@@ -118,7 +119,22 @@ fun ExpoNavHost(
                 navController.navigateToProgramDetailProgram(id)
             },
             onMessageClick = navController::navigateToSmsSendMessage,
-            navigationToFormCreate = navController::navigationToFormCreate,
+            navigationToFormCreate = { id, informationImage, participantType ->
+                navController.navigationToForm(
+                    id,
+                    informationImage,
+                    participantType,
+                    FormActionType.CREATE,
+                )
+            },
+            navigationToFormModify = { id, informationImage, participantType ->
+                navController.navigationToForm(
+                    id,
+                    informationImage,
+                    participantType,
+                    FormActionType.MODIFY,
+                )
+            },
             onErrorToast = makeErrorToast,
         )
 
@@ -192,7 +208,7 @@ fun ExpoNavHost(
             onMainNavigate = { navController.navigationPopUpToLogin(loginRoute = sigInRoute) }
         )
 
-        formCreateScreen(
+        formScreen(
             popUpBackStack = navController::popBackStack,
             onErrorToast = makeErrorToast,
         )

--- a/core/data/src/main/java/com/school_of_company/data/repository/form/FormRepository.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/form/FormRepository.kt
@@ -6,6 +6,6 @@ import kotlinx.coroutines.flow.Flow
 interface FormRepository {
     fun createForm(expoId: String, body: FormRequestAndResponseModel) : Flow<Unit>
     fun modifyForm(expoId: String, body: FormRequestAndResponseModel) : Flow<Unit>
-    fun getForm(expoId: String, formType: String) : Flow<FormRequestAndResponseModel>
+    fun getForm(expoId: String, participantType: String) : Flow<FormRequestAndResponseModel>
     fun deleteForm(expoId: String) : Flow<Unit>
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/form/FormRepository.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/form/FormRepository.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface FormRepository {
     fun createForm(expoId: String, body: FormRequestAndResponseModel) : Flow<Unit>
-    fun modifyForm(formId: Long, body: FormRequestAndResponseModel) : Flow<Unit>
-    fun getForm(formId: Long, formType: String) : Flow<FormRequestAndResponseModel>
-    fun deleteForm(formId: Long) : Flow<Unit>
+    fun modifyForm(formId: String, body: FormRequestAndResponseModel) : Flow<Unit>
+    fun getForm(formId: String, formType: String) : Flow<FormRequestAndResponseModel>
+    fun deleteForm(formId: String) : Flow<Unit>
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/form/FormRepository.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/form/FormRepository.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface FormRepository {
     fun createForm(expoId: String, body: FormRequestAndResponseModel) : Flow<Unit>
-    fun modifyForm(formId: String, body: FormRequestAndResponseModel) : Flow<Unit>
-    fun getForm(formId: String, formType: String) : Flow<FormRequestAndResponseModel>
-    fun deleteForm(formId: String) : Flow<Unit>
+    fun modifyForm(expoId: String, body: FormRequestAndResponseModel) : Flow<Unit>
+    fun getForm(expoId: String, formType: String) : Flow<FormRequestAndResponseModel>
+    fun deleteForm(expoId: String) : Flow<Unit>
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/form/FormRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/form/FormRepositoryImpl.kt
@@ -18,14 +18,14 @@ class FormRepositoryImpl @Inject constructor(
         )
     }
 
-    override fun modifyForm(formId: Long, body: FormRequestAndResponseModel): Flow<Unit> {
+    override fun modifyForm(formId: String, body: FormRequestAndResponseModel): Flow<Unit> {
         return dataSource.modifyForm(
             formId = formId,
             body = body.toModel()
         )
     }
 
-    override fun getForm(formId: Long, formType: String): Flow<FormRequestAndResponseModel> {
+    override fun getForm(formId: String, formType: String): Flow<FormRequestAndResponseModel> {
         return dataSource.getForm(
             formId = formId,
             formType = formType
@@ -34,7 +34,7 @@ class FormRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun deleteForm(formId: Long): Flow<Unit> {
+    override fun deleteForm(formId: String): Flow<Unit> {
         return dataSource.deleteForm(formId = formId)
     }
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/form/FormRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/form/FormRepositoryImpl.kt
@@ -25,10 +25,10 @@ class FormRepositoryImpl @Inject constructor(
         )
     }
 
-    override fun getForm(expoId: String, formType: String): Flow<FormRequestAndResponseModel> {
+    override fun getForm(expoId: String, participantType: String): Flow<FormRequestAndResponseModel> {
         return dataSource.getForm(
             expoId = expoId,
-            formType = formType
+            participantType = participantType
         ).transform { response ->
             emit(response.toModel())
         }

--- a/core/data/src/main/java/com/school_of_company/data/repository/form/FormRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/form/FormRepositoryImpl.kt
@@ -18,23 +18,23 @@ class FormRepositoryImpl @Inject constructor(
         )
     }
 
-    override fun modifyForm(formId: String, body: FormRequestAndResponseModel): Flow<Unit> {
+    override fun modifyForm(expoId: String, body: FormRequestAndResponseModel): Flow<Unit> {
         return dataSource.modifyForm(
-            formId = formId,
+            expoId = expoId,
             body = body.toModel()
         )
     }
 
-    override fun getForm(formId: String, formType: String): Flow<FormRequestAndResponseModel> {
+    override fun getForm(expoId: String, formType: String): Flow<FormRequestAndResponseModel> {
         return dataSource.getForm(
-            formId = formId,
+            expoId = expoId,
             formType = formType
         ).transform { response ->
             emit(response.toModel())
         }
     }
 
-    override fun deleteForm(formId: String): Flow<Unit> {
-        return dataSource.deleteForm(formId = formId)
+    override fun deleteForm(expoId: String): Flow<Unit> {
+        return dataSource.deleteForm(expoId = expoId)
     }
 }

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -87,8 +87,10 @@
     <string name="get_created_expo_list_empty">박람회 리스트가 비어있습니다.</string>
     <string name="expo_delete_fail">박람회 삭제를 실패하였습니다.</string>
 
+    <string name="form_modify_fail">폼 수정을 실패했습니다.</string>
     <string name="form_create_fail">폼 생성을 실패했습니다.</string>
     <string name="form_create_success">폼 생성을 성공했습니다.</string>
+    <string name="form_modify_success">폼 수정을 성공했습니다.</string>
 
     <string name="expo_image_fail">박람회 이미지가 유효하지 않습니다.</string>
 

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/form/DeleteFormUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/form/DeleteFormUseCase.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 class DeleteFormUseCase @Inject constructor(
     private val repository: FormRepository
 ) {
-    operator fun invoke(formId: String) = runCatching {
-        repository.deleteForm(formId = formId)
+    operator fun invoke(expoId: String) = runCatching {
+        repository.deleteForm(expoId = expoId)
     }
 }

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/form/DeleteFormUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/form/DeleteFormUseCase.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 class DeleteFormUseCase @Inject constructor(
     private val repository: FormRepository
 ) {
-    operator fun invoke(formId: Long) = runCatching {
+    operator fun invoke(formId: String) = runCatching {
         repository.deleteForm(formId = formId)
     }
 }

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/form/GetFormUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/form/GetFormUseCase.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 class GetFormUseCase @Inject constructor(
     private val repository: FormRepository
 ) {
-    operator fun invoke(formId: Long, formType: String): Flow<FormRequestAndResponseModel> =
+    operator fun invoke(formId: String, formType: String): Flow<FormRequestAndResponseModel> =
         repository.getForm(
             formId = formId,
             formType = formType

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/form/GetFormUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/form/GetFormUseCase.kt
@@ -8,10 +8,10 @@ import javax.inject.Inject
 class GetFormUseCase @Inject constructor(
     private val repository: FormRepository
 ) {
-    operator fun invoke(expoId: String, formType: String): Flow<FormRequestAndResponseModel> =
+    operator fun invoke(expoId: String, participantType: String): Flow<FormRequestAndResponseModel> =
         repository.getForm(
             expoId = expoId,
-            formType = formType
+            participantType = participantType
         )
 
 }

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/form/GetFormUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/form/GetFormUseCase.kt
@@ -8,9 +8,9 @@ import javax.inject.Inject
 class GetFormUseCase @Inject constructor(
     private val repository: FormRepository
 ) {
-    operator fun invoke(formId: String, formType: String): Flow<FormRequestAndResponseModel> =
+    operator fun invoke(expoId: String, formType: String): Flow<FormRequestAndResponseModel> =
         repository.getForm(
-            formId = formId,
+            expoId = expoId,
             formType = formType
         )
 

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/form/ModifyFormUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/form/ModifyFormUseCase.kt
@@ -7,9 +7,9 @@ import javax.inject.Inject
 class ModifyFormUseCase @Inject constructor(
     private val repository: FormRepository
 ) {
-    operator fun invoke(formId: String, body: FormRequestAndResponseModel) = runCatching {
+    operator fun invoke(expoId: String, body: FormRequestAndResponseModel) = runCatching {
         repository.modifyForm(
-            formId = formId,
+            expoId = expoId,
             body = body
         )
     }

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/form/ModifyFormUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/form/ModifyFormUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class ModifyFormUseCase @Inject constructor(
     private val repository: FormRepository
 ) {
-    operator fun invoke(formId: Long, body: FormRequestAndResponseModel) = runCatching {
+    operator fun invoke(formId: String, body: FormRequestAndResponseModel) = runCatching {
         repository.modifyForm(
             formId = formId,
             body = body

--- a/core/model/src/main/java/com/school_of_company/model/enum/ParticipantType.kt
+++ b/core/model/src/main/java/com/school_of_company/model/enum/ParticipantType.kt
@@ -1,4 +1,4 @@
-package com.school_of_company.form.enum
+package com.school_of_company.model.enum
 
 enum class ParticipantType {
     TRAINEE,

--- a/core/model/src/main/java/com/school_of_company/model/model/form/FormRequestAndResponseModel.kt
+++ b/core/model/src/main/java/com/school_of_company/model/model/form/FormRequestAndResponseModel.kt
@@ -12,4 +12,14 @@ data class DynamicFormModel(
     val itemList: List<String>,
     val requiredStatus: Boolean,
     val otherJson: Boolean,
-)
+) {
+    companion object {
+        fun createDefault(): DynamicFormModel = DynamicFormModel(
+            title = "",
+            formType = "SENTENCE",  // 기본 폼 타입 지정 (필요에 따라 변경 가능)
+            itemList = listOf(""),  // 기본 아이템 리스트
+            requiredStatus = false, // 기본 필수 여부
+            otherJson = false       // 기본 기타 JSON 여부
+        )
+    }
+}

--- a/core/network/src/main/java/com/school_of_company/network/api/FormAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/FormAPI.kt
@@ -19,18 +19,18 @@ interface FormAPI {
 
     @PATCH("/form/{form_id}")
     suspend fun modifyForm(
-        @Path("form_id") formId: Long,
+        @Path("form_id") formId: String,
         @Body body: FormRequestAndResponse
     )
 
     @GET("/form/{form_id}")
     suspend fun getForm(
-        @Path("form_id") formId: Long,
+        @Path("form_id") formId: String,
         @Query("formType") formType: String // TRAINEE, STANDARD
     ): FormRequestAndResponse
 
     @DELETE("/form/{form_id}")
     suspend fun deleteForm(
-        @Path("form_id") formId: Long
+        @Path("form_id") formId: String
     )
 }

--- a/core/network/src/main/java/com/school_of_company/network/api/FormAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/FormAPI.kt
@@ -19,18 +19,18 @@ interface FormAPI {
 
     @PATCH("/form/{form_id}")
     suspend fun modifyForm(
-        @Path("form_id") formId: String,
+        @Path("form_id") expoId: String,
         @Body body: FormRequestAndResponse
     )
 
     @GET("/form/{form_id}")
     suspend fun getForm(
-        @Path("form_id") formId: String,
-        @Query("formType") formType: String // TRAINEE, STANDARD
+        @Path("form_id") expoId: String,
+        @Query("formType") participantType: String // TRAINEE, STANDARD
     ): FormRequestAndResponse
 
     @DELETE("/form/{form_id}")
     suspend fun deleteForm(
-        @Path("form_id") formId: String
+        @Path("form_id") expoId: String
     )
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/form/FormDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/form/FormDataSource.kt
@@ -6,6 +6,6 @@ import kotlinx.coroutines.flow.Flow
 interface FormDataSource {
     fun createForm(expoId: String, body: FormRequestAndResponse) : Flow<Unit>
     fun modifyForm(expoId: String, body: FormRequestAndResponse) : Flow<Unit>
-    fun getForm(expoId: String, formType: String) : Flow<FormRequestAndResponse>
+    fun getForm(expoId: String, participantType: String) : Flow<FormRequestAndResponse>
     fun deleteForm(expoId: String) : Flow<Unit>
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/form/FormDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/form/FormDataSource.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface FormDataSource {
     fun createForm(expoId: String, body: FormRequestAndResponse) : Flow<Unit>
-    fun modifyForm(formId: Long, body: FormRequestAndResponse) : Flow<Unit>
-    fun getForm(formId: Long, formType: String) : Flow<FormRequestAndResponse>
-    fun deleteForm(formId: Long) : Flow<Unit>
+    fun modifyForm(formId: String, body: FormRequestAndResponse) : Flow<Unit>
+    fun getForm(formId: String, formType: String) : Flow<FormRequestAndResponse>
+    fun deleteForm(formId: String) : Flow<Unit>
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/form/FormDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/form/FormDataSource.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface FormDataSource {
     fun createForm(expoId: String, body: FormRequestAndResponse) : Flow<Unit>
-    fun modifyForm(formId: String, body: FormRequestAndResponse) : Flow<Unit>
-    fun getForm(formId: String, formType: String) : Flow<FormRequestAndResponse>
-    fun deleteForm(formId: String) : Flow<Unit>
+    fun modifyForm(expoId: String, body: FormRequestAndResponse) : Flow<Unit>
+    fun getForm(expoId: String, formType: String) : Flow<FormRequestAndResponse>
+    fun deleteForm(expoId: String) : Flow<Unit>
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/form/FormDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/form/FormDataSourceImpl.kt
@@ -17,16 +17,16 @@ class FormDataSourceImpl @Inject constructor(
 
     override fun modifyForm(expoId: String, body: FormRequestAndResponse): Flow<Unit> =
         performApiRequest { service.modifyForm(
-            formId = expoId,
+            expoId = expoId,
             body = body
         ) }
 
-    override fun getForm(expoId: String, formType: String): Flow<FormRequestAndResponse> =
+    override fun getForm(expoId: String, participantType: String): Flow<FormRequestAndResponse> =
         performApiRequest { service.getForm(
-            formId = expoId,
-            formType = formType
+            expoId = expoId,
+            participantType = participantType
         ) }
 
     override fun deleteForm(expoId: String): Flow<Unit> =
-        performApiRequest { service.deleteForm(formId = expoId) }
+        performApiRequest { service.deleteForm(expoId = expoId) }
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/form/FormDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/form/FormDataSourceImpl.kt
@@ -15,18 +15,18 @@ class FormDataSourceImpl @Inject constructor(
             body = body
         ) }
 
-    override fun modifyForm(formId: String, body: FormRequestAndResponse): Flow<Unit> =
+    override fun modifyForm(expoId: String, body: FormRequestAndResponse): Flow<Unit> =
         performApiRequest { service.modifyForm(
-            formId = formId,
+            formId = expoId,
             body = body
         ) }
 
-    override fun getForm(formId: String, formType: String): Flow<FormRequestAndResponse> =
+    override fun getForm(expoId: String, formType: String): Flow<FormRequestAndResponse> =
         performApiRequest { service.getForm(
-            formId = formId,
+            formId = expoId,
             formType = formType
         ) }
 
-    override fun deleteForm(formId: String): Flow<Unit> =
-        performApiRequest { service.deleteForm(formId = formId) }
+    override fun deleteForm(expoId: String): Flow<Unit> =
+        performApiRequest { service.deleteForm(formId = expoId) }
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/form/FormDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/form/FormDataSourceImpl.kt
@@ -15,18 +15,18 @@ class FormDataSourceImpl @Inject constructor(
             body = body
         ) }
 
-    override fun modifyForm(formId: Long, body: FormRequestAndResponse): Flow<Unit> =
+    override fun modifyForm(formId: String, body: FormRequestAndResponse): Flow<Unit> =
         performApiRequest { service.modifyForm(
             formId = formId,
             body = body
         ) }
 
-    override fun getForm(formId: Long, formType: String): Flow<FormRequestAndResponse> =
+    override fun getForm(formId: String, formType: String): Flow<FormRequestAndResponse> =
         performApiRequest { service.getForm(
             formId = formId,
             formType = formType
         ) }
 
-    override fun deleteForm(formId: Long): Flow<Unit> =
+    override fun deleteForm(formId: String): Flow<Unit> =
         performApiRequest { service.deleteForm(formId = formId) }
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
@@ -71,6 +71,7 @@ fun NavGraphBuilder.expoDetailScreen(
     onProgramClick: (String) -> Unit,
     onMessageClick: (String, String) -> Unit,
     navigationToFormCreate: (String, String, String) -> Unit,
+    navigationToFormModify: (String, String, String) -> Unit,
     onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
 ) {
     composable(route = "$expoDetailRoute/{id}") { backStackEntry ->
@@ -83,6 +84,7 @@ fun NavGraphBuilder.expoDetailScreen(
             onProgramClick = onProgramClick,
             onMessageClick = onMessageClick,
             navigationToFormCreate = navigationToFormCreate,
+            navigationToFormModify = navigationToFormModify,
             onErrorToast = onErrorToast,
         )
     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -52,6 +52,7 @@ import com.school_of_company.expo.viewmodel.uistate.GetExpoInformationUiState
 import com.school_of_company.expo.viewmodel.uistate.GetStandardProgramListUiState
 import com.school_of_company.expo.viewmodel.uistate.GetTrainingProgramListUiState
 import com.school_of_company.model.enum.Authority
+import com.school_of_company.model.enum.ParticipantType
 import com.school_of_company.ui.util.formatServerDate
 
 @Composable

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -101,7 +101,13 @@ internal fun ExpoDetailRoute(
         onCheckClick = onCheckClick,
         onModifyClick = onModifyClick,
         onProgramClick = onProgramClick,
-        navigationToFormCreate = { type -> navigationToFormCreate(id,coverImage,type) },
+        navigationToFormCreate = { type ->
+            navigationToFormCreate(
+                id,
+                coverImage,
+                type,
+            )
+        },
     )
 
     LaunchedEffect(Unit) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -66,6 +66,7 @@ internal fun ExpoDetailRoute(
     onMessageClick: (String, String) -> Unit,
     onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
     navigationToFormCreate: (String, String, String) -> Unit,
+    navigationToFormModify: (String, String, String) -> Unit,
     viewModel: ExpoViewModel = hiltViewModel(),
 ) {
     val getExpoInformationUiState by viewModel.getExpoInformationUiState.collectAsStateWithLifecycle()
@@ -109,6 +110,13 @@ internal fun ExpoDetailRoute(
                 type,
             )
         },
+        navigationToFormModify = { type ->
+            navigationToFormModify(
+                id,
+                coverImage,
+                type,
+            )
+        },
     )
 
     LaunchedEffect(Unit) {
@@ -133,6 +141,7 @@ private fun ExpoDetailScreen(
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit,
     navigationToFormCreate: (String) -> Unit,
+    navigationToFormModify: (String) -> Unit,
 ) {
     val (openDialog, isOpenDialog) = rememberSaveable { mutableStateOf(false) }
     val (openModifyDialog, isOpenModifyDialog) = rememberSaveable { mutableStateOf(false) }
@@ -526,11 +535,11 @@ private fun ExpoDetailScreen(
                 endButtonText = "연수자",
                 onStartClick = {
                     isOpenFormModifyDialog(false)
-                    // todo : Add Navigation TRAINEE Form Screen Logic
+                    navigationToFormModify(ParticipantType.STANDARD.name)
                 },
                 onEndClick = {
                     isOpenFormModifyDialog(false)
-                    // todo : Add Navigation STANDARD Form Screen Logic
+                    navigationToFormModify(ParticipantType.TRAINEE.name)
                 },
                 onDismissClick = { isOpenFormModifyDialog(false) }
             )
@@ -572,6 +581,7 @@ private fun HomeDetailScreenPreview() {
         onCheckClick = {},
         onModifyClick = {},
         onProgramClick = {},
-        navigationToFormCreate = { _ -> }
+        navigationToFormCreate = { _ -> },
+        navigationToFormModify = { _ -> }
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -544,11 +544,11 @@ private fun ExpoDetailScreen(
                 endButtonText = "연수자",
                 onStartClick = {
                     isOpenFormCreateDialog(false)
-                    navigationToFormCreate("STANDARD")
+                    navigationToFormCreate(ParticipantType.STANDARD.name)
                 },
                 onEndClick = {
                     isOpenFormCreateDialog(false)
-                    navigationToFormCreate("TRAINEE")
+                    navigationToFormCreate(ParticipantType.TRAINEE.name)
                 },
                 onDismissClick = { isOpenFormCreateDialog(false) }
             )

--- a/feature/form/src/main/java/com/school_of_company/form/enum/FormActionType.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/enum/FormActionType.kt
@@ -1,0 +1,7 @@
+package com.school_of_company.form.enum
+
+// formScreen이 어떤 동작을 하는지 구별하는 enum
+enum class FormActionType {
+    MODIFY,
+    CREATE,
+}

--- a/feature/form/src/main/java/com/school_of_company/form/navigation/FormNavigation.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/navigation/FormNavigation.kt
@@ -13,11 +13,12 @@ fun NavController.navigationToFormCreate(
     id: String,
     informationImage: String,
     participantType: String,
+    isCreate: Boolean = true,
     navOptions: NavOptions? = null
 ) {
     val encodedImage = Uri.encode(informationImage)
     this.navigate(
-        route = "$formCreateRoute/$id/$encodedImage/$participantType",
+        route = "$formCreateRoute/$id/$encodedImage/$participantType/$isCreate",
         navOptions
     )
 }
@@ -26,17 +27,19 @@ fun NavGraphBuilder.formCreateScreen(
     popUpBackStack: () -> Unit,
     onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
 ) {
-    composable(route = "$formCreateRoute/{id}/{informationImage}/{participantType}") { backStackEntry ->
+    composable(route = "$formCreateRoute/{id}/{informationImage}/{participantType}/{isCreate}") { backStackEntry ->
         val id = backStackEntry.arguments?.getString("id") ?: ""
         val encodedImage = backStackEntry.arguments?.getString("informationImage") ?: ""
         val informationImage = Uri.decode(encodedImage) // URL 디코딩
         val participantType = backStackEntry.arguments?.getString("participantType") ?: ""
+        val isCreate = backStackEntry.arguments?.getBoolean("isCreate") ?: true
 
         FormCreateRoute(
             popUpBackStack = popUpBackStack,
             expoId = id,
             informationImage = informationImage,
             participantType = participantType,
+            isCreate = isCreate,
             onErrorToast = onErrorToast,
         )
     }

--- a/feature/form/src/main/java/com/school_of_company/form/navigation/FormNavigation.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/navigation/FormNavigation.kt
@@ -4,8 +4,9 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import com.school_of_company.form.view.FormCreateRoute
+import com.school_of_company.form.view.FormRoute
 import android.net.Uri
+import com.school_of_company.form.enum.FormActionType
 
 const val formCreateRoute = "form_create_route"
 
@@ -13,12 +14,12 @@ fun NavController.navigationToForm(
     id: String,
     informationImage: String,
     participantType: String,
-    isCreate: Boolean = true,
+    formActionType: FormActionType = FormActionType.CREATE,
     navOptions: NavOptions? = null
 ) {
     val encodedImage = Uri.encode(informationImage)
     this.navigate(
-        route = "$formCreateRoute/$id/$encodedImage/$participantType/$isCreate",
+        route = "$formCreateRoute/$id/$encodedImage/$participantType/$formActionType",
         navOptions
     )
 }
@@ -27,19 +28,19 @@ fun NavGraphBuilder.formScreen(
     popUpBackStack: () -> Unit,
     onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
 ) {
-    composable(route = "$formCreateRoute/{id}/{informationImage}/{participantType}/{isCreate}") { backStackEntry ->
+    composable(route = "$formCreateRoute/{id}/{informationImage}/{participantType}/{formActionType}") { backStackEntry ->
         val id = backStackEntry.arguments?.getString("id") ?: ""
         val encodedImage = backStackEntry.arguments?.getString("informationImage") ?: ""
         val informationImage = Uri.decode(encodedImage) // URL 디코딩
         val participantType = backStackEntry.arguments?.getString("participantType") ?: ""
-        val isCreate = backStackEntry.arguments?.getBoolean("isCreate") ?: true
+        val formActionType = backStackEntry.arguments?.getString("formActionType") ?: FormActionType.CREATE.name
 
         FormRoute(
             popUpBackStack = popUpBackStack,
             expoId = id,
             informationImage = informationImage,
             participantType = participantType,
-            isCreate = isCreate,
+            formActionType = FormActionType.valueOf(formActionType),
             onErrorToast = onErrorToast,
         )
     }

--- a/feature/form/src/main/java/com/school_of_company/form/navigation/FormNavigation.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/navigation/FormNavigation.kt
@@ -9,7 +9,7 @@ import android.net.Uri
 
 const val formCreateRoute = "form_create_route"
 
-fun NavController.navigationToFormCreate(
+fun NavController.navigationToForm(
     id: String,
     informationImage: String,
     participantType: String,
@@ -23,7 +23,7 @@ fun NavController.navigationToFormCreate(
     )
 }
 
-fun NavGraphBuilder.formCreateScreen(
+fun NavGraphBuilder.formScreen(
     popUpBackStack: () -> Unit,
     onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
 ) {
@@ -34,7 +34,7 @@ fun NavGraphBuilder.formCreateScreen(
         val participantType = backStackEntry.arguments?.getString("participantType") ?: ""
         val isCreate = backStackEntry.arguments?.getBoolean("isCreate") ?: true
 
-        FormCreateRoute(
+        FormRoute(
             popUpBackStack = popUpBackStack,
             expoId = id,
             informationImage = informationImage,

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
@@ -34,7 +34,7 @@ import com.school_of_company.form.enum.FormType
 import com.school_of_company.form.view.component.FormAddButton
 import com.school_of_company.form.view.component.FormCard
 import com.school_of_company.form.viewModel.FormCreateViewModel
-import com.school_of_company.form.viewModel.uiState.CreateFormUiState
+import com.school_of_company.form.viewModel.uiState.FormUiState
 import com.school_of_company.model.model.form.DynamicFormModel
 
 @Composable
@@ -48,17 +48,17 @@ internal fun FormCreateRoute(
     viewModel: FormCreateViewModel = hiltViewModel(),
 ) {
     val formState by viewModel.formState.collectAsStateWithLifecycle()
-    val createFormUiState by viewModel.createFormUiState.collectAsStateWithLifecycle()
+    val formUiState by viewModel.formUiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(createFormUiState) {
-        when (createFormUiState) {
-            is CreateFormUiState.Loading -> Unit
-            is CreateFormUiState.Success -> {
+    LaunchedEffect(formUiState) {
+        when (formUiState) {
+            is FormUiState.Loading -> Unit
+            is FormUiState.Success -> {
                 popUpBackStack()
                 onErrorToast(null, R.string.form_create_success)
             }
-            is CreateFormUiState.Error -> {
                 onErrorToast(null, R.string.form_create_fail)
+            is FormUiState.Error -> {
             }
         }
     }

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormScreen.kt
@@ -38,7 +38,7 @@ import com.school_of_company.form.viewModel.uiState.FormUiState
 import com.school_of_company.model.model.form.DynamicFormModel
 
 @Composable
-internal fun FormCreateRoute(
+internal fun FormRoute(
     modifier: Modifier = Modifier,
     expoId: String,
     informationImage: String,
@@ -63,7 +63,7 @@ internal fun FormCreateRoute(
         }
     }
 
-    FormCreateScreen(
+    FormScreen(
         modifier = modifier,
         formList = formState,
         popUpBackStack = popUpBackStack,
@@ -75,7 +75,7 @@ internal fun FormCreateRoute(
 }
 
 @Composable
-private fun FormCreateScreen(
+private fun FormScreen(
     modifier: Modifier = Modifier,
     formList: List<DynamicFormModel>,
     focusManager: FocusManager = LocalFocusManager.current,

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormScreen.kt
@@ -43,6 +43,7 @@ internal fun FormRoute(
     expoId: String,
     informationImage: String,
     participantType: String,
+    formActionType: FormActionType,
     popUpBackStack: () -> Unit,
     onErrorToast: (throwable: Throwable?, message: Int?) -> Unit,
     viewModel: FormCreateViewModel = hiltViewModel(),

--- a/feature/form/src/main/java/com/school_of_company/form/viewModel/FormCreateViewModel.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/viewModel/FormCreateViewModel.kt
@@ -22,8 +22,8 @@ internal class FormCreateViewModel @Inject constructor(
     private val _formState = MutableStateFlow<List<DynamicFormModel>>(emptyList())
     internal val formState = _formState.asStateFlow()
 
-    private val _createFormUiState = MutableStateFlow<CreateFormUiState>(CreateFormUiState.Loading)
-    internal val createFormUiState = _createFormUiState.asStateFlow()
+    private val _formUiState = MutableStateFlow<FormUiState>(FormUiState.Loading)
+    internal val formUiState = _formUiState.asStateFlow()
 
     internal fun updateDynamicFormItem(index: Int, newItem: DynamicFormModel) {
         val currentList = _formState.value.toMutableList()
@@ -57,7 +57,7 @@ internal class FormCreateViewModel @Inject constructor(
         informationImage: String,
         participantType: String,
     ) = viewModelScope.launch {
-        _createFormUiState.value = CreateFormUiState.Loading
+        _formUiState.value = FormUiState.Loading
         createFormUseCase(
             expoId = expoId,
             body = FormRequestAndResponseModel(
@@ -68,13 +68,15 @@ internal class FormCreateViewModel @Inject constructor(
         )
             .onSuccess {
                 it.catch { remoteError ->
-                    _createFormUiState.value = CreateFormUiState.Error(remoteError)
+                    _formUiState.value = FormUiState.Error(remoteError)
                 }.collect {
-                    _createFormUiState.value = CreateFormUiState.Success
+                    _formUiState.value = FormUiState.Success
                 }
             }
             .onFailure { error ->
-                _createFormUiState.value = CreateFormUiState.Error(error)
+                _formUiState.value = FormUiState.Error(error)
+            }
+    }
             }
     }
 }

--- a/feature/form/src/main/java/com/school_of_company/form/viewModel/FormViewModel.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/viewModel/FormViewModel.kt
@@ -36,7 +36,7 @@ internal class FormViewModel @Inject constructor(
         mutableStateOf("")
     }
 
-    private val _formState = MutableStateFlow<List<DynamicFormModel>>(emptyList())
+    private val _formState = MutableStateFlow<List<DynamicFormModel>>(listOf(DynamicFormModel.createDefault()))
     internal val formState = _formState.asStateFlow()
 
     private val _formUiState = MutableStateFlow<FormUiState>(FormUiState.Loading)
@@ -62,14 +62,7 @@ internal class FormViewModel @Inject constructor(
     }
 
     internal fun addEmptyDynamicFormItem() {
-        val newItem = DynamicFormModel(
-            title = "",
-            formType = FormType.SENTENCE.name,
-            itemList = listOf(""),
-            requiredStatus = false,
-            otherJson = false
-        )
-        _formState.value += newItem
+        _formState.value += DynamicFormModel.createDefault()
     }
 
     internal fun createForm(

--- a/feature/form/src/main/java/com/school_of_company/form/viewModel/FormViewModel.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/viewModel/FormViewModel.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-internal class FormCreateViewModel @Inject constructor(
+internal class FormViewModel @Inject constructor(
     private val createFormUseCase: CreateFormUseCase,
 ) : ViewModel() {
 

--- a/feature/form/src/main/java/com/school_of_company/form/viewModel/FormViewModel.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/viewModel/FormViewModel.kt
@@ -1,29 +1,49 @@
 package com.school_of_company.form.viewModel
 
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.SavedStateHandleSaveableApi
+import androidx.lifecycle.viewmodel.compose.saveable
+import com.school_of_company.common.result.Result
+import com.school_of_company.common.result.asResult
 import com.school_of_company.domain.usecase.form.CreateFormUseCase
+import com.school_of_company.domain.usecase.form.GetFormUseCase
+import com.school_of_company.domain.usecase.form.ModifyFormUseCase
 import com.school_of_company.form.enum.FormType
-import com.school_of_company.form.viewModel.uiState.CreateFormUiState
+import com.school_of_company.form.viewModel.uiState.FormUiState
+import com.school_of_company.form.viewModel.uiState.GetFormUiState
 import com.school_of_company.model.model.form.DynamicFormModel
 import com.school_of_company.model.model.form.FormRequestAndResponseModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@OptIn(SavedStateHandleSaveableApi::class)
 @HiltViewModel
 internal class FormViewModel @Inject constructor(
     private val createFormUseCase: CreateFormUseCase,
+    private val getFormUseCase: GetFormUseCase,
+    private val modifyFormUseCase: ModifyFormUseCase,
+    private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
+    private var _coverImage by savedStateHandle.saveable {
+        mutableStateOf("")
+    }
 
     private val _formState = MutableStateFlow<List<DynamicFormModel>>(emptyList())
     internal val formState = _formState.asStateFlow()
 
     private val _formUiState = MutableStateFlow<FormUiState>(FormUiState.Loading)
     internal val formUiState = _formUiState.asStateFlow()
+
+    private val _getFormUiState = MutableStateFlow<GetFormUiState>(GetFormUiState.Loading)
+    internal val getFormUiState = _formUiState.asStateFlow()
 
     internal fun updateDynamicFormItem(index: Int, newItem: DynamicFormModel) {
         val currentList = _formState.value.toMutableList()
@@ -77,6 +97,51 @@ internal class FormViewModel @Inject constructor(
                 _formUiState.value = FormUiState.Error(error)
             }
     }
+
+    internal fun modifyForm(
+        expoId: String,
+        participantType: String,
+    ) = viewModelScope.launch {
+        _formUiState.value = FormUiState.Loading
+        modifyFormUseCase(
+            expoId = expoId,
+            body = FormRequestAndResponseModel(
+                informationImage = _coverImage,
+                participantType = participantType,
+                dynamicForm = _formState.value
+            ),
+        )
+            .onSuccess {
+                it.catch { remoteError ->
+                    _formUiState.value = FormUiState.Error(remoteError)
+                }.collect {
+                    _formUiState.value = FormUiState.Success
+                }
+            }
+            .onFailure { error ->
+                _formUiState.value = FormUiState.Error(error)
+            }
+    }
+
+    internal fun getForm(
+        expoId: String,
+        participantType: String,
+    ) = viewModelScope.launch {
+        _getFormUiState.value = GetFormUiState.Loading
+        getFormUseCase(
+            expoId = expoId,
+            participantType = participantType,
+        ).asResult()
+            .collectLatest {
+                when (it) {
+                    is Result.Loading -> _getFormUiState.value = GetFormUiState.Loading
+                    is Result.Success -> with(it.data) {
+                        _getFormUiState.value = GetFormUiState.Success
+                        _formState.value = dynamicForm
+                        _coverImage = informationImage
+                    }
+                    is Result.Error -> _getFormUiState.value = GetFormUiState.Error(it.exception)
+                }
             }
     }
 }

--- a/feature/form/src/main/java/com/school_of_company/form/viewModel/uiState/CreateFormUiState.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/viewModel/uiState/CreateFormUiState.kt
@@ -1,7 +1,0 @@
-package com.school_of_company.form.viewModel.uiState
-
-internal sealed interface CreateFormUiState {
-    object Loading : CreateFormUiState
-    object Success : CreateFormUiState
-    data class Error(val exception: Throwable) : CreateFormUiState
-}

--- a/feature/form/src/main/java/com/school_of_company/form/viewModel/uiState/FormUiState.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/viewModel/uiState/FormUiState.kt
@@ -1,0 +1,7 @@
+package com.school_of_company.form.viewModel.uiState
+
+internal sealed interface FormUiState {
+    object Loading : FormUiState
+    object Success : FormUiState
+    data class Error(val exception: Throwable) : FormUiState
+}

--- a/feature/form/src/main/java/com/school_of_company/form/viewModel/uiState/GetFormUiState.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/viewModel/uiState/GetFormUiState.kt
@@ -1,0 +1,9 @@
+package com.school_of_company.form.viewModel.uiState
+
+import com.school_of_company.model.model.form.DynamicFormModel
+
+internal sealed interface GetFormUiState {
+    object Loading : GetFormUiState
+    data class Success(val list: List<DynamicFormModel>) : GetFormUiState
+    data class Error(val exception: Throwable) : GetFormUiState
+}

--- a/feature/form/src/main/java/com/school_of_company/form/viewModel/uiState/GetFormUiState.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/viewModel/uiState/GetFormUiState.kt
@@ -1,9 +1,7 @@
 package com.school_of_company.form.viewModel.uiState
 
-import com.school_of_company.model.model.form.DynamicFormModel
-
 internal sealed interface GetFormUiState {
     object Loading : GetFormUiState
-    data class Success(val list: List<DynamicFormModel>) : GetFormUiState
+    object Success : GetFormUiState
     data class Error(val exception: Throwable) : GetFormUiState
 }


### PR DESCRIPTION
## 💡 개요

폼 수정화면을 퍼블리싱, 수정기능구현, navigation 연결

디자인

![image](https://github.com/user-attachments/assets/f93d8b65-7554-4166-a446-0af09d35c1d7)

퍼블리싱

![image](https://github.com/user-attachments/assets/9c70393a-9391-4c53-aa2b-6376a64cf9f3)

## 📃 작업내용

폼 수정화면을 퍼블리싱하고 
기존 FormViewModel 에 수정기능과 불러오기 기능을 추가했습니다
ExpoDetailScreen에 navigation 을 연결했습니다

## 🔀 변경사항

expoNavHost
form 관련 repository, usecase, api, datasource 
FormRequestAndResponseModel
CreateFormUiState -> FormUiState
FormCreateViewModel -> FormViewModel

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타
