### PR TITLE
🔀 :: (#499) - formToggleButton 의 드래그가 끝나면 무조건 드래그 시작점의 반대로 이동하는 버그를 수정했습니다

### DIFF
--- a/feature/form/src/main/java/com/school_of_company/form/view/component/FormToggleButton.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/component/FormToggleButton.kt
@@ -7,15 +7,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Switch
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -59,6 +56,7 @@ internal fun FormToggleButton(
                 else thumbOffset > (maxBound / 2)
 
                 if (isOverHalf) onClick()
+                thumbOffset = if (check) maxBound else minBound
             }
         }
 

--- a/feature/form/src/main/java/com/school_of_company/form/view/component/FormToggleButton.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/component/FormToggleButton.kt
@@ -56,7 +56,7 @@ internal fun FormToggleButton(
                 else thumbOffset > (maxBound / 2)
 
                 if (isOverHalf) onClick()
-                thumbOffset = if (check) maxBound else minBound
+                else thumbOffset = if (check) maxBound else minBound
             }
         }
 

--- a/feature/form/src/main/java/com/school_of_company/form/view/component/FormToggleButton.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/component/FormToggleButton.kt
@@ -7,13 +7,17 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Switch
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -49,6 +53,18 @@ internal fun FormToggleButton(
 
         val positionFraction = thumbOffset / maxBound
 
+        LaunchedEffect(isDragging) {
+            if (!isDragging) {
+                val isOverHalf = if (check) thumbOffset < (maxBound / 2)
+                else thumbOffset > (maxBound / 2)
+
+                if (isOverHalf) onClick()
+            }
+        }
+
+        LaunchedEffect(check) {
+            thumbOffset = if (check) maxBound else minBound
+        }
         val trackColor by animateColorAsState(
             targetValue = lerp(colors.gray100, colors.main100, positionFraction),
             animationSpec = spring(),
@@ -76,9 +92,6 @@ internal fun FormToggleButton(
                 },
                 onDragEnd = {
                     isDragging = false
-                    val shouldToggle = thumbOffset > (maxBound / 2)
-                    onClick()
-                    thumbOffset = if (shouldToggle) maxBound else minBound
                 }
             )
         }

--- a/feature/form/src/main/java/com/school_of_company/form/view/component/FormToggleButton.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/component/FormToggleButton.kt
@@ -62,9 +62,9 @@ internal fun FormToggleButton(
         )
 
         val animatedOffset by animateFloatAsState(
-            targetValue = if (isDragging) thumbOffset else if (check) maxBound else minBound,
+            targetValue = thumbOffset,
             animationSpec = spring(),
-            label = "custom_switch"
+            label = "thumb_offset"
         )
 
         val dragModifier = Modifier.pointerInput(Unit) {

--- a/feature/form/src/main/java/com/school_of_company/form/view/component/FormToggleButton.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/component/FormToggleButton.kt
@@ -47,7 +47,7 @@ internal fun FormToggleButton(
         var thumbOffset by remember { mutableFloatStateOf(if (check) maxBound else minBound) }
         var isDragging by remember { mutableStateOf(false) }
 
-        val positionFraction = (thumbOffset - minBound) / (maxBound - minBound)
+        val positionFraction = thumbOffset / maxBound
 
         val trackColor by animateColorAsState(
             targetValue = lerp(colors.gray100, colors.main100, positionFraction),


### PR DESCRIPTION
## 💡 개요

 formToggleButton 의 드래그가 끝나면 무조건 드래그 시작점의 반대로 이동하는 버그를 수정했습니다

https://github.com/user-attachments/assets/3f71adcd-c4c2-460e-a74c-8b606fabf80a


## 📃 작업내용

- 수식정리

[positionFraction의 수식중 불필요한 부분 삭제](https://github.com/School-of-Company/Expo-Android/commit/f2342059e4cb3ca62b2227866d1a1d42174a5819)
[animatedOffset의 label을 custom_switch -> thumb_offset 으로 바꾸고 tar…](https://github.com/School-of-Company/Expo-Android/commit/44ee24792fd2dbd91c7c7e1d18c32e44ca1885c4)

- 로직변경

onClick을 트리거하는곳에 조건식 추가

[isDragging을 key 값으로 받는 LaunchedEffect로 onClick을 트리거 하도록 수정](https://github.com/School-of-Company/Expo-Android/commit/20fffd2208bb872c0a1f41f41d17c7380c587787)
[isOverHalf가 true가 아닐때 thumbOffset을 maxBound, minBound로 변경하도록 수정](https://github.com/School-of-Company/Expo-Android/commit/61903706c0dab4514edf64ba1b9f9b79eed5600f)

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타
