### PR TITLE
🔀 :: (#513) - expoChartScreen의 막대그래프를 퍼블리싱했습니다

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoChartScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoChartScreen.kt
@@ -119,7 +119,7 @@ private fun ExpoChartScreen(
 
             DetailsPieChart(data = data)
 
-            Spacer(Modifier.height(35.dp))
+            Spacer(modifier = Modifier.padding(bottom = 35.dp))
 
             if (isPieChartSelected) {
                 ParticipantPieChart(data = data)

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoChartScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoChartScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,8 +23,10 @@ import com.school_of_company.design_system.icon.LeftArrowIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.expo.view.component.DetailsPieChart
 import com.school_of_company.expo.view.component.ExpoChartGroupButton
+import com.school_of_company.expo.view.component.ParticipantBarGraph
 import com.school_of_company.expo.view.component.ParticipantPieChart
 import com.school_of_company.expo.view.component.SchoolCategory
+import com.school_of_company.expo.view.component.SchoolCategoryItem
 import com.school_of_company.expo.view.component.SchoolData
 
 @Composable
@@ -116,15 +119,20 @@ private fun ExpoChartScreen(
 
             DetailsPieChart(data = data)
 
-            Spacer(modifier = Modifier.padding(bottom = 81.dp))
+            Spacer(Modifier.height(35.dp))
 
             if (isPieChartSelected) {
                 ParticipantPieChart(data = data)
             } else {
-                Text(
-                    text = "막대 그래프",
-                    style = typography.bodyRegular2,
-                    color = colors.gray500
+                val list = listOf(
+                    SchoolCategoryItem(number = 10f, percent = 10f),
+                    SchoolCategoryItem(number = 20f, percent = 20f),
+                    SchoolCategoryItem(number = 20f, percent = 20f),
+                    SchoolCategoryItem(number = 30f, percent = 30f),
+                    SchoolCategoryItem(number = 20f, percent = 20f),
+                )
+                ParticipantBarGraph(
+                    schoolCategoryList = list.map { Pair("이름입니다", it) }
                 )
             }
         }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ParticipantBarGraph.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ParticipantBarGraph.kt
@@ -1,0 +1,177 @@
+package com.school_of_company.expo.view.component
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+internal fun ParticipantBarGraph(
+    modifier: Modifier = Modifier,
+    schoolCategoryList: List<Pair<String, SchoolCategoryItem>>,
+) {
+    ExpoAndroidTheme { colors, typography ->
+
+        var trigger by remember { mutableStateOf(false) }
+
+        LaunchedEffect(Unit) {
+            trigger = true
+        }
+
+        val animateFloat by animateFloatAsState(
+            targetValue = if (trigger) 100f else 0f,
+            animationSpec = tween(durationMillis = 600)
+        )
+        val chartColors = listOf(
+            colors.main,
+            colors.main400,
+            colors.main500,
+            colors.main200,
+            colors.main100
+        )
+        val scrollState = rememberScrollState()
+
+        Column(modifier = modifier.verticalScroll(scrollState)) {
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Column(
+                    modifier = Modifier
+                        .padding(vertical = 25.dp)
+                        .height(IntrinsicSize.Max),
+                    verticalArrangement = Arrangement.spacedBy(49.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    schoolCategoryList
+                        .map { it.first }
+                        .forEach { schoolCategoryName ->
+                            Text(
+                                text = schoolCategoryName,
+                                style = typography.captionRegular2,
+                                color = colors.black,
+                                textAlign = TextAlign.Center,
+                            )
+                        }
+                }
+                Spacer(Modifier.width(8.dp))
+                Column {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .border(
+                                width = 1.dp,
+                                color = colors.gray300,
+                                shape = RoundedCornerShape(size = 6.dp)
+                            )
+                            .height(IntrinsicSize.Max)
+                            .padding(vertical = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(30.dp),
+                    ) {
+                        schoolCategoryList
+                            .map { it.second.percent }
+                            .forEachIndexed { index, percent ->
+                                Spacer(
+                                    Modifier
+                                        .fillMaxWidth((percent / 100f) * (animateFloat / 100f))
+                                        .height(32.dp)
+                                        .background(
+                                            color = chartColors[index],
+                                            shape = RoundedCornerShape(
+                                                topStart = 0.dp,
+                                                topEnd = 6.dp,
+                                                bottomStart = 0.dp,
+                                                bottomEnd = 6.dp
+                                            )
+                                        )
+                                )
+                            }
+                    }
+                    Spacer(Modifier.height(10.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text(
+                            text = "0%",
+                            style = typography.captionRegular2,
+                            color = colors.black,
+                            textAlign = TextAlign.Center,
+                        )
+                        Text(
+                            text = "25%",
+                            style = typography.captionRegular2,
+                            color = colors.black,
+                            textAlign = TextAlign.Center,
+                        )
+                        Text(
+                            text = "50%",
+                            style = typography.captionRegular2,
+                            color = colors.black,
+                            textAlign = TextAlign.Center,
+                        )
+                        Text(
+                            text = "75%",
+                            style = typography.captionRegular2,
+                            color = colors.black,
+                            textAlign = TextAlign.Center,
+                        )
+                        Text(
+                            text = "100%",
+                            style = typography.captionRegular2,
+                            color = colors.black,
+                            textAlign = TextAlign.Center,
+                        )
+
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+@Preview
+@Composable
+private fun ParticipantBarGraphPreview() {
+    Box(
+        Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        ParticipantBarGraph(
+            schoolCategoryList = listOf(
+                "Category 1" to SchoolCategoryItem(10f, 10f),
+                "Category 2" to SchoolCategoryItem(20f, 20f),
+                "Category 2" to SchoolCategoryItem(20f, 20f),
+                "Category 2" to SchoolCategoryItem(20f, 20f),
+                "Category 3" to SchoolCategoryItem(50f, 50f)
+            )
+        )
+    }
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ParticipantBarGraph.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ParticipantBarGraph.kt
@@ -32,6 +32,13 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 
+internal data class SchoolCategoryItem(
+    val number: Float,
+    val percent: Float,
+)
+
+// TODO: model과 통합
+
 @Composable
 internal fun ParticipantBarGraph(
     modifier: Modifier = Modifier,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ParticipantPieChart.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ParticipantPieChart.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -87,27 +88,25 @@ internal fun ParticipantPieChart(
             animationPlayed = true
         }
 
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.fillMaxWidth()
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+            contentAlignment = Alignment.Center,
         ) {
-
-            Box(modifier = Modifier.size(animateSize.dp)) {
-                Canvas(
-                    modifier = Modifier
-                        .size(radiusOuter * 2f)
-                        .rotate(animateRotation)
-                ) {
-                    floatValues.forEachIndexed { index, value ->
-                        drawArc(
-                            color = chartColors[index % chartColors.size],
-                            startAngle = lastValue,
-                            sweepAngle = value,
-                            useCenter = false,
-                            style = Stroke(chartBarWidth.toPx(), cap = StrokeCap.Butt)
-                        )
-                        lastValue += value
-                    }
+            Canvas(
+                modifier = Modifier
+                    .size(animateSize.dp)
+                    .rotate(animateRotation)
+            ) {
+                floatValues.forEachIndexed { index, value ->
+                    drawArc(
+                        color = chartColors[index % chartColors.size],
+                        startAngle = lastValue,
+                        sweepAngle = value,
+                        useCenter = false,
+                        style = Stroke(chartBarWidth.toPx(), cap = StrokeCap.Butt)
+                    )
+                    lastValue += value
                 }
             }
         }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ParticipantPieChart.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ParticipantPieChart.kt
@@ -91,6 +91,7 @@ internal fun ParticipantPieChart(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
+                .offset(y = 30.dp),
             contentAlignment = Alignment.Center,
         ) {
             Canvas(


### PR DESCRIPTION
## 💡 개요

[Screen_recording_20250407_151624.webm](https://github.com/user-attachments/assets/b551f646-cba2-4802-bbbe-8446105b3cb4)

## 📃 작업내용

expoChartScreen의 막대그래프를 퍼블리싱했습니다

## 🔀 변경사항

ParticipantPieChart의 불필요한 컴포넌트 Column 을 삭제하고 offset y = 30.dp 을 적용시켰습니다
ParticipantBarGraph를 퍼블리싱했습니다

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
x
## 🎸 기타
x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 애니메이션 효과를 적용한 막대 그래프가 추가되어, 카테고리별 데이터를 부드럽게 시각화합니다.
  - 막대 그래프 옵션 선택 시, 실제 데이터를 기반으로 한 시각적 차트가 제공됩니다.
  
- **리팩토링**
  - 파이 차트의 레이아웃이 간소화되고 위치가 조정되어, 전체 UI 정렬이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->