### PR TITLE
🔀 :: (#505) - 로딩중일때 LoadingDot가 띄워지도록 하였습니다.(로딩 애니메이션 추가)

### DIFF
--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/loading/LoadingDot.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/loading/LoadingDot.kt
@@ -1,0 +1,98 @@
+package com.school_of_company.design_system.component.loading
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.keyframes
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoTypography
+import com.school_of_company.design_system.theme.color.ExpoColor
+
+@Composable
+fun LoadingDot(modifier: Modifier = Modifier) {
+
+    val dotScale1 by animateScaleWithDelay(0)
+    val dotScale2 by animateScaleWithDelay(300)
+    val dotScale3 by animateScaleWithDelay(600)
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Center,
+            modifier = modifier.padding(top = 16.dp)
+        ) {
+            Dot(dotScale1)
+            Spacer(Modifier.width(10.dp))
+            Dot(dotScale2)
+            Spacer(Modifier.width(10.dp))
+            Dot(dotScale3)
+        }
+
+        Spacer(modifier = Modifier.padding(bottom = 4.5.dp))
+
+        Text(
+            text = "로딩중..",
+            style = ExpoTypography.bodyBold1,
+            color = ExpoColor.main
+        )
+    }
+}
+
+@Composable
+private fun Dot(scale: Float) = Spacer(
+    Modifier
+        .size(16.dp)
+        .scale(scale)
+        .background(
+            color = ExpoColor.main,
+            shape = CircleShape
+        )
+)
+
+@Composable
+private fun animateScaleWithDelay(delay: Int) = rememberInfiniteTransition().animateFloat(
+    initialValue = 1f,
+    targetValue = 1f,
+    animationSpec = infiniteRepeatable(
+        animation = keyframes {
+            durationMillis = 1100
+            1f at delay with LinearEasing
+            0f at delay + 275 with LinearEasing
+            1f at delay + 550 with LinearEasing
+        }
+    )
+)
+
+@Preview
+@Composable
+private fun PreviewLoadingDots() {
+    Column(
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = Color.White)
+    ) {
+        LoadingDot()
+    }
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -60,6 +59,7 @@ import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.bottomsheet.SettingBottomSheet
 import com.school_of_company.design_system.component.button.ExpoStateButton
 import com.school_of_company.design_system.component.button.state.ButtonState
+import com.school_of_company.design_system.component.loading.LoadingDot
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
 import com.school_of_company.design_system.component.textfield.ExpoLocationIconTextField
@@ -68,6 +68,7 @@ import com.school_of_company.design_system.component.textfield.NoneLimitedLength
 import com.school_of_company.design_system.icon.ImageIcon
 import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.design_system.theme.color.ExpoColor
 import com.school_of_company.expo.view.component.ExpoAddTextField
 import com.school_of_company.expo.view.component.ExpoSettingBottomSheet
 import com.school_of_company.expo.view.component.ExpoStandardAddTextField
@@ -158,19 +159,26 @@ internal fun ExpoCreateRoute(
     }
 
     LaunchedEffect(registerExpoInformationUiState) {
-        when (registerExpoInformationUiState) {
-            is RegisterExpoInformationUiState.Loading -> Unit
-            is RegisterExpoInformationUiState.Success -> {
-                viewModel.resetExpoInformation()
-                selectedImageUri = null
-                selectedImageUriString = null
-                makeToast(context, "박람회 등록을 완료하였습니다.")
-                viewModel.initRegisterExpo()
-            }
+        if (registerExpoInformationUiState is RegisterExpoInformationUiState.Success) {
+            viewModel.resetExpoInformation()
+            selectedImageUri = null
+            selectedImageUriString = null
+            makeToast(context, "박람회 등록을 완료하였습니다.")
+            viewModel.initRegisterExpo()
+        } else if (registerExpoInformationUiState is RegisterExpoInformationUiState.Error) {
+            onErrorToast(null, R.string.expo_register_fail)
+        }
+    }
 
-            is RegisterExpoInformationUiState.Error -> {
-                onErrorToast(null, R.string.expo_register_fail)
-            }
+    if (registerExpoInformationUiState is RegisterExpoInformationUiState.Loading) {
+        Column(
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = ExpoColor.main)
+        ) {
+            LoadingDot()
         }
     }
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -44,6 +44,7 @@ import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.button.EffectButton
 import com.school_of_company.design_system.component.button.ExpoEnableButton
 import com.school_of_company.design_system.component.button.ExpoEnableDetailButton
+import com.school_of_company.design_system.component.loading.LoadingDot
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
 import com.school_of_company.design_system.icon.LeftArrowIcon
@@ -502,7 +503,17 @@ private fun ExpoDetailScreen(
                 }
             }
 
-            getExpoInformationUiState is GetExpoInformationUiState.Loading || getTrainingProgramUiState is GetTrainingProgramListUiState.Loading || getStandardProgramUiState is GetStandardProgramListUiState.Loading -> Unit
+            getExpoInformationUiState is GetExpoInformationUiState.Loading || getTrainingProgramUiState is GetTrainingProgramListUiState.Loading || getStandardProgramUiState is GetStandardProgramListUiState.Loading -> {
+                Column(
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(color = colors.white)
+                ) {
+                    LoadingDot()
+                }
+            }
 
             getExpoInformationUiState is GetExpoInformationUiState.Error || getTrainingProgramUiState is GetTrainingProgramListUiState.Error || getStandardProgramUiState is GetStandardProgramListUiState.Error -> {
 


### PR DESCRIPTION
## 💡 개요
- 박람회 자세히 보기 등의 화면에서 로딩 시간이 길어지는 경우 따로 처리한 로직이 없어 하얀 바탕화면만 띄워져 부자연스러웠습니다.
## 📃 작업내용
- 위 개요에서 설명한 상황을 해결하기 위해 로딩중일때 나오는 애니메이샨을 추가하여 로딩중 상태일때 띄워주었습니다.

     https://github.com/user-attachments/assets/d367e63d-979a-4d3e-aa19-02dda6cf6444

## 🔀 변경사항
- add LoadingDot
- chore ExpoDetailScreen
- chore ExpoCreateScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 로딩 상태를 시각적으로 안내하는 애니메이션 표시기를 추가하여, 진행 상황을 명확하게 전달합니다.
	- Expo 등록 및 상세 화면에서 로딩 상태 시각적 피드백을 제공해 사용자 인터페이스가 개선되었습니다.
- **리팩토링**
	- Expo 관련 화면의 상태 처리 로직을 간소화하여 보다 직관적인 사용자 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->