### PR TITLE
🔀 :: (#522) - expo의 주소 관련 기능들이 정상 작동 하도록 수정했습니다

### DIFF
--- a/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/kakao/KakaoRepositoryImpl.kt
@@ -23,6 +23,6 @@ class KakaoRepositoryImpl @Inject constructor(
         return kakaoLocalDataSource.getAddress(
             x = x,
             y = y,
-        ).transform { response -> (response.toModel()) }
+        ).transform { response -> emit(response.toModel()) }
     }
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoAddressSearchScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoAddressSearchScreen.kt
@@ -57,7 +57,7 @@ internal fun ExpoAddressSearchRoute(
     val getCoordinatesUiState by viewModel.getCoordinatesUiState.collectAsStateWithLifecycle()
 
     val addressList by viewModel.addressList.collectAsStateWithLifecycle()
-    val location by viewModel.searched_location.collectAsStateWithLifecycle()
+    val location by viewModel.address.collectAsStateWithLifecycle()
     val coordinateX by viewModel.searched_coordinateX.collectAsStateWithLifecycle()
     val coordinateY by viewModel.searched_coordinateY.collectAsStateWithLifecycle()
 
@@ -65,10 +65,6 @@ internal fun ExpoAddressSearchRoute(
         onDispose {
             viewModel.initSearchedUiState()
         }
-    }
-
-    LaunchedEffect(Unit) {
-        viewModel.initSearchedData()
     }
 
     LaunchedEffect(getCoordinatesUiState) {
@@ -105,10 +101,10 @@ internal fun ExpoAddressSearchRoute(
         addressList = addressList,
         popUpBackStack = popUpBackStack,
         onLocationSearch = { viewModel.searchLocation(location) },
-        onLocationChange = viewModel::onSearchedLocationChange,
+        onLocationChange = viewModel::onAddressChange,
         onAddressItemClick = { item ->
             viewModel.convertJibunToXY(item)
-            viewModel.onSearchedLocationChange(item)
+            viewModel.onAddressChange(item)
         },
     )
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoAddressSearchScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoAddressSearchScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,6 +20,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusManager
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
@@ -201,6 +203,7 @@ private fun ExpoAddressSearchScreen(
                     HomeKakaoMap(
                         locationX = coordinateX.toDouble(),
                         locationY = coordinateY.toDouble(),
+                        modifier = Modifier.clip(RoundedCornerShape(8.dp)),
                     )
                 }
             }
@@ -219,8 +222,7 @@ private fun ExpoAddressSearchScreen(
                     ButtonState.Disable
                 },
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(14.dp),
+                    .fillMaxWidth(),
                 onClick = popUpBackStack
             )
         }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -160,7 +160,7 @@ internal fun ExpoCreateRoute(
 
     LaunchedEffect(registerExpoInformationUiState) {
         if (registerExpoInformationUiState is RegisterExpoInformationUiState.Success) {
-            viewModel.resetOnCreateExpoInformation()
+            viewModel.resetExpoInformation()
             selectedImageUri = null
             selectedImageUriString = null
             makeToast(context, "박람회 등록을 완료하였습니다.")

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -197,7 +197,7 @@ internal fun ExpoCreateRoute(
         onStartedDateChange = viewModel::onStartedDateChange,
         onEndedDateChange = viewModel::onEndedDateChange,
         onIntroduceTitleChange = viewModel::onIntroduceTitleChange,
-        onAddressChange = viewModel::onAddressChange,
+        onLocationChange = viewModel::onLocationChange,
         onExpoCreateCallBack = {
             if (selectedImageUri != null) {
                 viewModel.imageUpLoad(context, selectedImageUri!!)
@@ -241,7 +241,7 @@ private fun ExpoCreateScreen(
     onEndedDateChange: (String) -> Unit,
     onModifyTitleChange: (String) -> Unit,
     onIntroduceTitleChange: (String) -> Unit,
-    onAddressChange: (String) -> Unit,
+    onLocationChange: (String) -> Unit,
     onRemoveTrainingProgram: (Int) -> Unit,
     onRemoveStandardProgram: (Int) -> Unit,
     onTrainingProgramChange: (Int, TrainingProRequestParam) -> Unit,
@@ -520,14 +520,14 @@ private fun ExpoCreateScreen(
                             placeholder = "위치를 알려주세요.",
                             isDisabled = true,
                             onButtonClicked = navigateToExpoAddressSearch,
-                            value = locationState,
+                            value = addressState,
                             onValueChange = { _ -> },
                         )
 
                         NoneLimitedLengthTextField(
-                            value = addressState,
+                            value = locationState,
                             placeholder = "상세주소를 입력해주세요.",
-                            updateTextValue = onAddressChange
+                            updateTextValue = onLocationChange
                         )
                     }
 
@@ -633,7 +633,7 @@ private fun ExpoCreateScreenPreview() {
         onEndedDateChange = {},
         onModifyTitleChange = {},
         onIntroduceTitleChange = {},
-        onAddressChange = {},
+        onLocationChange = {},
         onRemoveTrainingProgram = {},
         onRemoveStandardProgram = {},
         navigateToExpoAddressSearch = {},

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -123,7 +123,7 @@ internal fun ExpoCreateRoute(
         }
 
     LaunchedEffect(Unit) {
-        viewModel.initializeWithSearchedData()
+        viewModel.setCurrentScreen(ExpoViewModel.CurrentScreen.CREATE)
     }
 
     DisposableEffect(Unit) {
@@ -512,12 +512,12 @@ private fun ExpoCreateScreen(
                         Text(
                             text = "장소",
                             style = typography.bodyRegular2,
-                            color = colors.gray600,
+                            color = colors.black,
                             fontWeight = FontWeight.W600,
                         )
 
                         ExpoLocationIconTextField(
-                            placeholder = "위치를 알려주세요.",
+                            placeholder = "장소를 선택해주세요.",
                             isDisabled = true,
                             onButtonClicked = navigateToExpoAddressSearch,
                             value = addressState,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -160,7 +160,7 @@ internal fun ExpoCreateRoute(
 
     LaunchedEffect(registerExpoInformationUiState) {
         if (registerExpoInformationUiState is RegisterExpoInformationUiState.Success) {
-            viewModel.resetExpoInformation()
+            viewModel.resetOnCreateExpoInformation()
             selectedImageUri = null
             selectedImageUriString = null
             makeToast(context, "박람회 등록을 완료하였습니다.")

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -120,6 +121,10 @@ internal fun ExpoModifyRoute(
             }
         }
 
+    LaunchedEffect(Unit) {
+        viewModel.setCurrentScreen(ExpoViewModel.CurrentScreen.MODIFY)
+    }
+
     LaunchedEffect(id) {
         viewModel.getExpoInformation(id)
         viewModel.getStandardProgramList(id)
@@ -128,7 +133,6 @@ internal fun ExpoModifyRoute(
 
     DisposableEffect(Unit) {
         onDispose {
-            viewModel.resetExpoInformation()
             viewModel.initModifyExpo()
         }
     }
@@ -198,6 +202,7 @@ internal fun ExpoModifyRoute(
         navigateToExpoAddressSearch = navigateToExpoAddressSearch,
         onAddStandardProgram = viewModel::addStandardProgramModifyText,
         onAddTrainingProgram = viewModel::addTrainingProgramModifyText,
+        clearExpoInformation = viewModel::resetExpoInformation,
         onStartedDateChange = viewModel::onStartedDateChange,
         onEndedDateChange = viewModel::onEndedDateChange,
         onModifyTitleChange = viewModel::onModifyTitleChange,
@@ -233,6 +238,7 @@ private fun ExpoModifyScreen(
     navigateToExpoAddressSearch: () -> Unit,
     onAddStandardProgram: () -> Unit,
     onAddTrainingProgram: () -> Unit,
+    clearExpoInformation: () -> Unit,
     onStartedDateChange: (String) -> Unit,
     onEndedDateChange: (String) -> Unit,
     onModifyTitleChange: (String) -> Unit,
@@ -283,7 +289,10 @@ private fun ExpoModifyScreen(
                 startIcon = {
                     LeftArrowIcon(
                         tint = colors.black,
-                        modifier = Modifier.expoClickable { onBackClick() }
+                        modifier = Modifier.expoClickable {
+                            onBackClick()
+                            clearExpoInformation()
+                        }
                     )
                 },
                 betweenText = "박람회 수정하기"
@@ -531,11 +540,17 @@ private fun ExpoModifyScreen(
                     Spacer(modifier = Modifier.padding(top = 28.dp))
 
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top)) {
+                        Text(
+                            text = "장소",
+                            style = typography.bodyRegular2,
+                            color = colors.black,
+                            fontWeight = FontWeight.W600,
+                        )
 
                         ExpoLocationIconTextField(
                             value = addressState,
                             onValueChange = { _ -> },
-                            placeholder = "장소를 입력해주세요.",
+                            placeholder = "장소를 선택해주세요.",
                             isDisabled = true,
                             onButtonClicked = navigateToExpoAddressSearch,
                         )
@@ -642,6 +657,7 @@ private fun HomeDetailModifyScreenPreview() {
         locationState = "",
         onModifyTitleChange = {},
         onLocationChange = {},
+        clearExpoInformation = {},
         onStartedDateChange = {},
         onEndedDateChange = {},
         onIntroduceTitleChange = {},

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -108,7 +108,8 @@ internal fun ExpoModifyRoute(
 
     val context = LocalContext.current
 
-    val galleryLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+    val galleryLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
             if (uri != null) {
                 val options = BitmapFactory.Options().apply { inJustDecodeBounds = true }
                 context.contentResolver.openInputStream(uri)?.use { inputStream ->
@@ -168,6 +169,7 @@ internal fun ExpoModifyRoute(
                 viewModel.initModifyExpo()
                 makeToast(context, "박람회 수정을 완료하였습니다.")
             }
+
             is ModifyExpoInformationUiState.Error -> {
                 onErrorToast(null, R.string.expo_modify_fail)
             }
@@ -199,7 +201,6 @@ internal fun ExpoModifyRoute(
         onStartedDateChange = viewModel::onStartedDateChange,
         onEndedDateChange = viewModel::onEndedDateChange,
         onModifyTitleChange = viewModel::onModifyTitleChange,
-        onAddressChange = viewModel::onAddressChange,
         onLocationChange = viewModel::onLocationChange,
         onIntroduceTitleChange = viewModel::onIntroduceTitleChange,
         onRemoveTrainingProgram = viewModel::removeTrainingProgramModifyText,
@@ -235,7 +236,6 @@ private fun ExpoModifyScreen(
     onStartedDateChange: (String) -> Unit,
     onEndedDateChange: (String) -> Unit,
     onModifyTitleChange: (String) -> Unit,
-    onAddressChange: (String) -> Unit,
     onLocationChange: (String) -> Unit,
     onIntroduceTitleChange: (String) -> Unit,
     onRemoveTrainingProgram: (Int) -> Unit,
@@ -533,17 +533,17 @@ private fun ExpoModifyScreen(
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top)) {
 
                         ExpoLocationIconTextField(
+                            value = addressState,
+                            onValueChange = { _ -> },
                             placeholder = "장소를 입력해주세요.",
                             isDisabled = true,
-                            onValueChange = onLocationChange,
                             onButtonClicked = navigateToExpoAddressSearch,
-                            value = locationState,
                         )
 
                         NoneLimitedLengthTextField(
-                            value = addressState,
-                            placeholder = "상세주소를 입력해주세요.",
-                            updateTextValue = onAddressChange
+                            value = locationState,
+                            updateTextValue = onLocationChange,
+                            placeholder = "상세주소를 입력해주세요."
                         )
                     }
 
@@ -642,7 +642,6 @@ private fun HomeDetailModifyScreenPreview() {
         locationState = "",
         onModifyTitleChange = {},
         onLocationChange = {},
-        onAddressChange = {},
         onStartedDateChange = {},
         onEndedDateChange = {},
         onIntroduceTitleChange = {},

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -146,8 +146,8 @@ internal fun ExpoModifyRoute(
                         description = viewModel.introduce_title.value,
                         location = viewModel.location.value,
                         coverImage = (imageUpLoadUiState as ImageUpLoadUiState.Success).data.imageURL,
-                        x = "37.511734",
-                        y = "127.05905",
+                        x = viewModel.coordinateX.value,
+                        y = viewModel.coordinateY.value,
                         updateStandardProRequestDto = standardProgramTextState,
                         updateTrainingProRequestDto = trainingProgramTextState
                     )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -128,7 +128,7 @@ internal fun ExpoModifyRoute(
 
     DisposableEffect(Unit) {
         onDispose {
-            viewModel.resetOnModifyExpoInformation()
+            viewModel.resetExpoInformation()
             viewModel.initModifyExpo()
         }
     }
@@ -165,7 +165,7 @@ internal fun ExpoModifyRoute(
             is ModifyExpoInformationUiState.Loading -> Unit
             is ModifyExpoInformationUiState.Success -> {
                 onBackClick()
-                viewModel.resetOnModifyExpoInformation()
+                viewModel.resetExpoInformation()
                 viewModel.initModifyExpo()
                 makeToast(context, "박람회 수정을 완료하였습니다.")
             }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -128,7 +128,7 @@ internal fun ExpoModifyRoute(
 
     DisposableEffect(Unit) {
         onDispose {
-            viewModel.resetExpoInformation()
+            viewModel.resetOnModifyExpoInformation()
             viewModel.initModifyExpo()
         }
     }
@@ -165,7 +165,7 @@ internal fun ExpoModifyRoute(
             is ModifyExpoInformationUiState.Loading -> Unit
             is ModifyExpoInformationUiState.Success -> {
                 onBackClick()
-                viewModel.resetExpoInformation()
+                viewModel.resetOnModifyExpoInformation()
                 viewModel.initModifyExpo()
                 makeToast(context, "박람회 수정을 완료하였습니다.")
             }

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -287,6 +287,7 @@ internal class ExpoViewModel @Inject constructor(
         onIntroduceTitleChange("")
         onStartedDateChange("")
         onEndedDateChange("")
+        onLocationChange("")
         onCoverImageChange(null)
         onModifyTitleChange("")
         onStartedChange("")

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -442,7 +442,6 @@ internal class ExpoViewModel @Inject constructor(
                         is Result.Success -> {
                             if (result.data.isNotEmpty()) {
                                 _getAddressUiState.value = GetAddressUiState.Success(result.data)
-                                onAddressChange(result.data.first().roadAddr)
                             } else {
                                 _getAddressUiState.value = GetAddressUiState.Error(
                                     NoResponseException()

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -287,6 +287,8 @@ internal class ExpoViewModel @Inject constructor(
         onIntroduceTitleChange("")
         onStartedDateChange("")
         onEndedDateChange("")
+        onLocationChange("")
+        onAddressChange("")
         onCoverImageChange(null)
         onModifyTitleChange("")
         onStartedChange("")

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -485,6 +485,7 @@ internal class ExpoViewModel @Inject constructor(
                         _getCoordinatesToAddressUiState.value = GetCoordinatesToAddressUiState.Error(NoResponseException())
                     } else {
                         _getCoordinatesToAddressUiState.value = GetCoordinatesToAddressUiState.Success(result.data)
+                        onAddressChange(result.data.addressName)
                     }
                     is Result.Error -> _getCoordinatesToAddressUiState.value = GetCoordinatesToAddressUiState.Error(result.exception)
                 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -88,63 +88,49 @@ internal class ExpoViewModel @Inject constructor(
     private val _swipeRefreshLoading = MutableStateFlow(false)
     val swipeRefreshLoading = _swipeRefreshLoading.asStateFlow()
 
-    private val _trainingProgramTextState =
-        MutableStateFlow<List<TrainingProRequestParam>>(emptyList())
+    private val _trainingProgramTextState = MutableStateFlow<List<TrainingProRequestParam>>(emptyList())
     internal val trainingProgramTextState = _trainingProgramTextState.asStateFlow()
 
-    private val _standardProgramTextState =
-        MutableStateFlow<List<StandardProRequestParam>>(emptyList())
+    private val _standardProgramTextState = MutableStateFlow<List<StandardProRequestParam>>(emptyList())
     internal val standardProgramTextState = _standardProgramTextState.asStateFlow()
 
-    private val _trainingProgramModifyTextState =
-        MutableStateFlow<List<TrainingProIdRequestParam>>(emptyList())
+    private val _trainingProgramModifyTextState = MutableStateFlow<List<TrainingProIdRequestParam>>(emptyList())
     internal val trainingProgramModifyTextState = _trainingProgramModifyTextState.asStateFlow()
 
-    private val _standardProgramModifyTextState =
-        MutableStateFlow<List<StandardProIdRequestParam>>(emptyList())
+    private val _standardProgramModifyTextState = MutableStateFlow<List<StandardProIdRequestParam>>(emptyList())
     internal val standardProgramModifyTextState = _standardProgramModifyTextState.asStateFlow()
 
-    private val _getExpoInformationUiState =
-        MutableStateFlow<GetExpoInformationUiState>(GetExpoInformationUiState.Loading)
+    private val _getExpoInformationUiState = MutableStateFlow<GetExpoInformationUiState>(GetExpoInformationUiState.Loading)
     internal val getExpoInformationUiState = _getExpoInformationUiState.asStateFlow()
 
-    private val _getCoordinatesUiState =
-        MutableStateFlow<GetCoordinatesUiState>(GetCoordinatesUiState.Loading)
+    private val _getCoordinatesUiState = MutableStateFlow<GetCoordinatesUiState>(GetCoordinatesUiState.Loading)
     internal val getCoordinatesUiState = _getCoordinatesUiState.asStateFlow()
 
-    private val _getCoordinatesToAddressUiState =
-        MutableStateFlow<GetCoordinatesToAddressUiState>(GetCoordinatesToAddressUiState.Loading)
+    private val _getCoordinatesToAddressUiState = MutableStateFlow<GetCoordinatesToAddressUiState>(GetCoordinatesToAddressUiState.Loading)
     internal val getCoordinatesToAddressUiState = _getCoordinatesToAddressUiState.asStateFlow()
 
     private val _getAddressUiState = MutableStateFlow<GetAddressUiState>(GetAddressUiState.Loading)
     internal val getAddressUiState = _getAddressUiState.asStateFlow()
 
-    private val _registerExpoInformationUiState =
-        MutableStateFlow<RegisterExpoInformationUiState>(RegisterExpoInformationUiState.Loading)
+    private val _registerExpoInformationUiState = MutableStateFlow<RegisterExpoInformationUiState>(RegisterExpoInformationUiState.Loading)
     internal val registerExpoInformationUiState = _registerExpoInformationUiState.asStateFlow()
 
-    private val _modifyExpoInformationUiState =
-        MutableStateFlow<ModifyExpoInformationUiState>(ModifyExpoInformationUiState.Loading)
+    private val _modifyExpoInformationUiState = MutableStateFlow<ModifyExpoInformationUiState>(ModifyExpoInformationUiState.Loading)
     internal val modifyExpoInformationUiState = _modifyExpoInformationUiState.asStateFlow()
 
-    private val _deleteExpoInformationUiState =
-        MutableStateFlow<DeleteExpoInformationUiState>(DeleteExpoInformationUiState.Loading)
+    private val _deleteExpoInformationUiState = MutableStateFlow<DeleteExpoInformationUiState>(DeleteExpoInformationUiState.Loading)
     internal val deleteExpoInformationUiState = _deleteExpoInformationUiState.asStateFlow()
 
-    private val _getExpoListUiState =
-        MutableStateFlow<GetExpoListUiState>(GetExpoListUiState.Loading)
+    private val _getExpoListUiState = MutableStateFlow<GetExpoListUiState>(GetExpoListUiState.Loading)
     internal val getExpoListUiState = _getExpoListUiState.asStateFlow()
 
-    private val _imageUpLoadUiState =
-        MutableStateFlow<ImageUpLoadUiState>(ImageUpLoadUiState.Loading)
+    private val _imageUpLoadUiState = MutableStateFlow<ImageUpLoadUiState>(ImageUpLoadUiState.Loading)
     internal val imageUpLoadUiState = _imageUpLoadUiState.asStateFlow()
 
-    private val _getStandardProgramListUiState =
-        MutableStateFlow<GetStandardProgramListUiState>(GetStandardProgramListUiState.Loading)
+    private val _getStandardProgramListUiState = MutableStateFlow<GetStandardProgramListUiState>(GetStandardProgramListUiState.Loading)
     internal val getStandardProgramListUiState = _getStandardProgramListUiState.asStateFlow()
 
-    private val _getTrainingProgramListUiState =
-        MutableStateFlow<GetTrainingProgramListUiState>(GetTrainingProgramListUiState.Loading)
+    private val _getTrainingProgramListUiState = MutableStateFlow<GetTrainingProgramListUiState>(GetTrainingProgramListUiState.Loading)
     internal val getTrainingProgramListUiState = _getTrainingProgramListUiState.asStateFlow()
 
     internal var modify_title = savedStateHandle.getStateFlow(key = MODIFY_TITLE, initialValue = "")
@@ -153,8 +139,7 @@ internal class ExpoViewModel @Inject constructor(
 
     internal var ended_date = savedStateHandle.getStateFlow(key = ENDED_DATE, initialValue = "")
 
-    internal var introduce_title =
-        savedStateHandle.getStateFlow(key = INTRODUCE_TITLE, initialValue = "")
+    internal var introduce_title = savedStateHandle.getStateFlow(key = INTRODUCE_TITLE, initialValue = "")
 
     internal var address = savedStateHandle.getStateFlow(key = ADDRESS, initialValue = "")
 
@@ -166,14 +151,11 @@ internal class ExpoViewModel @Inject constructor(
 
     internal var coordinateY = savedStateHandle.getStateFlow(key = COORDINATEY, initialValue = "")
 
-    internal var searched_location =
-        savedStateHandle.getStateFlow(key = SEARCHED_LOCATION, initialValue = "")
+    internal var searched_location = savedStateHandle.getStateFlow(key = SEARCHED_LOCATION, initialValue = "")
 
-    internal var searched_coordinateX =
-        savedStateHandle.getStateFlow(key = SEARCHED_COORDINATEX, initialValue = "")
+    internal var searched_coordinateX = savedStateHandle.getStateFlow(key = SEARCHED_COORDINATEX, initialValue = "")
 
-    internal var searched_coordinateY =
-        savedStateHandle.getStateFlow(key = SEARCHED_COORDINATEY, initialValue = "")
+    internal var searched_coordinateY = savedStateHandle.getStateFlow(key = SEARCHED_COORDINATEY, initialValue = "")
 
     val expoListSize: StateFlow<Int> = getExpoListUiState
         .map { state ->
@@ -198,12 +180,9 @@ internal class ExpoViewModel @Inject constructor(
             .asResult()
             .collectLatest { result ->
                 when (result) {
-                    is Result.Loading -> _getExpoInformationUiState.value =
-                        GetExpoInformationUiState.Loading
-
+                    is Result.Loading -> _getExpoInformationUiState.value = GetExpoInformationUiState.Loading
                     is Result.Success -> {
-                        _getExpoInformationUiState.value =
-                            GetExpoInformationUiState.Success(result.data)
+                        _getExpoInformationUiState.value = GetExpoInformationUiState.Success(result.data)
 
                         result.data.let {
                             onModifyTitleChange(it.title)
@@ -220,9 +199,7 @@ internal class ExpoViewModel @Inject constructor(
                             onCoverImageChange(it.coverImage)
                         }
                     }
-
-                    is Result.Error -> _getExpoInformationUiState.value =
-                        GetExpoInformationUiState.Error(result.exception)
+                    is Result.Error -> _getExpoInformationUiState.value = GetExpoInformationUiState.Error(result.exception)
                 }
             }
     }
@@ -251,14 +228,9 @@ internal class ExpoViewModel @Inject constructor(
                 .asResult() // TODO: 컨벤션 확인
                 .collectLatest { result ->
                     when (result) {
-                        is Result.Loading -> _registerExpoInformationUiState.value =
-                            RegisterExpoInformationUiState.Loading
-
-                        is Result.Success -> _registerExpoInformationUiState.value =
-                            RegisterExpoInformationUiState.Success(result.data)
-
-                        is Result.Error -> _registerExpoInformationUiState.value =
-                            RegisterExpoInformationUiState.Error(result.exception)
+                        is Result.Loading -> _registerExpoInformationUiState.value = RegisterExpoInformationUiState.Loading
+                        is Result.Success -> _registerExpoInformationUiState.value = RegisterExpoInformationUiState.Success(result.data)
+                        is Result.Error -> _registerExpoInformationUiState.value = RegisterExpoInformationUiState.Error(result.exception)
                     }
                 }
         }
@@ -296,8 +268,7 @@ internal class ExpoViewModel @Inject constructor(
         )
             .onSuccess {
                 it.catch { remoteError ->
-                    _modifyExpoInformationUiState.value =
-                        ModifyExpoInformationUiState.Error(remoteError)
+                    _modifyExpoInformationUiState.value = ModifyExpoInformationUiState.Error(remoteError)
                 }.collect {
                     _modifyExpoInformationUiState.value = ModifyExpoInformationUiState.Success
                 }
@@ -345,8 +316,7 @@ internal class ExpoViewModel @Inject constructor(
         deleteExpoInformationUseCase(expoId = expoId)
             .onSuccess {
                 it.catch { remoteError ->
-                    _deleteExpoInformationUiState.value =
-                        DeleteExpoInformationUiState.Error(remoteError)
+                    _deleteExpoInformationUiState.value = DeleteExpoInformationUiState.Error(remoteError)
                 }.collect {
                     _deleteExpoInformationUiState.value = DeleteExpoInformationUiState.Success
                     getExpoList()
@@ -377,7 +347,6 @@ internal class ExpoViewModel @Inject constructor(
                             _swipeRefreshLoading.value = false
                         }
                     }
-
                     is Result.Error -> {
                         _getExpoListUiState.value = GetExpoListUiState.Error(result.exception)
                         _swipeRefreshLoading.value = false
@@ -393,8 +362,7 @@ internal class ExpoViewModel @Inject constructor(
         val multipartFile = getMultipartFile(context, image)
 
         if (multipartFile == null) {
-            _imageUpLoadUiState.value =
-                ImageUpLoadUiState.Error(IllegalStateException("이미지 파일 변환 실패"))
+            _imageUpLoadUiState.value = ImageUpLoadUiState.Error(IllegalStateException("이미지 파일 변환 실패"))
             return@launch
         }
 
@@ -403,11 +371,8 @@ internal class ExpoViewModel @Inject constructor(
             .collectLatest { result ->
                 when (result) {
                     is Result.Loading -> _imageUpLoadUiState.value = ImageUpLoadUiState.Loading
-                    is Result.Success -> _imageUpLoadUiState.value =
-                        ImageUpLoadUiState.Success(result.data)
-
-                    is Result.Error -> _imageUpLoadUiState.value =
-                        ImageUpLoadUiState.Error(result.exception)
+                    is Result.Success -> _imageUpLoadUiState.value = ImageUpLoadUiState.Success(result.data)
+                    is Result.Error -> _imageUpLoadUiState.value = ImageUpLoadUiState.Error(result.exception)
                 }
             }
     }
@@ -418,12 +383,9 @@ internal class ExpoViewModel @Inject constructor(
             .asResult()
             .collectLatest { result ->
                 when (result) {
-                    is Result.Loading -> _getStandardProgramListUiState.value =
-                        GetStandardProgramListUiState.Loading
-
+                    is Result.Loading -> _getStandardProgramListUiState.value = GetStandardProgramListUiState.Loading
                     is Result.Success -> {
-                        _getStandardProgramListUiState.value =
-                            GetStandardProgramListUiState.Success(result.data)
+                        _getStandardProgramListUiState.value = GetStandardProgramListUiState.Success(result.data)
 
                         _standardProgramModifyTextState.value = result.data.map { program ->
                             StandardProIdRequestParam(
@@ -434,9 +396,7 @@ internal class ExpoViewModel @Inject constructor(
                             )
                         }
                     }
-
-                    is Result.Error -> _getStandardProgramListUiState.value =
-                        GetStandardProgramListUiState.Error(result.exception)
+                    is Result.Error -> _getStandardProgramListUiState.value = GetStandardProgramListUiState.Error(result.exception)
                 }
             }
     }
@@ -448,12 +408,9 @@ internal class ExpoViewModel @Inject constructor(
             .asResult()
             .collectLatest { result ->
                 when (result) {
-                    is Result.Loading -> _getTrainingProgramListUiState.value =
-                        GetTrainingProgramListUiState.Loading
-
+                    is Result.Loading -> _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Loading
                     is Result.Success -> {
-                        _getTrainingProgramListUiState.value =
-                            GetTrainingProgramListUiState.Success(result.data)
+                        _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Success(result.data)
 
                         _trainingProgramModifyTextState.value = result.data.map { program ->
                             TrainingProIdRequestParam(
@@ -465,9 +422,7 @@ internal class ExpoViewModel @Inject constructor(
                             )
                         }
                     }
-
-                    is Result.Error -> _getTrainingProgramListUiState.value =
-                        GetTrainingProgramListUiState.Error(result.exception)
+                    is Result.Error -> _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Error(result.exception)
                 }
             }
     }
@@ -507,9 +462,7 @@ internal class ExpoViewModel @Inject constructor(
                                 )
                             }
                         }
-
-                        is Result.Error -> _getAddressUiState.value =
-                            GetAddressUiState.Error(result.exception)
+                        is Result.Error -> _getAddressUiState.value = GetAddressUiState.Error(result.exception)
                     }
                 }
         }
@@ -519,27 +472,20 @@ internal class ExpoViewModel @Inject constructor(
         getCoordinatesUseCase(address = searchText)
             .asResult()
             .collectLatest { result ->
-                when (result) {
-                    is Result.Loading -> _getCoordinatesUiState.value =
-                        GetCoordinatesUiState.Loading
-
+                when(result){
+                    is Result.Loading -> _getCoordinatesUiState.value = GetCoordinatesUiState.Loading
                     is Result.Success -> if (result.data.addressName == "Unknown") {
-                        _getCoordinatesUiState.value =
-                            GetCoordinatesUiState.Error(NoResponseException())
+                        _getCoordinatesUiState.value = GetCoordinatesUiState.Error(NoResponseException())
                     } else {
                         onSearchedCoordinateChange(
-                            x = result.data.x.toDoubleOrNull()?.let { "%.6f".format(it) }
-                                ?: "0.000000",
-                            y = result.data.y.toDoubleOrNull()?.let { "%.6f".format(it) }
-                                ?: "0.000000"
+                            x = result.data.x.toDoubleOrNull()?.let { "%.6f".format(it) } ?: "0.000000",
+                            y = result.data.y.toDoubleOrNull()?.let { "%.6f".format(it) } ?: "0.000000"
                         )
                         onSearchedLocationChange(result.data.addressName)
 
                         _getCoordinatesUiState.value = GetCoordinatesUiState.Success(result.data)
                     }
-
-                    is Result.Error -> _getCoordinatesUiState.value =
-                        GetCoordinatesUiState.Error(result.exception)
+                    is Result.Error -> _getCoordinatesUiState.value = GetCoordinatesUiState.Error(result.exception)
                 }
             }
     }
@@ -549,42 +495,28 @@ internal class ExpoViewModel @Inject constructor(
             .asResult()
             .collectLatest { result ->
                 when (result) {
-                    is Result.Loading -> _getCoordinatesToAddressUiState.value =
-                        GetCoordinatesToAddressUiState.Loading
-
+                    is Result.Loading -> _getCoordinatesToAddressUiState.value = GetCoordinatesToAddressUiState.Loading
                     is Result.Success -> if (result.data.addressName == "Unknown") {
-                        _getCoordinatesToAddressUiState.value =
-                            GetCoordinatesToAddressUiState.Error(NoResponseException())
+                        _getCoordinatesToAddressUiState.value = GetCoordinatesToAddressUiState.Error(NoResponseException())
                     } else {
-                        _getCoordinatesToAddressUiState.value =
-                            GetCoordinatesToAddressUiState.Success(result.data)
+                        _getCoordinatesToAddressUiState.value = GetCoordinatesToAddressUiState.Success(result.data)
                         onAddressChange(result.data.addressName)
                     }
-
-                    is Result.Error -> _getCoordinatesToAddressUiState.value =
-                        GetCoordinatesToAddressUiState.Error(result.exception)
+                    is Result.Error -> _getCoordinatesToAddressUiState.value = GetCoordinatesToAddressUiState.Error(result.exception)
                 }
             }
     }
 
-    internal fun updateTrainingProgramModifyText(
-        index: Int,
-        updateItem: TrainingProIdRequestParam
-    ) {
-        _trainingProgramModifyTextState.value =
-            _trainingProgramModifyTextState.value.toMutableList().apply {
-                set(index, updateItem)
-            }
+    internal fun updateTrainingProgramModifyText(index: Int, updateItem: TrainingProIdRequestParam) {
+        _trainingProgramModifyTextState.value = _trainingProgramModifyTextState.value.toMutableList().apply {
+            set(index, updateItem)
+        }
     }
 
-    internal fun updateStandardProgramModifyText(
-        index: Int,
-        updateItem: StandardProIdRequestParam
-    ) {
-        _standardProgramModifyTextState.value =
-            _standardProgramModifyTextState.value.toMutableList().apply {
-                set(index, updateItem)
-            }
+    internal fun updateStandardProgramModifyText(index: Int, updateItem: StandardProIdRequestParam) {
+        _standardProgramModifyTextState.value = _standardProgramModifyTextState.value.toMutableList().apply {
+            set(index, updateItem)
+        }
     }
 
     internal fun addTrainingProgramModifyText() {
@@ -614,37 +546,27 @@ internal class ExpoViewModel @Inject constructor(
     }
 
     internal fun removeTrainingProgramModifyText(index: Int) {
-        _trainingProgramModifyTextState.value =
-            _trainingProgramModifyTextState.value.toMutableList().apply {
-                removeAt(index)
-            }
+        _trainingProgramModifyTextState.value = _trainingProgramModifyTextState.value.toMutableList().apply {
+            removeAt(index)
+        }
     }
 
     internal fun removeStandardProgramModifyText(index: Int) {
-        _standardProgramModifyTextState.value =
-            _standardProgramModifyTextState.value.toMutableList().apply {
-                removeAt(index)
-            }
+        _standardProgramModifyTextState.value = _standardProgramModifyTextState.value.toMutableList().apply {
+            removeAt(index)
+        }
     }
 
-    internal fun updateExistingTrainingProgramModify(
-        index: Int,
-        updatedItem: TrainingProIdRequestParam
-    ) {
-        _trainingProgramModifyTextState.value =
-            _trainingProgramModifyTextState.value.toMutableList().apply {
-                this[index] = updatedItem
-            }
+    internal fun updateExistingTrainingProgramModify(index: Int, updatedItem: TrainingProIdRequestParam) {
+        _trainingProgramModifyTextState.value = _trainingProgramModifyTextState.value.toMutableList().apply {
+            this[index] = updatedItem
+        }
     }
 
-    internal fun updateExistingStandardProgramModify(
-        index: Int,
-        updatedItem: StandardProIdRequestParam
-    ) {
-        _standardProgramModifyTextState.value =
-            _standardProgramModifyTextState.value.toMutableList().apply {
-                this[index] = updatedItem
-            }
+    internal fun updateExistingStandardProgramModify(index: Int, updatedItem: StandardProIdRequestParam) {
+        _standardProgramModifyTextState.value = _standardProgramModifyTextState.value.toMutableList().apply {
+            this[index] = updatedItem
+        }
     }
 
     internal fun updateTrainingProgramText(index: Int, updateItem: TrainingProRequestParam) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -190,9 +190,7 @@ internal class ExpoViewModel @Inject constructor(
                             onEndedDateChange(it.finishedDay.formatNoneHyphenServerDate())
                             onIntroduceTitleChange(it.description)
                             if (searched_location.value.isNotBlank()) {
-                                onLocationChange(searched_location.value)
-                                onCoordinateChange(x = searched_coordinateX.value, y = searched_coordinateX.value)
-                                convertXYToJibun(x = searched_coordinateX.value, y = searched_coordinateX.value)
+                                setSearchedData()
                             } else {
                                 onLocationChange(it.location)
                                 onCoordinateChange(x = it.x, y = it.y)

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -88,49 +88,63 @@ internal class ExpoViewModel @Inject constructor(
     private val _swipeRefreshLoading = MutableStateFlow(false)
     val swipeRefreshLoading = _swipeRefreshLoading.asStateFlow()
 
-    private val _trainingProgramTextState = MutableStateFlow<List<TrainingProRequestParam>>(emptyList())
+    private val _trainingProgramTextState =
+        MutableStateFlow<List<TrainingProRequestParam>>(emptyList())
     internal val trainingProgramTextState = _trainingProgramTextState.asStateFlow()
 
-    private val _standardProgramTextState = MutableStateFlow<List<StandardProRequestParam>>(emptyList())
+    private val _standardProgramTextState =
+        MutableStateFlow<List<StandardProRequestParam>>(emptyList())
     internal val standardProgramTextState = _standardProgramTextState.asStateFlow()
 
-    private val _trainingProgramModifyTextState = MutableStateFlow<List<TrainingProIdRequestParam>>(emptyList())
+    private val _trainingProgramModifyTextState =
+        MutableStateFlow<List<TrainingProIdRequestParam>>(emptyList())
     internal val trainingProgramModifyTextState = _trainingProgramModifyTextState.asStateFlow()
 
-    private val _standardProgramModifyTextState = MutableStateFlow<List<StandardProIdRequestParam>>(emptyList())
+    private val _standardProgramModifyTextState =
+        MutableStateFlow<List<StandardProIdRequestParam>>(emptyList())
     internal val standardProgramModifyTextState = _standardProgramModifyTextState.asStateFlow()
 
-    private val _getExpoInformationUiState = MutableStateFlow<GetExpoInformationUiState>(GetExpoInformationUiState.Loading)
+    private val _getExpoInformationUiState =
+        MutableStateFlow<GetExpoInformationUiState>(GetExpoInformationUiState.Loading)
     internal val getExpoInformationUiState = _getExpoInformationUiState.asStateFlow()
 
-    private val _getCoordinatesUiState = MutableStateFlow<GetCoordinatesUiState>(GetCoordinatesUiState.Loading)
+    private val _getCoordinatesUiState =
+        MutableStateFlow<GetCoordinatesUiState>(GetCoordinatesUiState.Loading)
     internal val getCoordinatesUiState = _getCoordinatesUiState.asStateFlow()
 
-    private val _getCoordinatesToAddressUiState = MutableStateFlow<GetCoordinatesToAddressUiState>(GetCoordinatesToAddressUiState.Loading)
+    private val _getCoordinatesToAddressUiState =
+        MutableStateFlow<GetCoordinatesToAddressUiState>(GetCoordinatesToAddressUiState.Loading)
     internal val getCoordinatesToAddressUiState = _getCoordinatesToAddressUiState.asStateFlow()
 
     private val _getAddressUiState = MutableStateFlow<GetAddressUiState>(GetAddressUiState.Loading)
     internal val getAddressUiState = _getAddressUiState.asStateFlow()
 
-    private val _registerExpoInformationUiState = MutableStateFlow<RegisterExpoInformationUiState>(RegisterExpoInformationUiState.Loading)
+    private val _registerExpoInformationUiState =
+        MutableStateFlow<RegisterExpoInformationUiState>(RegisterExpoInformationUiState.Loading)
     internal val registerExpoInformationUiState = _registerExpoInformationUiState.asStateFlow()
 
-    private val _modifyExpoInformationUiState = MutableStateFlow<ModifyExpoInformationUiState>(ModifyExpoInformationUiState.Loading)
+    private val _modifyExpoInformationUiState =
+        MutableStateFlow<ModifyExpoInformationUiState>(ModifyExpoInformationUiState.Loading)
     internal val modifyExpoInformationUiState = _modifyExpoInformationUiState.asStateFlow()
 
-    private val _deleteExpoInformationUiState = MutableStateFlow<DeleteExpoInformationUiState>(DeleteExpoInformationUiState.Loading)
+    private val _deleteExpoInformationUiState =
+        MutableStateFlow<DeleteExpoInformationUiState>(DeleteExpoInformationUiState.Loading)
     internal val deleteExpoInformationUiState = _deleteExpoInformationUiState.asStateFlow()
 
-    private val _getExpoListUiState = MutableStateFlow<GetExpoListUiState>(GetExpoListUiState.Loading)
+    private val _getExpoListUiState =
+        MutableStateFlow<GetExpoListUiState>(GetExpoListUiState.Loading)
     internal val getExpoListUiState = _getExpoListUiState.asStateFlow()
 
-    private val _imageUpLoadUiState = MutableStateFlow<ImageUpLoadUiState>(ImageUpLoadUiState.Loading)
+    private val _imageUpLoadUiState =
+        MutableStateFlow<ImageUpLoadUiState>(ImageUpLoadUiState.Loading)
     internal val imageUpLoadUiState = _imageUpLoadUiState.asStateFlow()
 
-    private val _getStandardProgramListUiState = MutableStateFlow<GetStandardProgramListUiState>(GetStandardProgramListUiState.Loading)
+    private val _getStandardProgramListUiState =
+        MutableStateFlow<GetStandardProgramListUiState>(GetStandardProgramListUiState.Loading)
     internal val getStandardProgramListUiState = _getStandardProgramListUiState.asStateFlow()
 
-    private val _getTrainingProgramListUiState = MutableStateFlow<GetTrainingProgramListUiState>(GetTrainingProgramListUiState.Loading)
+    private val _getTrainingProgramListUiState =
+        MutableStateFlow<GetTrainingProgramListUiState>(GetTrainingProgramListUiState.Loading)
     internal val getTrainingProgramListUiState = _getTrainingProgramListUiState.asStateFlow()
 
     internal var modify_title = savedStateHandle.getStateFlow(key = MODIFY_TITLE, initialValue = "")
@@ -139,7 +153,8 @@ internal class ExpoViewModel @Inject constructor(
 
     internal var ended_date = savedStateHandle.getStateFlow(key = ENDED_DATE, initialValue = "")
 
-    internal var introduce_title = savedStateHandle.getStateFlow(key = INTRODUCE_TITLE, initialValue = "")
+    internal var introduce_title =
+        savedStateHandle.getStateFlow(key = INTRODUCE_TITLE, initialValue = "")
 
     internal var address = savedStateHandle.getStateFlow(key = ADDRESS, initialValue = "")
 
@@ -151,11 +166,14 @@ internal class ExpoViewModel @Inject constructor(
 
     internal var coordinateY = savedStateHandle.getStateFlow(key = COORDINATEY, initialValue = "")
 
-    internal var searched_location = savedStateHandle.getStateFlow(key = SEARCHED_LOCATION, initialValue = "")
+    internal var searched_location =
+        savedStateHandle.getStateFlow(key = SEARCHED_LOCATION, initialValue = "")
 
-    internal var searched_coordinateX = savedStateHandle.getStateFlow(key = SEARCHED_COORDINATEX, initialValue = "")
+    internal var searched_coordinateX =
+        savedStateHandle.getStateFlow(key = SEARCHED_COORDINATEX, initialValue = "")
 
-    internal var searched_coordinateY = savedStateHandle.getStateFlow(key = SEARCHED_COORDINATEY, initialValue = "")
+    internal var searched_coordinateY =
+        savedStateHandle.getStateFlow(key = SEARCHED_COORDINATEY, initialValue = "")
 
     val expoListSize: StateFlow<Int> = getExpoListUiState
         .map { state ->
@@ -180,9 +198,12 @@ internal class ExpoViewModel @Inject constructor(
             .asResult()
             .collectLatest { result ->
                 when (result) {
-                    is Result.Loading -> _getExpoInformationUiState.value = GetExpoInformationUiState.Loading
+                    is Result.Loading -> _getExpoInformationUiState.value =
+                        GetExpoInformationUiState.Loading
+
                     is Result.Success -> {
-                        _getExpoInformationUiState.value = GetExpoInformationUiState.Success(result.data)
+                        _getExpoInformationUiState.value =
+                            GetExpoInformationUiState.Success(result.data)
 
                         result.data.let {
                             onModifyTitleChange(it.title)
@@ -199,7 +220,9 @@ internal class ExpoViewModel @Inject constructor(
                             onCoverImageChange(it.coverImage)
                         }
                     }
-                    is Result.Error -> _getExpoInformationUiState.value = GetExpoInformationUiState.Error(result.exception)
+
+                    is Result.Error -> _getExpoInformationUiState.value =
+                        GetExpoInformationUiState.Error(result.exception)
                 }
             }
     }
@@ -228,9 +251,14 @@ internal class ExpoViewModel @Inject constructor(
                 .asResult() // TODO: 컨벤션 확인
                 .collectLatest { result ->
                     when (result) {
-                        is Result.Loading -> _registerExpoInformationUiState.value = RegisterExpoInformationUiState.Loading
-                        is Result.Success -> _registerExpoInformationUiState.value = RegisterExpoInformationUiState.Success(result.data)
-                        is Result.Error -> _registerExpoInformationUiState.value = RegisterExpoInformationUiState.Error(result.exception)
+                        is Result.Loading -> _registerExpoInformationUiState.value =
+                            RegisterExpoInformationUiState.Loading
+
+                        is Result.Success -> _registerExpoInformationUiState.value =
+                            RegisterExpoInformationUiState.Success(result.data)
+
+                        is Result.Error -> _registerExpoInformationUiState.value =
+                            RegisterExpoInformationUiState.Error(result.exception)
                     }
                 }
         }
@@ -268,7 +296,8 @@ internal class ExpoViewModel @Inject constructor(
         )
             .onSuccess {
                 it.catch { remoteError ->
-                    _modifyExpoInformationUiState.value = ModifyExpoInformationUiState.Error(remoteError)
+                    _modifyExpoInformationUiState.value =
+                        ModifyExpoInformationUiState.Error(remoteError)
                 }.collect {
                     _modifyExpoInformationUiState.value = ModifyExpoInformationUiState.Success
                 }
@@ -283,26 +312,41 @@ internal class ExpoViewModel @Inject constructor(
         _modifyExpoInformationUiState.value = ModifyExpoInformationUiState.Loading
     }
 
-    internal fun resetExpoInformation() {
-            onIntroduceTitleChange("")
-            onStartedDateChange("")
-            onEndedDateChange("")
-            onAddressChange("")
-            onLocationChange("")
-            onCoverImageChange(null)
-            onModifyTitleChange("")
-            onStartedChange("")
-            onEndedChange("")
-            _trainingProgramTextState.value = emptyList()
-            _standardProgramTextState.value = emptyList()
+    internal fun resetOnCreateExpoInformation() {
+        onIntroduceTitleChange("")
+        onStartedDateChange("")
+        onEndedDateChange("")
+        onAddressChange("")
+        onLocationChange("")
+        onCoverImageChange(null)
+        onModifyTitleChange("")
+        onStartedChange("")
+        onEndedChange("")
+        _trainingProgramTextState.value = emptyList()
+        _standardProgramTextState.value = emptyList()
     }
+
+    internal fun resetOnModifyExpoInformation() {
+        onIntroduceTitleChange("")
+        onStartedDateChange("")
+        onEndedDateChange("")
+        onAddressChange("")
+        onCoverImageChange(null)
+        onModifyTitleChange("")
+        onStartedChange("")
+        onEndedChange("")
+        _trainingProgramTextState.value = emptyList()
+        _standardProgramTextState.value = emptyList()
+    }
+
 
     internal fun deleteExpoInformation(expoId: String) = viewModelScope.launch {
         _deleteExpoInformationUiState.value = DeleteExpoInformationUiState.Loading
         deleteExpoInformationUseCase(expoId = expoId)
             .onSuccess {
                 it.catch { remoteError ->
-                    _deleteExpoInformationUiState.value = DeleteExpoInformationUiState.Error(remoteError)
+                    _deleteExpoInformationUiState.value =
+                        DeleteExpoInformationUiState.Error(remoteError)
                 }.collect {
                     _deleteExpoInformationUiState.value = DeleteExpoInformationUiState.Success
                     getExpoList()
@@ -333,6 +377,7 @@ internal class ExpoViewModel @Inject constructor(
                             _swipeRefreshLoading.value = false
                         }
                     }
+
                     is Result.Error -> {
                         _getExpoListUiState.value = GetExpoListUiState.Error(result.exception)
                         _swipeRefreshLoading.value = false
@@ -348,7 +393,8 @@ internal class ExpoViewModel @Inject constructor(
         val multipartFile = getMultipartFile(context, image)
 
         if (multipartFile == null) {
-            _imageUpLoadUiState.value = ImageUpLoadUiState.Error(IllegalStateException("이미지 파일 변환 실패"))
+            _imageUpLoadUiState.value =
+                ImageUpLoadUiState.Error(IllegalStateException("이미지 파일 변환 실패"))
             return@launch
         }
 
@@ -357,8 +403,11 @@ internal class ExpoViewModel @Inject constructor(
             .collectLatest { result ->
                 when (result) {
                     is Result.Loading -> _imageUpLoadUiState.value = ImageUpLoadUiState.Loading
-                    is Result.Success -> _imageUpLoadUiState.value = ImageUpLoadUiState.Success(result.data)
-                    is Result.Error -> _imageUpLoadUiState.value = ImageUpLoadUiState.Error(result.exception)
+                    is Result.Success -> _imageUpLoadUiState.value =
+                        ImageUpLoadUiState.Success(result.data)
+
+                    is Result.Error -> _imageUpLoadUiState.value =
+                        ImageUpLoadUiState.Error(result.exception)
                 }
             }
     }
@@ -369,9 +418,12 @@ internal class ExpoViewModel @Inject constructor(
             .asResult()
             .collectLatest { result ->
                 when (result) {
-                    is Result.Loading -> _getStandardProgramListUiState.value = GetStandardProgramListUiState.Loading
+                    is Result.Loading -> _getStandardProgramListUiState.value =
+                        GetStandardProgramListUiState.Loading
+
                     is Result.Success -> {
-                        _getStandardProgramListUiState.value = GetStandardProgramListUiState.Success(result.data)
+                        _getStandardProgramListUiState.value =
+                            GetStandardProgramListUiState.Success(result.data)
 
                         _standardProgramModifyTextState.value = result.data.map { program ->
                             StandardProIdRequestParam(
@@ -382,7 +434,9 @@ internal class ExpoViewModel @Inject constructor(
                             )
                         }
                     }
-                    is Result.Error -> _getStandardProgramListUiState.value = GetStandardProgramListUiState.Error(result.exception)
+
+                    is Result.Error -> _getStandardProgramListUiState.value =
+                        GetStandardProgramListUiState.Error(result.exception)
                 }
             }
     }
@@ -394,9 +448,12 @@ internal class ExpoViewModel @Inject constructor(
             .asResult()
             .collectLatest { result ->
                 when (result) {
-                    is Result.Loading -> _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Loading
+                    is Result.Loading -> _getTrainingProgramListUiState.value =
+                        GetTrainingProgramListUiState.Loading
+
                     is Result.Success -> {
-                        _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Success(result.data)
+                        _getTrainingProgramListUiState.value =
+                            GetTrainingProgramListUiState.Success(result.data)
 
                         _trainingProgramModifyTextState.value = result.data.map { program ->
                             TrainingProIdRequestParam(
@@ -408,7 +465,9 @@ internal class ExpoViewModel @Inject constructor(
                             )
                         }
                     }
-                    is Result.Error -> _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Error(result.exception)
+
+                    is Result.Error -> _getTrainingProgramListUiState.value =
+                        GetTrainingProgramListUiState.Error(result.exception)
                 }
             }
     }
@@ -448,7 +507,9 @@ internal class ExpoViewModel @Inject constructor(
                                 )
                             }
                         }
-                        is Result.Error -> _getAddressUiState.value = GetAddressUiState.Error(result.exception)
+
+                        is Result.Error -> _getAddressUiState.value =
+                            GetAddressUiState.Error(result.exception)
                     }
                 }
         }
@@ -458,20 +519,27 @@ internal class ExpoViewModel @Inject constructor(
         getCoordinatesUseCase(address = searchText)
             .asResult()
             .collectLatest { result ->
-                when(result){
-                    is Result.Loading -> _getCoordinatesUiState.value = GetCoordinatesUiState.Loading
+                when (result) {
+                    is Result.Loading -> _getCoordinatesUiState.value =
+                        GetCoordinatesUiState.Loading
+
                     is Result.Success -> if (result.data.addressName == "Unknown") {
-                        _getCoordinatesUiState.value = GetCoordinatesUiState.Error(NoResponseException())
+                        _getCoordinatesUiState.value =
+                            GetCoordinatesUiState.Error(NoResponseException())
                     } else {
                         onSearchedCoordinateChange(
-                            x = result.data.x.toDoubleOrNull()?.let { "%.6f".format(it) } ?: "0.000000",
-                            y = result.data.y.toDoubleOrNull()?.let { "%.6f".format(it) } ?: "0.000000"
+                            x = result.data.x.toDoubleOrNull()?.let { "%.6f".format(it) }
+                                ?: "0.000000",
+                            y = result.data.y.toDoubleOrNull()?.let { "%.6f".format(it) }
+                                ?: "0.000000"
                         )
                         onSearchedLocationChange(result.data.addressName)
 
                         _getCoordinatesUiState.value = GetCoordinatesUiState.Success(result.data)
                     }
-                    is Result.Error -> _getCoordinatesUiState.value = GetCoordinatesUiState.Error(result.exception)
+
+                    is Result.Error -> _getCoordinatesUiState.value =
+                        GetCoordinatesUiState.Error(result.exception)
                 }
             }
     }
@@ -481,28 +549,42 @@ internal class ExpoViewModel @Inject constructor(
             .asResult()
             .collectLatest { result ->
                 when (result) {
-                    is Result.Loading -> _getCoordinatesToAddressUiState.value = GetCoordinatesToAddressUiState.Loading
+                    is Result.Loading -> _getCoordinatesToAddressUiState.value =
+                        GetCoordinatesToAddressUiState.Loading
+
                     is Result.Success -> if (result.data.addressName == "Unknown") {
-                        _getCoordinatesToAddressUiState.value = GetCoordinatesToAddressUiState.Error(NoResponseException())
+                        _getCoordinatesToAddressUiState.value =
+                            GetCoordinatesToAddressUiState.Error(NoResponseException())
                     } else {
-                        _getCoordinatesToAddressUiState.value = GetCoordinatesToAddressUiState.Success(result.data)
+                        _getCoordinatesToAddressUiState.value =
+                            GetCoordinatesToAddressUiState.Success(result.data)
                         onAddressChange(result.data.addressName)
                     }
-                    is Result.Error -> _getCoordinatesToAddressUiState.value = GetCoordinatesToAddressUiState.Error(result.exception)
+
+                    is Result.Error -> _getCoordinatesToAddressUiState.value =
+                        GetCoordinatesToAddressUiState.Error(result.exception)
                 }
             }
     }
 
-    internal fun updateTrainingProgramModifyText(index: Int, updateItem: TrainingProIdRequestParam) {
-        _trainingProgramModifyTextState.value = _trainingProgramModifyTextState.value.toMutableList().apply {
-            set(index, updateItem)
-        }
+    internal fun updateTrainingProgramModifyText(
+        index: Int,
+        updateItem: TrainingProIdRequestParam
+    ) {
+        _trainingProgramModifyTextState.value =
+            _trainingProgramModifyTextState.value.toMutableList().apply {
+                set(index, updateItem)
+            }
     }
 
-    internal fun updateStandardProgramModifyText(index: Int, updateItem: StandardProIdRequestParam) {
-        _standardProgramModifyTextState.value = _standardProgramModifyTextState.value.toMutableList().apply {
-            set(index, updateItem)
-        }
+    internal fun updateStandardProgramModifyText(
+        index: Int,
+        updateItem: StandardProIdRequestParam
+    ) {
+        _standardProgramModifyTextState.value =
+            _standardProgramModifyTextState.value.toMutableList().apply {
+                set(index, updateItem)
+            }
     }
 
     internal fun addTrainingProgramModifyText() {
@@ -532,27 +614,37 @@ internal class ExpoViewModel @Inject constructor(
     }
 
     internal fun removeTrainingProgramModifyText(index: Int) {
-        _trainingProgramModifyTextState.value = _trainingProgramModifyTextState.value.toMutableList().apply {
-            removeAt(index)
-        }
+        _trainingProgramModifyTextState.value =
+            _trainingProgramModifyTextState.value.toMutableList().apply {
+                removeAt(index)
+            }
     }
 
     internal fun removeStandardProgramModifyText(index: Int) {
-        _standardProgramModifyTextState.value = _standardProgramModifyTextState.value.toMutableList().apply {
-            removeAt(index)
-        }
+        _standardProgramModifyTextState.value =
+            _standardProgramModifyTextState.value.toMutableList().apply {
+                removeAt(index)
+            }
     }
 
-    internal fun updateExistingTrainingProgramModify(index: Int, updatedItem: TrainingProIdRequestParam) {
-        _trainingProgramModifyTextState.value = _trainingProgramModifyTextState.value.toMutableList().apply {
-            this[index] = updatedItem
-        }
+    internal fun updateExistingTrainingProgramModify(
+        index: Int,
+        updatedItem: TrainingProIdRequestParam
+    ) {
+        _trainingProgramModifyTextState.value =
+            _trainingProgramModifyTextState.value.toMutableList().apply {
+                this[index] = updatedItem
+            }
     }
 
-    internal fun updateExistingStandardProgramModify(index: Int, updatedItem: StandardProIdRequestParam) {
-        _standardProgramModifyTextState.value = _standardProgramModifyTextState.value.toMutableList().apply {
-            this[index] = updatedItem
-        }
+    internal fun updateExistingStandardProgramModify(
+        index: Int,
+        updatedItem: StandardProIdRequestParam
+    ) {
+        _standardProgramModifyTextState.value =
+            _standardProgramModifyTextState.value.toMutableList().apply {
+                this[index] = updatedItem
+            }
     }
 
     internal fun updateTrainingProgramText(index: Int, updateItem: TrainingProRequestParam) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -318,6 +318,8 @@ internal class ExpoViewModel @Inject constructor(
     }
 
     internal fun resetExpoInformation() {
+        onCoordinateChange("", "")
+        onSearchedCoordinateChange("", "")
         onIntroduceTitleChange("")
         onStartedDateChange("")
         onEndedDateChange("")
@@ -445,11 +447,6 @@ internal class ExpoViewModel @Inject constructor(
                     is Result.Error -> _getTrainingProgramListUiState.value = GetTrainingProgramListUiState.Error(result.exception)
                 }
             }
-    }
-
-    internal fun initSearchedData() {
-        onAddressChange("")
-        onSearchedCoordinateChange("", "")
     }
 
     internal fun initSearchedUiState() {
@@ -665,10 +662,6 @@ internal class ExpoViewModel @Inject constructor(
     internal fun onCoordinateChange(x: String, y: String) {
         savedStateHandle[COORDINATEX] = x
         savedStateHandle[COORDINATEY] = y
-    }
-
-    internal fun onSearchedLocationChange(value: String) {
-        savedStateHandle[SEARCHED_LOCATION] = value
     }
 
     internal fun onSearchedCoordinateChange(x: String, y: String) {

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -522,6 +522,13 @@ internal class ExpoViewModel @Inject constructor(
         )
     }
 
+    private fun setSearchedData() {
+        if (searched_location.value.isNotEmpty()) {
+            onCoordinateChange(searched_coordinateX.value, searched_coordinateY.value)
+            onAddressChange(searched_location.value)
+        }
+    }
+
     internal fun removeTrainingProgramModifyText(index: Int) {
         _trainingProgramModifyTextState.value = _trainingProgramModifyTextState.value.toMutableList().apply {
             removeAt(index)

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -468,6 +468,8 @@ internal class ExpoViewModel @Inject constructor(
                             x = result.data.x.toDoubleOrNull()?.let { "%.6f".format(it) } ?: "0.000000",
                             y = result.data.y.toDoubleOrNull()?.let { "%.6f".format(it) } ?: "0.000000"
                         )
+                        onSearchedLocationChange(result.data.addressName)
+
                         _getCoordinatesUiState.value = GetCoordinatesUiState.Success(result.data)
                     }
                     is Result.Error -> _getCoordinatesUiState.value = GetCoordinatesUiState.Error(result.exception)

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -283,12 +283,10 @@ internal class ExpoViewModel @Inject constructor(
         _modifyExpoInformationUiState.value = ModifyExpoInformationUiState.Loading
     }
 
-    internal fun resetOnCreateExpoInformation() {
+    internal fun resetExpoInformation() {
         onIntroduceTitleChange("")
         onStartedDateChange("")
         onEndedDateChange("")
-        onAddressChange("")
-        onLocationChange("")
         onCoverImageChange(null)
         onModifyTitleChange("")
         onStartedChange("")
@@ -296,20 +294,6 @@ internal class ExpoViewModel @Inject constructor(
         _trainingProgramTextState.value = emptyList()
         _standardProgramTextState.value = emptyList()
     }
-
-    internal fun resetOnModifyExpoInformation() {
-        onIntroduceTitleChange("")
-        onStartedDateChange("")
-        onEndedDateChange("")
-        onAddressChange("")
-        onCoverImageChange(null)
-        onModifyTitleChange("")
-        onStartedChange("")
-        onEndedChange("")
-        _trainingProgramTextState.value = emptyList()
-        _standardProgramTextState.value = emptyList()
-    }
-
 
     internal fun deleteExpoInformation(expoId: String) = viewModelScope.launch {
         _deleteExpoInformationUiState.value = DeleteExpoInformationUiState.Loading

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -426,7 +426,6 @@ internal class ExpoViewModel @Inject constructor(
     }
 
     internal fun initializeWithSearchedData() {
-        onLocationChange(searched_location.value)
         onCoordinateChange(
             searched_coordinateX.value,
             searched_coordinateY.value
@@ -445,6 +444,7 @@ internal class ExpoViewModel @Inject constructor(
                         is Result.Success -> {
                             if (result.data.isNotEmpty()) {
                                 _getAddressUiState.value = GetAddressUiState.Success(result.data)
+                                onAddressChange(result.data.first().roadAddr)
                             } else {
                                 _getAddressUiState.value = GetAddressUiState.Error(
                                     NoResponseException()

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -287,7 +287,6 @@ internal class ExpoViewModel @Inject constructor(
         onIntroduceTitleChange("")
         onStartedDateChange("")
         onEndedDateChange("")
-        onLocationChange("")
         onCoverImageChange(null)
         onModifyTitleChange("")
         onStartedChange("")

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -426,6 +426,7 @@ internal class ExpoViewModel @Inject constructor(
             searched_coordinateX.value,
             searched_coordinateY.value
         )
+        onAddressChange(searched_location.value)
         initSearchedData()
     }
 

--- a/feature/form/src/main/java/com/school_of_company/form/view/component/FormToggleButton.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/component/FormToggleButton.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import kotlinx.coroutines.flow.flow
 import kotlin.math.roundToInt
 
 @Composable
@@ -137,4 +138,10 @@ private fun ExpoToggleButtonPreview() {
         width = 70.dp,
         onClick = { isToggled = !isToggled },
     )
+    val numbers = flow {
+        println("Flow started!")
+        emit(1) // 데이터 방출
+        emit(2) // 데이터 방출
+    }
+
 }


### PR DESCRIPTION
## 💡 개요

expo 생성시에 상세 주소와 주소가 바뀌어 생성되는 문제
expo 수정화면의 수정시에 보내는 값이 고정된 값인 문제
expoDetail화면의 좌표를 도로명주소로 변경하는 api가 정상적으로 동작하지 않는 문제가 있었습니다

## 📃 작업내용

expo 생성, 수정, 확인 화면의 상세주소와 주소의 이름을 각각 location, address 로 통일했습니다
expo 수정화면의 xy 좌표값을 viewModel의 값을 사용하도록 수정
역지오코딩 api의 repository에서 정상적으로 값을 emit 해주도록 수정

## 🔀 변경사항

![image](https://github.com/user-attachments/assets/531cb444-c26c-4cd4-b37e-4b17c5e477de)

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **리팩토링**
	- 데이터 처리 방식을 반응형 발행으로 개선하여 안정성과 성능을 향상시켰습니다.
	- Expo 생성 및 수정 화면에서 '주소' 대신 '위치' 용어를 일관되게 사용하고, 상태 초기화 로직을 세분화하였습니다.
	- 내부 상태 관리 및 UI 상호작용을 정제하여 유지 보수성을 높였습니다.
	- Expo 주소 검색 화면에서 UI 요소의 시각적 표현을 개선하였습니다.
- **새로운 기능**
	- 미리보기 기능에 비동기 데이터 흐름을 도입하여 향후 데이터 처리 확장 가능성을 마련하였습니다.
	- Expo 생성 및 수정 화면에서 화면 상태 관리를 위한 새로운 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->