### PR TITLE
🔀 :: (#494) - 디자인과 구현한 코드와 차이점이 있어 수정을 하였습니다.

### DIFF
--- a/.github/workflows/expo_ci.yml
+++ b/.github/workflows/expo_ci.yml
@@ -53,7 +53,6 @@ jobs:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}
           image: ${{ secrets.SUCCESS_IMAGE }}
-          content: "<@${{ secrets.ID1 }}> <@${{ secrets.ID2 }}> 성공! 확인부탁드립니다...!!!"
           description: 뀨
           color: 65280
           url: "https://github.com/sarisia/actions-status-discord"

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -396,7 +397,7 @@ fun ExpoLocationIconTextField(
     onButtonClicked: () -> Unit,
 ) {
     ExpoAndroidTheme { colors, typography ->
-        Box {
+        Box(modifier = modifier.clip(RoundedCornerShape(8.dp))) {
             OutlinedTextField(
                 placeholder = {
                     Text(
@@ -413,7 +414,7 @@ fun ExpoLocationIconTextField(
                     .height(50.dp)
                     .border(
                         width = 1.dp,
-                        shape = RoundedCornerShape(6.dp),
+                        shape = RoundedCornerShape(8.dp),
                         color = colors.gray100
                     )
                     .background(color = Color.Transparent)
@@ -585,6 +586,14 @@ fun ExpoOutlinedTextFieldPreview() {
                 placeholder = "",
                 updateTextValue = {},
                 textStyle = ExpoTypography.bodyBold2.copy(fontWeight = FontWeight.W600)
+            )
+
+            ExpoLocationIconTextField(
+                value = "",
+                onValueChange = {},
+                placeholder = "",
+                isDisabled = false,
+                onButtonClicked = {}
             )
         }
     }

--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
@@ -244,9 +244,7 @@ fun LimitedLengthTextField(
     visualTransformation: VisualTransformation = VisualTransformation.None,
     lengthLimit: Int = 0,
 ) {
-    val lengthCheck = remember {
-        if (lengthLimit != 0) value.length >= lengthLimit else false
-    }
+    val lengthCheck = lengthLimit != 0 && value.length > lengthLimit
 
     ExpoAndroidTheme { colors, typography ->
         Column(

--- a/core/ui/src/main/java/com/school_of_company/ui/preview/ExpoPreviews.kt
+++ b/core/ui/src/main/java/com/school_of_company/ui/preview/ExpoPreviews.kt
@@ -17,9 +17,9 @@ import androidx.compose.ui.tooling.preview.Preview
  * }
  * ```
  */
-@Preview(name = "phone_1", device = "spec:shape=Normal,width=360,height=880,unit=dp,dpi=480")
-@Preview(name = "phone_2", device = "spec:shape=Normal,width=412,height=732,unit=dp,dpi=420")
-@Preview(name = "s23", device = "spec:shape=Normal,width=360,height=780,unit=dp,dpi=480")
-@Preview(name = "foldable", device = "spec:shape=Normal,width=673,height=841,unit=dp,dpi=480")
-@Preview(name = "tablet", device = "spec:shape=Normal,width=1280,height=800,unit=dp,dpi=480")
+@Preview(name = "phone_1", device = "spec:width=360dp,height=880dp,dpi=480")
+@Preview(name = "phone_2", device = "spec:width=412dp,height=732dp,dpi=420")
+@Preview(name = "s23", device = "spec:width=360dp,height=780dp,dpi=480")
+@Preview(name = "foldable", device = "spec:width=673dp,height=841dp,dpi=480")
+@Preview(name = "tablet", device = "spec:width=1280dp,height=800dp,dpi=480")
 annotation class ExpoPreviews

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoAddressSearchScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoAddressSearchScreen.kt
@@ -32,6 +32,7 @@ import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.button.ExpoStateButton
 import com.school_of_company.design_system.component.button.state.ButtonState
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
+import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
 import com.school_of_company.design_system.component.textfield.ExpoSearchIconTextField
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
 import com.school_of_company.design_system.icon.LeftArrowIcon
@@ -128,7 +129,11 @@ private fun ExpoAddressSearchScreen(
             modifier = modifier
                 .fillMaxSize()
                 .background(color = colors.white)
-                .padding(16.dp)
+                .paddingHorizontal(
+                    horizontal = 16.dp,
+                    top = 68.dp,
+                    bottom = 24.dp
+                )
                 .pointerInput(Unit) {
                     detectTapGestures(
                         onTap = {
@@ -138,7 +143,6 @@ private fun ExpoAddressSearchScreen(
                 },
         ) {
             ExpoTopBar(
-                modifier = Modifier.padding(vertical = 16.dp),
                 startIcon = {
                     LeftArrowIcon(
                         tint = colors.black,
@@ -146,6 +150,7 @@ private fun ExpoAddressSearchScreen(
                     )
                 },
                 betweenText = "장소",
+                modifier = Modifier.padding(bottom = 38.dp)
             )
 
             Column(modifier = Modifier.fillMaxWidth()) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -519,9 +519,7 @@ private fun ExpoCreateScreen(
                         } else {
                             ButtonState.Disable
                         },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(14.dp),
+                        modifier = Modifier.fillMaxWidth(),
                         onClick = onExpoCreateCallBack
                     )
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -102,7 +103,9 @@ internal fun ExpoCreateRoute(
     val trainingProgramTextState by viewModel.trainingProgramTextState.collectAsStateWithLifecycle()
     val standardProgramTextState by viewModel.standardProgramTextState.collectAsStateWithLifecycle()
 
-    var selectedImageUri by rememberSaveable { mutableStateOf<Uri?>(null) }
+    var selectedImageUriString by rememberSaveable { mutableStateOf<String?>(null) }
+    var selectedImageUri: Uri? = selectedImageUriString?.let { Uri.parse(it) }
+
 
     val context = LocalContext.current
 
@@ -112,12 +115,13 @@ internal fun ExpoCreateRoute(
                 val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
                 context.contentResolver.openInputStream(uri)?.use { inputStream ->
                     BitmapFactory.decodeStream(inputStream, null, options)
+                    selectedImageUriString = uri.toString()
                     selectedImageUri = uri
                 }
             }
         }
 
-    LaunchedEffect("InitializeWithSearchedData") {
+    LaunchedEffect(Unit) {
         viewModel.initializeWithSearchedData()
     }
 
@@ -159,6 +163,7 @@ internal fun ExpoCreateRoute(
             is RegisterExpoInformationUiState.Success -> {
                 viewModel.resetExpoInformation()
                 selectedImageUri = null
+                selectedImageUriString = null
                 makeToast(context, "박람회 등록을 완료하였습니다.")
                 viewModel.initRegisterExpo()
             }
@@ -238,8 +243,8 @@ private fun ExpoCreateScreen(
     val (openTrainingSettingBottomSheet, isOpenTrainingSettingBottomSheet) = rememberSaveable { mutableStateOf(false) }
     val (openStandardSettingBottomSheet, isOpenStandardSettingBottomSheet) = rememberSaveable { mutableStateOf(false) }
 
-    var selectedTrainingIndex by remember { mutableStateOf<Int?>(null) }
-    var selectedStandardIndex by remember { mutableStateOf<Int?>(null) }
+    var selectedTrainingIndex by rememberSaveable { mutableStateOf<Int?>(null) }
+    var selectedStandardIndex by rememberSaveable { mutableStateOf<Int?>(null) }
 
     ExpoAndroidTheme { colors, typography ->
         Column(
@@ -352,6 +357,26 @@ private fun ExpoCreateScreen(
                         text = "이미지 328 × 178 사이즈를 권장합니다.",
                         style = typography.captionRegular2,
                         color = colors.gray300
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(3.dp))
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp, Alignment.Start),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.expoClickable { onImageClick() }
+                ) {
+                    ImageIcon(
+                        tint = colors.gray300,
+                        modifier = Modifier.size(16.dp)
+                    )
+
+                    Text(
+                        text = "이미지 수정하기(클릭)",
+                        style = typography.captionRegular2,
+                        color = colors.gray300,
+                        textDecoration = TextDecoration.Underline
                     )
                 }
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -145,7 +145,10 @@ private fun ExpoCreatedScreen(
                     when (getExpoListUiState) {
                         is GetExpoListUiState.Loading -> Unit
                         is GetExpoListUiState.Success -> {
-                            Column(horizontalAlignment = Alignment.CenterHorizontally,) {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                modifier = Modifier.padding(horizontal = 8.dp)
+                            ) {
                                 CreatedExpoList(
                                     selectedIndex = selectedIndex,
                                     expoList = getExpoListUiState.data.toPersistentList(),

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -57,7 +57,7 @@ internal fun ExpoCreatedRoute(
 
     val context = LocalContext.current
 
-    LaunchedEffect("initCreatedExpo") {
+    LaunchedEffect(Unit) {
         expoViewModel.getExpoList()
     }
 
@@ -71,6 +71,7 @@ internal fun ExpoCreatedRoute(
         when (deleteExpoInformationUiState) {
             is DeleteExpoInformationUiState.Loading -> Unit
             is DeleteExpoInformationUiState.Success -> {
+                setSelectedIndex(-1)
                 makeToast(context, "박람회가 삭제되었습니다.")
             }
             is DeleteExpoInformationUiState.Error -> {

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -38,6 +38,7 @@ import com.school_of_company.expo.viewmodel.ExpoViewModel
 import com.school_of_company.expo.viewmodel.uistate.DeleteExpoInformationUiState
 import com.school_of_company.expo.viewmodel.uistate.GetExpoListUiState
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
+import com.school_of_company.ui.preview.ExpoPreviews
 import com.school_of_company.ui.toast.makeToast
 import kotlinx.collections.immutable.immutableListOf
 import kotlinx.collections.immutable.toPersistentList
@@ -178,7 +179,7 @@ private fun ExpoCreatedScreen(
     }
 }
 
-@Preview
+@ExpoPreviews
 @Composable
 private fun ExpoCreatedScreenPreview() {
     ExpoCreatedScreen(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -316,12 +316,20 @@ private fun ExpoDetailScreen(
                                     color = colors.gray400
                                 )
 
-                                getStandardProgramUiState.data.forEach { program ->
+                                if (getStandardProgramUiState.data.isEmpty()) {
                                     Text(
-                                        text = "· ${program.title}",
+                                        text = "일반 프로그램이 없습니다.",
                                         style = typography.bodyRegular2,
                                         color = colors.gray400
                                     )
+                                } else {
+                                    getStandardProgramUiState.data.forEach { program ->
+                                        Text(
+                                            text = "· ${program.title}",
+                                            style = typography.bodyRegular2,
+                                            color = colors.gray400
+                                        )
+                                    }
                                 }
                             }
 
@@ -332,12 +340,20 @@ private fun ExpoDetailScreen(
                                     color = colors.gray400
                                 )
 
-                                getTrainingProgramUiState.data.forEach { program ->
+                                if (getTrainingProgramUiState.data.isEmpty()) {
                                     Text(
-                                        text = "· ${program.title}",
+                                        text = "프로그램이 존재하지 않음",
                                         style = typography.bodyRegular2,
                                         color = colors.gray400
                                     )
+                                } else {
+                                    getTrainingProgramUiState.data.forEach { program ->
+                                        Text(
+                                            text = "· ${program.title}",
+                                            style = typography.bodyRegular2,
+                                            color = colors.gray400
+                                        )
+                                    }
                                 }
                             }
                         }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -263,7 +263,7 @@ private fun ExpoDetailScreen(
                             if (showReadMoreButtonState) {
                                 Text(
                                     text = if (expandedExpoIntroductionTextState) "접기" else "더보기",
-                                    color = colors.gray200,
+                                    color = if (expandedExpoIntroductionTextState) colors.main else colors.gray200,
                                     modifier = Modifier.expoClickable {
                                         expandedExpoIntroductionTextState = !expandedExpoIntroductionTextState
                                     },

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/CreatedExpoListItem.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidthIn
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,11 +18,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.school_of_company.design_system.icon.CircleIcon
-import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
-import com.school_of_company.design_system.theme.ExpoTypography
-import com.school_of_company.design_system.theme.color.ColorTheme
 import com.school_of_company.expo.util.formatDateToMonthDay
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
 
@@ -35,9 +32,9 @@ internal fun CreatedExpoListItem(
     onClick: () -> Unit,
 ) {
     with(item) {
-        ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
+        ExpoAndroidTheme { colors, typography ->
             Row(
-                horizontalArrangement = Arrangement.spacedBy(38.dp, Alignment.Start),
+                horizontalArrangement = Arrangement.spacedBy(65.dp, Alignment.Start),
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = modifier
                     .horizontalScroll(scrollState)
@@ -56,16 +53,11 @@ internal fun CreatedExpoListItem(
                     textAlign = TextAlign.Center,
                 )
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(48.dp, Alignment.Start),
+                    horizontalArrangement = Arrangement.spacedBy(75.dp, Alignment.Start),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    if (coverImage == null) {
-                        XIcon(tint = colors.error)
-                    } else {
-                        CircleIcon(tint = colors.black)
-                    }
                     Text(
-                        modifier = Modifier.requiredWidthIn(136.dp),
+                        modifier = Modifier.width(80.dp),
                         text = title,
                         style = typography.captionRegular2,
                         fontWeight = FontWeight.W400,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTable.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoCreatedTable.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidthIn
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -18,40 +17,31 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
-import com.school_of_company.design_system.theme.ExpoTypography
-import com.school_of_company.design_system.theme.color.ColorTheme
 
 @Composable
 fun ExpoCreatedTable(modifier: Modifier = Modifier) {
-    ExpoAndroidTheme { colors: ColorTheme, typography: ExpoTypography ->
+    ExpoAndroidTheme { colors, typography ->
         Column(Modifier.fillMaxWidth()) {
             HorizontalDivider(thickness = 1.dp, color = colors.gray200)
             Row(
                 horizontalArrangement = Arrangement.spacedBy(73.dp, Alignment.Start),
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = modifier
+                    .fillMaxWidth()
                     .background(color = colors.white)
                     .padding(
-                        horizontal = 54.dp,
+                        horizontal = 90.dp,
                         vertical = 14.dp,
                     )
             ) {
                 Text(
-                    modifier = Modifier.requiredWidthIn(37.dp),
-                    text = "이미지",
-                    style = typography.captionBold1,
-                    fontWeight = FontWeight.W600,
-                    color = colors.gray600,
-                    textAlign = TextAlign.Center,
-                )
-                Text(
-                    modifier = Modifier.requiredWidthIn(64.dp),
+                    modifier = Modifier.requiredWidthIn(80.dp),
                     text = "박람회 이름",
                     style = typography.captionBold1,
                     fontWeight = FontWeight.W600,
                     color = colors.gray600,
-                    textAlign = TextAlign.Center,
                 )
+
                 Text(
                     modifier = Modifier.requiredWidthIn(52.dp),
                     text = "모집 기간",

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoKakaoMapComponent.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoKakaoMapComponent.kt
@@ -47,7 +47,7 @@ internal fun HomeKakaoMap(
                         }
 
                         override fun onMapError(exception: Exception?) {
-                            makeToast(context = context, toastMessage = "지도를 불러오는 중 알 수 없는 에러가 발생했습니다.\n onMapError: $exception")
+                            makeToast(context = context, toastMessage = "지도를 불러오는 중 알 수 없는 에러가 발생했습니다.")
                         }
                     },
 

--- a/feature/sms/src/main/java/com/school_of_company/sms/view/SendMessageScreen.kt
+++ b/feature/sms/src/main/java/com/school_of_company/sms/view/SendMessageScreen.kt
@@ -101,7 +101,7 @@ private fun SendMessageScreen(
                 .background(color = colors.white)
                 .paddingHorizontal(
                     horizontal = 16.dp,
-                    top = 61.dp
+                    top = 68.dp
                 )
                 .pointerInput(Unit) {
                     detectTapGestures(

--- a/feature/sms/src/main/java/com/school_of_company/sms/view/component/SendMessageTopBar.kt
+++ b/feature/sms/src/main/java/com/school_of_company/sms/view/component/SendMessageTopBar.kt
@@ -23,7 +23,7 @@ internal fun HomeSendMessageTopBar(
     betweenText: String = "",
     endIcon: @Composable () -> Unit = { Spacer(modifier = Modifier.size(24.dp)) }
 ) {
-    ExpoAndroidTheme { _, typography ->
+    ExpoAndroidTheme { colors, typography ->
         Row(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
@@ -34,6 +34,7 @@ internal fun HomeSendMessageTopBar(
                 text = betweenText,
                 style = typography.bodyRegular1,
                 fontWeight = FontWeight(400),
+                color = colors.black
             )
             endIcon()
         }


### PR DESCRIPTION
## 💡 개요
- 디자인과 실제 구현한 코드와 차이점이 많이 있어 코드를 수정할 필요가 있었습니다.
## 📃 작업내용
- 탑바 padding(top) 수정
- 등록된 박람회를 삭제하고 버튼상태가 초기화되지 않는 문제 해결
- 박람회 생성에서 이미지를 선택하고 다른 네비게이션뷰로 이동한 이후에 이미지 값이 저장이 되지 않고 없어지는 문제를 해결
- 길이 제한이 있는 텍스트 필드가 최대 크기가 되어도 에러가 나오는 문제가 있어 해결
- 다른 디자인 요소들이 맞지않는 문제가 있어 수정
## 🔀 변경사항
<img width="686" alt="스크린샷 2025-03-27 오전 12 34 42" src="https://github.com/user-attachments/assets/e0d652b8-c2b2-4ef6-ac87-643b022ab8af" />

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- 이미지 수정 UI 요소와 텍스트 필드 미리보기 업데이트로 상호작용을 개선했습니다.
  
- **Style**
	- 텍스트 필드의 입력 제한 로직과 모서리 둥글기를 통일하여 외관을 개선했습니다.
	- 주소 검색, 생성, 상세, 목록, 테이블, 지도 및 메시지 화면의 패딩과 간격을 최적화했습니다.
	- “Read More” 버튼의 색상이 상태에 따라 변화하도록 조정했으며, 지도 오류 메시지를 단순화하여 사용자 알림을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->