### PR TITLE
🔀(480) ::인증번호의 에러핸들링 및 인증번호 전송 상태에 따라 버튼을 다르게 하는 것을 구현했습니다.

### DIFF
--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/button/ExpoButton.kt
@@ -57,6 +57,44 @@ fun ExpoButton(
         }
     }
 }
+@Composable
+fun TimeExpoStateButton(
+    modifier: Modifier = Modifier,
+    state: ButtonState = ButtonState.Enable,
+    text: String,
+    onClick: () -> Unit,
+) {
+    ExpoAndroidTheme { colors, typography ->
+
+        val interactionSource = remember { MutableInteractionSource() }
+
+        val enabledState: (buttonState: ButtonState) -> Boolean = {
+            when (it) {
+                ButtonState.Enable -> true
+                ButtonState.Disable -> false
+            }
+        }
+        Button(
+            modifier = modifier,
+            interactionSource = interactionSource,
+            enabled = enabledState(state),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = colors.main,
+                contentColor = colors.white,
+                disabledContainerColor = colors.gray200,
+                disabledContentColor = colors.gray400
+            ),
+            contentPadding = PaddingValues(vertical = 16.dp),
+            shape = RoundedCornerShape(12.dp),
+            onClick = onClick,
+        ) {
+            Text(
+                text = text,
+                style = typography.bodyBold2
+            )
+        }
+    }
+}
 
 @Composable
 fun ExpoStateButton(

--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -112,6 +112,7 @@
     <string name="write_certification">인증 번호 입력</string>
     <string name="valid_certification">인증번호가 올바르지 않습니다.</string>
     <string name="fail_certification">인증에 실패하셨습니다.</string>
+    <string name="sms_not_certification">인증번호를 발급해주세요.</string>
 
     <string name="re_certificationCode">인증번호 재발송</string>
     <string name="certificationCode">인증번호 발송</string>

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/sms/SmsSignUpCertificationNumberCertificationRequestUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/sms/SmsSignUpCertificationNumberCertificationRequestUseCase.kt
@@ -2,15 +2,15 @@ package com.school_of_company.domain.usecase.sms
 
 import android.util.Log
 import com.school_of_company.data.repository.sms.SmsRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class SmsSignUpCertificationNumberCertificationRequestUseCase @Inject constructor(
     private val repository: SmsRepository
 ) {
-    operator fun invoke(phoneNumber: String, code: String) = runCatching {
+    operator fun invoke(phoneNumber: String, code: String): Flow<Unit> =
         repository.smsSignUpCertificationNumberCertification(
             phoneNumber = phoneNumber,
             code = code
         )
-    }
 }

--- a/feature/signup/build.gradle.kts
+++ b/feature/signup/build.gradle.kts
@@ -6,3 +6,9 @@ plugins {
 android {
     namespace = "com.school_of_company.signup"
 }
+
+dependencies {
+    implementation(libs.retrofit.core)
+    implementation(libs.retrofit.kotlin.serialization)
+    implementation(libs.retrofit.moshi.converter)
+}

--- a/feature/signup/src/main/java/com/school_of_company/signup/view/SignUpScreen.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/view/SignUpScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -38,6 +39,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.button.ExpoStateButton
+import com.school_of_company.design_system.component.button.TimeExpoStateButton
 import com.school_of_company.design_system.component.button.state.ButtonState
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
@@ -50,7 +52,10 @@ import com.school_of_company.model.param.auth.AdminSignUpRequestParam
 import com.school_of_company.model.param.sms.SmsSignUpCertificationNumberSendRequestParam
 import com.school_of_company.signup.viewmodel.SignUpViewModel
 import com.school_of_company.signup.viewmodel.uistate.SignUpUiState
+import com.school_of_company.signup.viewmodel.uistate.SmsSignUpCertificationCodeUiState
+import com.school_of_company.signup.viewmodel.uistate.SmsSignUpCertificationSendCodeUiState
 import com.school_of_company.ui.toast.makeToast
+import kotlinx.coroutines.delay
 
 @Composable
 internal fun SignUpRoute(
@@ -62,7 +67,9 @@ internal fun SignUpRoute(
 ) {
     val signUpUiState by viewModel.signUpUiState.collectAsStateWithLifecycle()
     val name by viewModel.name.collectAsStateWithLifecycle()
+    val SmsSignUpCertificationSendCodeUiState by viewModel.smsSignUpCertificationSendCodeUiState.collectAsStateWithLifecycle()
     val nickname by viewModel.nickname.collectAsStateWithLifecycle()
+    val smsSignUpCertificationCodeUiState by viewModel.smsSignUpCertificationCodeUiState.collectAsStateWithLifecycle()
     val email by viewModel.email.collectAsStateWithLifecycle()
     val password by viewModel.password.collectAsStateWithLifecycle()
     val rePassword by viewModel.rePassword.collectAsStateWithLifecycle()
@@ -73,6 +80,7 @@ internal fun SignUpRoute(
     val isEmailValidError by viewModel.isEmailValidError.collectAsStateWithLifecycle()
     val isCertificationCodeError by viewModel.isCertificationCodeValid.collectAsStateWithLifecycle()
     val context = LocalContext.current
+
 
     DisposableEffect(signUpUiState) {
         when (signUpUiState) {
@@ -110,6 +118,28 @@ internal fun SignUpRoute(
             }
         }
         onDispose { viewModel.initSignUp() }
+    }
+
+    LaunchedEffect(smsSignUpCertificationCodeUiState){
+        when(smsSignUpCertificationCodeUiState){
+            is SmsSignUpCertificationCodeUiState.Loading -> Unit
+
+            is SmsSignUpCertificationCodeUiState.Success -> {
+                makeToast(context, "인증을 성공했습니다.")
+            }
+
+            is SmsSignUpCertificationCodeUiState.Error -> {
+                val error = smsSignUpCertificationCodeUiState as SmsSignUpCertificationCodeUiState.Error
+
+                when(error.errorType){
+                    SmsSignUpCertificationCodeUiState.ErrorType.Unauthorized -> viewModel.setBadRequestError(true)
+                    SmsSignUpCertificationCodeUiState.ErrorType.BAD_REQUEST -> viewModel.setBadRequestError(true)
+                    SmsSignUpCertificationCodeUiState.ErrorType.GENERAL -> viewModel.setError(true)
+
+                }
+                onErrorToast(error.exception, error.messageResId)
+            }
+        }
     }
 
     SignUpScreen(
@@ -158,7 +188,7 @@ internal fun SignUpRoute(
         onRePasswordChange = viewModel::onRePasswordChange,
         onPhoneNumberChange = viewModel::onPhoneNumberChange,
         onCertificationNumberChange = viewModel::onCertificationNumberChange,
-
+        smsSignUpCertificationSendCodeUiState = SmsSignUpCertificationSendCodeUiState
     )
 }
 
@@ -168,6 +198,7 @@ private fun SignUpScreen(
     isPasswordValidError: Boolean,
     isPasswordMismatchError: Boolean,
     isEmailValidError: Boolean,
+    smsSignUpCertificationSendCodeUiState: SmsSignUpCertificationSendCodeUiState,
     isCertificationCodeError: Boolean,
     name: String,
     nickname: String,
@@ -192,6 +223,17 @@ private fun SignUpScreen(
 ) {
     var isPasswordVisible by remember { mutableStateOf(false) }
     var isCheckPasswordVisible by remember { mutableStateOf(false) }
+    var isEnabled by remember { mutableStateOf(false) }
+    var remainingAttempts by remember { mutableStateOf(5) }
+    var isFirstAttempt by remember { mutableStateOf(true) }
+
+    LaunchedEffect(remainingAttempts) {
+        if (remainingAttempts > 0) {
+            isEnabled = false
+            delay(300_000L)
+            isEnabled = true
+        }
+    }
 
     ExpoAndroidTheme { colors, typography ->
 
@@ -343,12 +385,27 @@ private fun SignUpScreen(
                         keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
                     )
 
-                    ExpoStateButton(
-                        text = "인증번호",
-                        state = if (phoneNumber.isNotBlank()) ButtonState.Enable else ButtonState.Disable,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        sendCertificationCodeCallBack()
+                    if (smsSignUpCertificationSendCodeUiState is SmsSignUpCertificationSendCodeUiState.Success || !isFirstAttempt) {
+                        TimeExpoStateButton(
+                            modifier = Modifier.fillMaxWidth(),
+                            text =  "재발송",
+                            state = if (isEnabled && remainingAttempts > 0) ButtonState.Enable else ButtonState.Disable
+                        ) {
+                            if (isEnabled && remainingAttempts > 0) {
+                                sendCertificationCodeCallBack()
+                                isEnabled = false
+                                remainingAttempts--
+                            }
+                        }
+                    }else{
+                        ExpoStateButton(
+                            text = "인증번호",
+                            state = if (phoneNumber.isNotBlank()) ButtonState.Enable else ButtonState.Disable,
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            sendCertificationCodeCallBack()
+                            isFirstAttempt = false
+                        }
                     }
                 }
 
@@ -424,5 +481,6 @@ private fun SignUpScreenPreview() {
         certificationCallBack = {},
         sendCertificationCodeCallBack = {},
         isCertificationCodeError = false,
+        smsSignUpCertificationSendCodeUiState = SmsSignUpCertificationSendCodeUiState.Loading
     )
 }

--- a/feature/signup/src/main/java/com/school_of_company/signup/viewmodel/uistate/SmsSignUpCertificationCodeUiState.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/viewmodel/uistate/SmsSignUpCertificationCodeUiState.kt
@@ -3,5 +3,13 @@ package com.school_of_company.signup.viewmodel.uistate
 sealed interface SmsSignUpCertificationCodeUiState {
     object Loading : SmsSignUpCertificationCodeUiState
     object Success : SmsSignUpCertificationCodeUiState
-    data class Error(val exception: Throwable) : SmsSignUpCertificationCodeUiState
+    data class Error(
+        val exception: Throwable? = null,
+        val messageResId: Int,
+        val errorType: ErrorType
+    ) : SmsSignUpCertificationCodeUiState
+
+    enum class ErrorType {
+        Unauthorized, BAD_REQUEST, GENERAL
+    }
 }


### PR DESCRIPTION
## 💡 개요
인증번호의 에러핸들링 및 인증번호 전송 상태에 따라 버튼을 다르게 하는 것을 구현했습니다.

## 📃 작업내용
viewModel에서 에러코드 기반으로 에러를 핸들링 핟록 하였습니다..(:feature:signup)

Signup(ViewModel, UiState, Screen)에서 에러 코드를 받아 직접 에러를 핸들링하는 방법으로 리팩터링을 하였습니다
 TimeExpoButton 버튼을 추가하여습니다.
Signup Screen에서 인증번호를 누르면 재발송 버튼으로 바뀌고 5분후 버튼이 Enable 상태로 바뀌는 것을 구현했습니다.
![image](https://github.com/user-attachments/assets/5ddf5d42-0224-4c54-9357-7fb8e2a469e8)
![image](https://github.com/user-attachments/assets/d5488835-98b9-4db7-b03a-708ffda674b9)


## 🔀 변경사항
recycle  SignUpScreen
recycle SmsSignUpCertificationCodeUiState
recycle ExpoButton
recycle  SignUpScreen
recycle SignUpViewModel


## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타
