### PR TITLE
🔀 :: (#501) - 박람회 사전 및 현장 신청 관람객 정보 API에 변동 사항이 존재하여 이를 수정하였습니다.

### DIFF
--- a/core/data/src/main/java/com/school_of_company/data/repository/participant/ParticipantRepository.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/participant/ParticipantRepository.kt
@@ -4,5 +4,12 @@ import com.school_of_company.model.entity.participant.ParticipantInformationResp
 import kotlinx.coroutines.flow.Flow
 
 interface ParticipantRepository {
-    fun getParticipantInformationList(type: String, expoId: String, name: String? = null): Flow<List<ParticipantInformationResponseEntity>>
+    fun getParticipantInformationList(
+        type: String,
+        expoId: String,
+        name: String? = null,
+        page: Int? = null,
+        size: Int? = null,
+        localDate: String? = null
+    ): Flow<ParticipantInformationResponseEntity>
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/participant/ParticipantRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/participant/ParticipantRepositoryImpl.kt
@@ -13,14 +13,20 @@ class ParticipantRepositoryImpl @Inject constructor(
     override fun getParticipantInformationList(
         type: String,
         expoId: String,
-        name: String?
-    ): Flow<List<ParticipantInformationResponseEntity>> {
+        name: String?,
+        page: Int?,
+        size: Int?,
+        localDate: String?
+    ): Flow<ParticipantInformationResponseEntity> {
         return dataSource.getParticipantInformationList(
             type = type,
             expoId = expoId,
-            name = name
-        ).transform { list ->
-            emit(list.map { it.toEntity() })
+            name = name,
+            page = page,
+            size = size,
+            localDate = localDate
+        ).transform { response ->
+            emit(response.toEntity())
         }
     }
 }

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/participant/ParticipantInformationResponseUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/participant/ParticipantInformationResponseUseCase.kt
@@ -11,11 +11,17 @@ class ParticipantInformationResponseUseCase @Inject constructor(
     operator fun invoke(
         type: String,
         expoId: String,
-        name: String? = null
-    ): Flow<List<ParticipantInformationResponseEntity>> =
+        name: String? = null,
+        page: Int? = null,
+        size: Int? = null,
+        localDate: String? = null
+    ): Flow<ParticipantInformationResponseEntity> =
         repository.getParticipantInformationList(
             type = type,
             expoId = expoId,
-            name = name
+            name = name,
+            page = page,
+            size = size,
+            localDate = localDate
         )
 }

--- a/core/model/src/main/java/com/school_of_company/model/entity/participant/ParticipantInformationResponseEntity.kt
+++ b/core/model/src/main/java/com/school_of_company/model/entity/participant/ParticipantInformationResponseEntity.kt
@@ -1,8 +1,18 @@
 package com.school_of_company.model.entity.participant
 
 data class ParticipantInformationResponseEntity(
+    val info: PageInfoEntity,
+    val participant: List<ParticipantEntity>
+)
+
+data class PageInfoEntity(
+    val totalPage: Int,
+    val totalElement: Int
+)
+
+data class ParticipantEntity(
     val id: Long,
     val name: String,
     val phoneNumber: String,
-    val informationStatus: Boolean,
+    val informationStatus: Boolean
 )

--- a/core/network/src/main/java/com/school_of_company/network/api/ParticipantAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/ParticipantAPI.kt
@@ -11,6 +11,9 @@ interface ParticipantAPI {
     suspend fun getParticipantInformationList(
         @Path("expo_id") expoId: String,
         @Query("type") type: String,
-        @Query("name") name: String? = null
-    ): List<ParticipantInformationResponse>
+        @Query("name") name: String? = null,
+        @Query("page") page: Int? = null,
+        @Query("size") size: Int? = null,
+        @Query("LocalDate") localDate: String? = null
+    ): ParticipantInformationResponse
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/participant/ParticipantDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/participant/ParticipantDataSource.kt
@@ -4,5 +4,12 @@ import com.school_of_company.network.dto.participant.response.ParticipantInforma
 import kotlinx.coroutines.flow.Flow
 
 interface ParticipantDataSource {
-    fun getParticipantInformationList(type: String, expoId: String, name: String? = null): Flow<List<ParticipantInformationResponse>>
+    fun getParticipantInformationList(
+        type: String,
+        expoId: String,
+        name: String? = null,
+        page: Int? = null,
+        size: Int? = null,
+        localDate: String? = null
+    ): Flow<ParticipantInformationResponse>
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/participant/ParticipantDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/participant/ParticipantDataSourceImpl.kt
@@ -12,11 +12,17 @@ class ParticipantDataSourceImpl @Inject constructor(
     override fun getParticipantInformationList(
         type: String,
         expoId: String,
-        name: String?
-    ): Flow<List<ParticipantInformationResponse>> =
+        name: String?,
+        page: Int?,
+        size: Int?,
+        localDate: String?
+    ): Flow<ParticipantInformationResponse> =
         performApiRequest { service.getParticipantInformationList(
             type = type,
             expoId = expoId,
-            name = name
+            name = name,
+            page = page,
+            size = size,
+            localDate = localDate
         ) }
 }

--- a/core/network/src/main/java/com/school_of_company/network/dto/participant/response/ParticipantInformationResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/participant/response/ParticipantInformationResponse.kt
@@ -5,8 +5,20 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class ParticipantInformationResponse(
+    @Json(name = "info") val info: PageInfo,
+    @Json(name = "participant") val participant: List<ParticipantResponse>
+)
+
+@JsonClass(generateAdapter = true)
+data class PageInfo(
+    @Json(name = "totalPage") val totalPage: Int,
+    @Json(name = "totalElement") val totalElement: Int
+)
+
+@JsonClass(generateAdapter = true)
+data class ParticipantResponse(
     @Json(name = "id") val id: Long,
     @Json(name = "name") val name: String,
     @Json(name = "phoneNumber") val phoneNumber: String,
-    @Json(name = "informationStatus") val informationStatus: Boolean,
+    @Json(name = "informationStatus") val informationStatus: Boolean
 )

--- a/core/network/src/main/java/com/school_of_company/network/mapper/participant/response/ParticipantInformationResponseMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/participant/response/ParticipantInformationResponseMapper.kt
@@ -1,10 +1,26 @@
 package com.school_of_company.network.mapper.participant.response
 
+import com.school_of_company.model.entity.participant.PageInfoEntity
+import com.school_of_company.model.entity.participant.ParticipantEntity
 import com.school_of_company.model.entity.participant.ParticipantInformationResponseEntity
+import com.school_of_company.network.dto.participant.response.PageInfo
 import com.school_of_company.network.dto.participant.response.ParticipantInformationResponse
+import com.school_of_company.network.dto.participant.response.ParticipantResponse
 
 fun ParticipantInformationResponse.toEntity(): ParticipantInformationResponseEntity =
     ParticipantInformationResponseEntity(
+        info = this.info.toEntity(),
+        participant = this.participant.map { it.toEntity() }
+    )
+
+fun PageInfo.toEntity(): PageInfoEntity =
+    PageInfoEntity(
+        totalPage = this.totalPage,
+        totalElement = this.totalElement
+    )
+
+fun ParticipantResponse.toEntity(): ParticipantEntity =
+    ParticipantEntity(
         id = this.id,
         name = this.name,
         phoneNumber = this.phoneNumber,

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -58,7 +58,6 @@ import com.school_of_company.program.viewmodel.ProgramViewModel
 import com.school_of_company.program.viewmodel.uistate.ParticipantResponseListUiState
 import com.school_of_company.program.viewmodel.uistate.TraineeResponseListUiState
 import kotlinx.coroutines.delay
-import okhttp3.internal.toImmutableList
 
 @Composable
 internal fun ProgramDetailParticipantManagementRoute(
@@ -526,7 +525,7 @@ private fun ProgramDetailParticipantManagementScreen(
 
                                     ProgramTraineeList(
                                         scrollState = scrollState,
-                                        item = traineeInformationUiState.data.toImmutableList()
+                                        item = traineeInformationUiState.data
                                     )
                                 }
                             }

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -57,8 +57,8 @@ import com.school_of_company.program.view.component.ProgramTraineeTable
 import com.school_of_company.program.viewmodel.ProgramViewModel
 import com.school_of_company.program.viewmodel.uistate.ParticipantResponseListUiState
 import com.school_of_company.program.viewmodel.uistate.TraineeResponseListUiState
-import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.delay
+import okhttp3.internal.toImmutableList
 
 @Composable
 internal fun ProgramDetailParticipantManagementRoute(
@@ -298,7 +298,7 @@ private fun ProgramDetailParticipantManagementScreen(
 
                                 is ParticipantResponseListUiState.Success -> {
                                     Text(
-                                        text = "${participantAheadResponseListUiState.data.size}명",
+                                        text = "${participantAheadResponseListUiState.data.participant.size}명",
                                         style = typography.captionRegular2,
                                         color = colors.main
                                     )
@@ -334,7 +334,7 @@ private fun ProgramDetailParticipantManagementScreen(
 
                                 is ParticipantResponseListUiState.Success -> {
                                     Text(
-                                        text = "${participantFieldResponseListUiState.data.size}명",
+                                        text = "${participantFieldResponseListUiState.data}명",
                                         style = typography.captionRegular2,
                                         color = colors.main
                                     )
@@ -464,7 +464,7 @@ private fun ProgramDetailParticipantManagementScreen(
 
                                     ProgramDetailParticipantManagementList(
                                         scrollState = scrollState,
-                                        item = participantAheadResponseListUiState.data.toImmutableList()
+                                        item = participantAheadResponseListUiState.data
                                     )
                                 }
                             }
@@ -494,7 +494,7 @@ private fun ProgramDetailParticipantManagementScreen(
 
                                     ProgramDetailParticipantManagementList(
                                         scrollState = scrollState,
-                                        item = participantFieldResponseListUiState.data.toImmutableList()
+                                        item = participantFieldResponseListUiState.data
                                     )
                                 }
                             }

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementList.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementList.kt
@@ -13,13 +13,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.entity.participant.ParticipantInformationResponseEntity
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun ProgramDetailParticipantManagementList(
     modifier: Modifier = Modifier,
-    item: ImmutableList<ParticipantInformationResponseEntity> = persistentListOf(),
+    item: ParticipantInformationResponseEntity,
     scrollState: ScrollState
 ) {
     ExpoAndroidTheme { colors, _ ->
@@ -30,7 +29,7 @@ internal fun ProgramDetailParticipantManagementList(
                 .background(color = colors.white)
                 .padding(start = 16.dp)
         ) {
-            itemsIndexed(item) { index, item ->
+            itemsIndexed(item.participant) { index, item ->
                 ProgramDetailParticipantManagementListItem(
                     index = index + 1,
                     data = item,
@@ -39,13 +38,4 @@ internal fun ProgramDetailParticipantManagementList(
             }
         }
     }
-}
-
-@Preview
-@Composable
-private fun HomeDetailParticipantManagementListPreview() {
-    ProgramDetailParticipantManagementList(
-        item = persistentListOf(),
-        scrollState = rememberScrollState()
-    )
 }

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementListItem.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementListItem.kt
@@ -21,13 +21,14 @@ import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.icon.CircleIcon
 import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.model.entity.participant.ParticipantEntity
 import com.school_of_company.model.entity.participant.ParticipantInformationResponseEntity
 
 @Composable
 internal fun ProgramDetailParticipantManagementListItem(
     modifier: Modifier = Modifier,
     index: Int,
-    data: ParticipantInformationResponseEntity,
+    data: ParticipantEntity,
     horizontalScrollState: ScrollState,
 ) {
     Spacer(modifier = Modifier.height(20.dp))
@@ -89,7 +90,7 @@ internal fun ProgramDetailParticipantManagementListItem(
 private fun HomeDetailParticipantManagementListItemPreview() {
     ProgramDetailParticipantManagementListItem(
         index = 1,
-        data = ParticipantInformationResponseEntity(
+        data = ParticipantEntity(
             name = "이명훈",
             id = 0,
             phoneNumber = "01038251716",

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeList.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramTraineeList.kt
@@ -11,13 +11,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.entity.trainee.TraineeResponseEntity
-import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun ProgramTraineeList(
     modifier: Modifier = Modifier,
-    item: ImmutableList<TraineeResponseEntity> = persistentListOf(),
+    item: List<TraineeResponseEntity> = persistentListOf(),
     scrollState: ScrollState,
 ) {
     ExpoAndroidTheme { colors, _ ->

--- a/feature/program/src/main/java/com/school_of_company/program/viewmodel/ProgramViewModel.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/viewmodel/ProgramViewModel.kt
@@ -241,7 +241,7 @@ internal class ProgramViewModel @Inject constructor(
                 when (result) {
                     is Result.Loading -> enumData.value = ParticipantResponseListUiState.Loading
                     is Result.Success -> {
-                        if (result.data.isEmpty()) {
+                        if (result.data.participant.isEmpty()) {
                             _swipeRefreshLoading.value = false
                             enumData.value = ParticipantResponseListUiState.Empty
                         } else {

--- a/feature/program/src/main/java/com/school_of_company/program/viewmodel/uistate/ParticipantResponseListUiState.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/viewmodel/uistate/ParticipantResponseListUiState.kt
@@ -5,6 +5,6 @@ import com.school_of_company.model.entity.participant.ParticipantInformationResp
 sealed interface ParticipantResponseListUiState {
     object Loading : ParticipantResponseListUiState
     object Empty : ParticipantResponseListUiState
-    data class Success(val data: List<ParticipantInformationResponseEntity>) : ParticipantResponseListUiState
+    data class Success(val data: ParticipantInformationResponseEntity) : ParticipantResponseListUiState
     data class Error(val exception: Throwable) : ParticipantResponseListUiState
 }


### PR DESCRIPTION
## 💡 개요
- 박람회 사전 및 현장 신청 관람객 정보 API에 변동 사항이 생겨 이를 수정해야했습니다.
## 📃 작업내용
- 박람회 사전 및 현장 신청 관람객 정보 API에 변동 사항이 존재하여 이를 수정하였습니다.
## 🔀 변경사항
<img width="594" alt="스크린샷 2025-03-27 오후 9 04 15" src="https://github.com/user-attachments/assets/775df007-bd2a-441a-873f-67a989c8db2f" />

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- 사전, 현장 참가자 부분은 아직 API 명세서만 나와서 제대로 동작 안하고, 교원연수만 잘 동작합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 참가자 정보 조회에 페이징 및 로컬 날짜 필터링 옵션이 추가되어, 원하는 데이터를 보다 정밀하게 검색할 수 있습니다.
- **UI 개선**
  - 참가자 관리 화면에서 참여자 수 집계 및 정보 표시 방식이 개선되어, 보다 명확하고 간결한 데이터 확인이 가능합니다.
- **데이터 처리 개선**
  - 정보 응답 구조가 단일 엔티티 형식으로 업데이트되어 사용자 경험과 정보 제공이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->