### PR TITLE
🔀 :: (#486) - 박람회 자세히 보기 화면에서 소개글 부분에 Read More(Less) 기능을 구현을 추가하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -241,7 +241,7 @@ private fun ExpoDetailScreen(
 
                             if (showReadMoreButtonState) {
                                 Text(
-                                    text = if (expandedState) "줄이기" else "더보기",
+                                    text = if (expandedState) "접기" else "더보기",
                                     color = colors.gray200,
                                     modifier = Modifier.expoClickable {
                                         expandedState = !expandedState

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -23,12 +23,15 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -54,6 +57,7 @@ import com.school_of_company.expo.viewmodel.uistate.GetTrainingProgramListUiStat
 import com.school_of_company.model.enum.Authority
 import com.school_of_company.model.enum.ParticipantType
 import com.school_of_company.ui.util.formatServerDate
+import kotlin.math.max
 
 @Composable
 internal fun ExpoDetailRoute(
@@ -145,6 +149,11 @@ private fun ExpoDetailScreen(
     val (openFormModifyDialog, isOpenFormModifyDialog) = rememberSaveable { mutableStateOf(false) }
     val (openFormCreateDialog, isOpenFormCreateDialog) = rememberSaveable { mutableStateOf(false) }
 
+    var expandedState by rememberSaveable { mutableStateOf(false) }
+    var showReadMoreButtonState by rememberSaveable { mutableStateOf(false) }
+
+    val maxLines = if (expandedState) 100 else 5
+
     ExpoAndroidTheme { colors, typography ->
         when {
 
@@ -220,8 +229,28 @@ private fun ExpoDetailScreen(
                             Text(
                                 text = getExpoInformationUiState.data.description,
                                 style = typography.bodyRegular2,
-                                color = colors.gray400
+                                color = colors.gray400,
+                                overflow = TextOverflow.Ellipsis,
+                                maxLines = maxLines,
+                                onTextLayout = { textLayoutResult: TextLayoutResult ->
+                                    if (textLayoutResult.lineCount > 4) {
+                                        if (textLayoutResult.isLineEllipsized(4)) showReadMoreButtonState = true
+                                    }
+                                }
                             )
+
+                            if (showReadMoreButtonState) {
+                                Text(
+                                    text = if (expandedState) "줄이기" else "더보기",
+                                    color = colors.gray200,
+                                    modifier = Modifier.expoClickable {
+                                        expandedState = !expandedState
+                                    },
+                                    style = typography.bodyRegular2
+                                )
+                            }
+
+                            Spacer(modifier = Modifier.height(8.dp))
 
                             Row(
                                 horizontalArrangement = Arrangement.spacedBy(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextLayoutResult
@@ -226,18 +228,37 @@ private fun ExpoDetailScreen(
                                 fontWeight = FontWeight(600),
                             )
 
-                            Text(
-                                text = getExpoInformationUiState.data.description,
-                                style = typography.bodyRegular2,
-                                color = colors.gray400,
-                                overflow = TextOverflow.Ellipsis,
-                                maxLines = maxLines,
-                                onTextLayout = { textLayoutResult: TextLayoutResult ->
-                                    if (textLayoutResult.lineCount > 4) {
-                                        if (textLayoutResult.isLineEllipsized(4)) showReadMoreButtonState = true
+                            Box(modifier = Modifier.fillMaxWidth()) {
+                                Text(
+                                    text = getExpoInformationUiState.data.description,
+                                    style = typography.bodyRegular2,
+                                    color = colors.gray400,
+                                    overflow = TextOverflow.Ellipsis,
+                                    maxLines = maxLines,
+                                    onTextLayout = { textLayoutResult: TextLayoutResult ->
+                                        if (textLayoutResult.lineCount > 4) {
+                                            if (textLayoutResult.isLineEllipsized(4)) showReadMoreButtonState =
+                                                true
+                                        }
                                     }
+                                )
+
+                                if (!expandedState) {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .height(40.dp)
+                                            .align(Alignment.BottomCenter)
+                                            .background(
+                                                brush = Brush.verticalGradient(
+                                                    colors = listOf(Color.Transparent, colors.white),
+                                                    startY = 0f,
+                                                    endY = 120f
+                                                )
+                                            )
+                                    )
                                 }
-                            )
+                            }
 
                             if (showReadMoreButtonState) {
                                 Text(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -151,10 +151,10 @@ private fun ExpoDetailScreen(
     val (openFormModifyDialog, isOpenFormModifyDialog) = rememberSaveable { mutableStateOf(false) }
     val (openFormCreateDialog, isOpenFormCreateDialog) = rememberSaveable { mutableStateOf(false) }
 
-    var expandedState by rememberSaveable { mutableStateOf(false) }
+    var expandedExpoIntroductionTextState by rememberSaveable { mutableStateOf(false) }
     var showReadMoreButtonState by rememberSaveable { mutableStateOf(false) }
 
-    val maxLines = if (expandedState) 100 else 5
+    val maxLines = if (expandedExpoIntroductionTextState) 100 else 5
 
     ExpoAndroidTheme { colors, typography ->
         when {
@@ -243,7 +243,7 @@ private fun ExpoDetailScreen(
                                     }
                                 )
 
-                                if (!expandedState) {
+                                if (!expandedExpoIntroductionTextState) {
                                     Box(
                                         modifier = Modifier
                                             .fillMaxWidth()
@@ -262,10 +262,10 @@ private fun ExpoDetailScreen(
 
                             if (showReadMoreButtonState) {
                                 Text(
-                                    text = if (expandedState) "접기" else "더보기",
+                                    text = if (expandedExpoIntroductionTextState) "접기" else "더보기",
                                     color = colors.gray200,
                                     modifier = Modifier.expoClickable {
-                                        expandedState = !expandedState
+                                        expandedExpoIntroductionTextState = !expandedExpoIntroductionTextState
                                     },
                                     style = typography.bodyRegular2
                                 )


### PR DESCRIPTION
## 💡 개요
- 긴 텍스트가 한 번에 표시되면 화면이 너무 길어지고 가독성이 떨어질 수 있다고 생각이 되었습니다.
## 📃 작업내용
- Read More, Read Less 기능을 추가하여 위와 같은 문제를 해결하여 사용자 경험을 향상 시킬 수 있었습니다.

     https://github.com/user-attachments/assets/c4400c94-e7b3-4d6c-81df-81b8fd086032

## 🔀 변경사항
- chore ExpoDetailScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 전시 상세 화면에서 긴 설명을 간략하게 표시하는 기능이 추가되었습니다. 기본적으로 5줄까지만 보여주며, 내용이 넘치는 경우 "더 읽기" 버튼이 나타납니다.
	- 버튼 클릭 시 전체 내용을 확인할 수 있으며, 그라데이션 오버레이를 통해 추가 내용이 있음을 시각적으로 안내합니다.
	- 이를 통해 사용자 인터페이스가 더욱 직관적이고 사용하기 쉬워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->