### PR TITLE
🔀 :: (#529) - 박람회 동적폼, 만족도 조사 생성 여부 네트워크 세팅을 하였습니다.

### DIFF
--- a/core/data/src/main/java/com/school_of_company/data/repository/expo/ExpoRepository.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/expo/ExpoRepository.kt
@@ -15,5 +15,5 @@ interface ExpoRepository {
     fun registerExpoInformation(body: ExpoAllRequestParam) : Flow<ExpoIdResponseEntity>
     fun modifyExpoInformation(expoId: String, body: ExpoModifyRequestParam) : Flow<Unit>
     fun deleteExpoInformation(expoId: String) : Flow<Unit>
-    fun checkExpoSurveyDynamicFormEnable(expoId: String) : Flow<ExpoSurveyDynamicFormEnabledEntity>
+    fun checkExpoSurveyDynamicFormEnable() : Flow<ExpoSurveyDynamicFormEnabledEntity>
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/expo/ExpoRepository.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/expo/ExpoRepository.kt
@@ -2,6 +2,7 @@ package com.school_of_company.data.repository.expo
 
 import com.school_of_company.model.entity.expo.ExpoIdResponseEntity
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
+import com.school_of_company.model.entity.expo.ExpoSurveyDynamicFormEnabledEntity
 import com.school_of_company.model.model.expo.ExpoRequestAndResponseModel
 import com.school_of_company.model.param.expo.ExpoAllRequestParam
 import com.school_of_company.model.param.expo.ExpoModifyRequestParam
@@ -14,4 +15,5 @@ interface ExpoRepository {
     fun registerExpoInformation(body: ExpoAllRequestParam) : Flow<ExpoIdResponseEntity>
     fun modifyExpoInformation(expoId: String, body: ExpoModifyRequestParam) : Flow<Unit>
     fun deleteExpoInformation(expoId: String) : Flow<Unit>
+    fun checkExpoSurveyDynamicFormEnable(expoId: String) : Flow<ExpoSurveyDynamicFormEnabledEntity>
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/expo/ExpoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/expo/ExpoRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.school_of_company.data.repository.expo
 
 import com.school_of_company.model.entity.expo.ExpoIdResponseEntity
 import com.school_of_company.model.entity.expo.ExpoListResponseEntity
+import com.school_of_company.model.entity.expo.ExpoSurveyDynamicFormEnabledEntity
 import com.school_of_company.model.model.expo.ExpoRequestAndResponseModel
 import com.school_of_company.model.param.expo.ExpoAllRequestParam
 import com.school_of_company.model.param.expo.ExpoModifyRequestParam
@@ -48,5 +49,11 @@ class ExpoRepositoryImpl @Inject constructor(
 
     override fun deleteExpoInformation(expoId: String): Flow<Unit> {
         return dataSource.deleteExpoInformation(expoId = expoId)
+    }
+
+    override fun checkExpoSurveyDynamicFormEnable(expoId: String): Flow<ExpoSurveyDynamicFormEnabledEntity> {
+        return dataSource.checkExpoSurveyDynamicFormEnable(expoId = expoId).transform { response ->
+            emit(response.toEntity())
+        }
     }
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/expo/ExpoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/expo/ExpoRepositoryImpl.kt
@@ -51,8 +51,8 @@ class ExpoRepositoryImpl @Inject constructor(
         return dataSource.deleteExpoInformation(expoId = expoId)
     }
 
-    override fun checkExpoSurveyDynamicFormEnable(expoId: String): Flow<ExpoSurveyDynamicFormEnabledEntity> {
-        return dataSource.checkExpoSurveyDynamicFormEnable(expoId = expoId).transform { response ->
+    override fun checkExpoSurveyDynamicFormEnable(): Flow<ExpoSurveyDynamicFormEnabledEntity> {
+        return dataSource.checkExpoSurveyDynamicFormEnable().transform { response ->
             emit(response.toEntity())
         }
     }

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/expo/CheckExpoSurveyDynamicFormEnableUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/expo/CheckExpoSurveyDynamicFormEnableUseCase.kt
@@ -1,0 +1,13 @@
+package com.school_of_company.domain.usecase.expo
+
+import com.school_of_company.data.repository.expo.ExpoRepository
+import com.school_of_company.model.entity.expo.ExpoSurveyDynamicFormEnabledEntity
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class CheckExpoSurveyDynamicFormEnableUseCase @Inject constructor(
+    private val repository: ExpoRepository
+) {
+    operator fun invoke(expoId: String): Flow<ExpoSurveyDynamicFormEnabledEntity> =
+        repository.checkExpoSurveyDynamicFormEnable(expoId = expoId)
+}

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/expo/CheckExpoSurveyDynamicFormEnableUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/expo/CheckExpoSurveyDynamicFormEnableUseCase.kt
@@ -8,6 +8,6 @@ import javax.inject.Inject
 class CheckExpoSurveyDynamicFormEnableUseCase @Inject constructor(
     private val repository: ExpoRepository
 ) {
-    operator fun invoke(expoId: String): Flow<ExpoSurveyDynamicFormEnabledEntity> =
-        repository.checkExpoSurveyDynamicFormEnable(expoId = expoId)
+    operator fun invoke(): Flow<ExpoSurveyDynamicFormEnabledEntity> =
+        repository.checkExpoSurveyDynamicFormEnable()
 }

--- a/core/model/src/main/java/com/school_of_company/model/entity/expo/ExpoSurveyDynamicFormEnabledEntity.kt
+++ b/core/model/src/main/java/com/school_of_company/model/entity/expo/ExpoSurveyDynamicFormEnabledEntity.kt
@@ -1,13 +1,13 @@
 package com.school_of_company.model.entity.expo
 
 data class ExpoSurveyDynamicFormEnabledEntity(
-    val expoValid: List<ExpoValidityEntity>
+    val expoValid: List<ExpoValidityEntity>,
 )
 
 data class ExpoValidityEntity(
-    val expoId: String,
+    val expoId: Long,
     val standardFormCreatedStatus: Boolean,
     val traineeFormCreatedStatus: Boolean,
     val standardSurveyCreatedStatus: Boolean,
-    val traineeSurveyCreatedStatus: Boolean
+    val traineeSurveyCreatedStatus: Boolean,
 )

--- a/core/model/src/main/java/com/school_of_company/model/entity/expo/ExpoSurveyDynamicFormEnabledEntity.kt
+++ b/core/model/src/main/java/com/school_of_company/model/entity/expo/ExpoSurveyDynamicFormEnabledEntity.kt
@@ -5,7 +5,7 @@ data class ExpoSurveyDynamicFormEnabledEntity(
 )
 
 data class ExpoValidityEntity(
-    val expoId: Long,
+    val expoId: String,
     val standardFormCreatedStatus: Boolean,
     val traineeFormCreatedStatus: Boolean,
     val standardSurveyCreatedStatus: Boolean,

--- a/core/model/src/main/java/com/school_of_company/model/entity/expo/ExpoSurveyDynamicFormEnabledEntity.kt
+++ b/core/model/src/main/java/com/school_of_company/model/entity/expo/ExpoSurveyDynamicFormEnabledEntity.kt
@@ -1,0 +1,13 @@
+package com.school_of_company.model.entity.expo
+
+data class ExpoSurveyDynamicFormEnabledEntity(
+    val expoValid: List<ExpoValidityEntity>
+)
+
+data class ExpoValidityEntity(
+    val expoId: Long,
+    val standardFormCreatedStatus: Boolean,
+    val traineeFormCreatedStatus: Boolean,
+    val standardSurveyCreatedStatus: Boolean,
+    val traineeSurveyCreatedStatus: Boolean
+)

--- a/core/network/src/main/java/com/school_of_company/network/api/ExpoAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/ExpoAPI.kt
@@ -5,6 +5,7 @@ import com.school_of_company.network.dto.expo.request.ExpoModifyRequest
 import com.school_of_company.network.dto.expo.response.ExpoResponse
 import com.school_of_company.network.dto.expo.response.ExpoIdResponse
 import com.school_of_company.network.dto.expo.response.ExpoListResponse
+import com.school_of_company.network.dto.expo.response.ExpoSurveyDynamicFormEnabledResponse
 import retrofit2.http.*
 
 interface ExpoAPI {
@@ -32,4 +33,9 @@ interface ExpoAPI {
     suspend fun deleteExpoInformation(
         @Path("expo_id") expoId: String
     )
+
+    @GET("/valid/{expo_id}")
+    suspend fun checkExpoSurveyDynamicFormEnable(
+        @Path("expo_id") expoId: String
+    ) : ExpoSurveyDynamicFormEnabledResponse
 }

--- a/core/network/src/main/java/com/school_of_company/network/api/ExpoAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/ExpoAPI.kt
@@ -34,6 +34,6 @@ interface ExpoAPI {
         @Path("expo_id") expoId: String
     )
 
-    @GET("/valid")
+    @GET("/expo/valid")
     suspend fun checkExpoSurveyDynamicFormEnable() : ExpoSurveyDynamicFormEnabledResponse
 }

--- a/core/network/src/main/java/com/school_of_company/network/api/ExpoAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/ExpoAPI.kt
@@ -34,8 +34,6 @@ interface ExpoAPI {
         @Path("expo_id") expoId: String
     )
 
-    @GET("/valid/{expo_id}")
-    suspend fun checkExpoSurveyDynamicFormEnable(
-        @Path("expo_id") expoId: String
-    ) : ExpoSurveyDynamicFormEnabledResponse
+    @GET("/valid")
+    suspend fun checkExpoSurveyDynamicFormEnable() : ExpoSurveyDynamicFormEnabledResponse
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/expo/ExpoDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/expo/ExpoDataSource.kt
@@ -5,6 +5,7 @@ import com.school_of_company.network.dto.expo.request.ExpoModifyRequest
 import com.school_of_company.network.dto.expo.response.ExpoResponse
 import com.school_of_company.network.dto.expo.response.ExpoIdResponse
 import com.school_of_company.network.dto.expo.response.ExpoListResponse
+import com.school_of_company.network.dto.expo.response.ExpoSurveyDynamicFormEnabledResponse
 import kotlinx.coroutines.flow.Flow
 
 interface ExpoDataSource {
@@ -13,4 +14,5 @@ interface ExpoDataSource {
     fun registerExpoInformation(body: ExpoAllRequest) : Flow<ExpoIdResponse>
     fun modifyExpoInformation(expoId: String, body: ExpoModifyRequest) : Flow<Unit>
     fun deleteExpoInformation(expoId: String) : Flow<Unit>
+    fun checkExpoSurveyDynamicFormEnable(expoId: String) : Flow<ExpoSurveyDynamicFormEnabledResponse>
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/expo/ExpoDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/expo/ExpoDataSource.kt
@@ -14,5 +14,5 @@ interface ExpoDataSource {
     fun registerExpoInformation(body: ExpoAllRequest) : Flow<ExpoIdResponse>
     fun modifyExpoInformation(expoId: String, body: ExpoModifyRequest) : Flow<Unit>
     fun deleteExpoInformation(expoId: String) : Flow<Unit>
-    fun checkExpoSurveyDynamicFormEnable(expoId: String) : Flow<ExpoSurveyDynamicFormEnabledResponse>
+    fun checkExpoSurveyDynamicFormEnable() : Flow<ExpoSurveyDynamicFormEnabledResponse>
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/expo/ExpoDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/expo/ExpoDataSourceImpl.kt
@@ -32,6 +32,6 @@ class ExpoDataSourceImpl @Inject constructor(
     override fun deleteExpoInformation(expoId: String): Flow<Unit> =
         performApiRequest { service.deleteExpoInformation(expoId = expoId) }
 
-    override fun checkExpoSurveyDynamicFormEnable(expoId: String): Flow<ExpoSurveyDynamicFormEnabledResponse> =
-        performApiRequest { service.checkExpoSurveyDynamicFormEnable(expoId = expoId) }
+    override fun checkExpoSurveyDynamicFormEnable(): Flow<ExpoSurveyDynamicFormEnabledResponse> =
+        performApiRequest { service.checkExpoSurveyDynamicFormEnable() }
 }

--- a/core/network/src/main/java/com/school_of_company/network/datasource/expo/ExpoDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/expo/ExpoDataSourceImpl.kt
@@ -6,6 +6,7 @@ import com.school_of_company.network.dto.expo.request.ExpoModifyRequest
 import com.school_of_company.network.dto.expo.response.ExpoResponse
 import com.school_of_company.network.dto.expo.response.ExpoIdResponse
 import com.school_of_company.network.dto.expo.response.ExpoListResponse
+import com.school_of_company.network.dto.expo.response.ExpoSurveyDynamicFormEnabledResponse
 import com.school_of_company.network.util.performApiRequest
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
@@ -30,4 +31,7 @@ class ExpoDataSourceImpl @Inject constructor(
 
     override fun deleteExpoInformation(expoId: String): Flow<Unit> =
         performApiRequest { service.deleteExpoInformation(expoId = expoId) }
+
+    override fun checkExpoSurveyDynamicFormEnable(expoId: String): Flow<ExpoSurveyDynamicFormEnabledResponse> =
+        performApiRequest { service.checkExpoSurveyDynamicFormEnable(expoId = expoId) }
 }

--- a/core/network/src/main/java/com/school_of_company/network/dto/expo/response/ExpoSurveyDynamicFormEnabledResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/expo/response/ExpoSurveyDynamicFormEnabledResponse.kt
@@ -13,6 +13,6 @@ data class ExpoValidityResponse(
     @Json(name = "expoId") val expoId: String,
     @Json(name = "standardFormCreatedStatus") val standardFormCreatedStatus: Boolean,
     @Json(name = "traineeFormCreatedStatus") val traineeFormCreatedStatus: Boolean,
-    @Json(name = "StandardSurveyCreatedStatus") val standardSurveyCreatedStatus: Boolean,
+    @Json(name = "standardSurveyCreatedStatus") val standardSurveyCreatedStatus: Boolean,
     @Json(name = "traineeSurveyCreatedStatus") val traineeSurveyCreatedStatus: Boolean
 )

--- a/core/network/src/main/java/com/school_of_company/network/dto/expo/response/ExpoSurveyDynamicFormEnabledResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/expo/response/ExpoSurveyDynamicFormEnabledResponse.kt
@@ -5,14 +5,14 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class ExpoSurveyDynamicFormEnabledResponse(
-    @Json(name = "expoValid") val expoValid: List<ExpoValidityResponse>
+    @Json(name = "expoValid") val expoValid: List<ExpoValidityResponse>,
 )
 
 @JsonClass(generateAdapter = true)
 data class ExpoValidityResponse(
-    @Json(name = "expoId") val expoId: String,
+    @Json(name = "expoId") val expoId: Long,
     @Json(name = "standardFormCreatedStatus") val standardFormCreatedStatus: Boolean,
     @Json(name = "traineeFormCreatedStatus") val traineeFormCreatedStatus: Boolean,
     @Json(name = "standardSurveyCreatedStatus") val standardSurveyCreatedStatus: Boolean,
-    @Json(name = "traineeSurveyCreatedStatus") val traineeSurveyCreatedStatus: Boolean
+    @Json(name = "traineeSurveyCreatedStatus") val traineeSurveyCreatedStatus: Boolean,
 )

--- a/core/network/src/main/java/com/school_of_company/network/dto/expo/response/ExpoSurveyDynamicFormEnabledResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/expo/response/ExpoSurveyDynamicFormEnabledResponse.kt
@@ -10,7 +10,7 @@ data class ExpoSurveyDynamicFormEnabledResponse(
 
 @JsonClass(generateAdapter = true)
 data class ExpoValidityResponse(
-    @Json(name = "expoId") val expoId: Long,
+    @Json(name = "expoId") val expoId: String,
     @Json(name = "standardFormCreatedStatus") val standardFormCreatedStatus: Boolean,
     @Json(name = "traineeFormCreatedStatus") val traineeFormCreatedStatus: Boolean,
     @Json(name = "StandardSurveyCreatedStatus") val standardSurveyCreatedStatus: Boolean,

--- a/core/network/src/main/java/com/school_of_company/network/dto/expo/response/ExpoSurveyDynamicFormEnabledResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/expo/response/ExpoSurveyDynamicFormEnabledResponse.kt
@@ -1,0 +1,18 @@
+package com.school_of_company.network.dto.expo.response
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ExpoSurveyDynamicFormEnabledResponse(
+    @Json(name = "expoValid") val expoValid: List<ExpoValidityResponse>
+)
+
+@JsonClass(generateAdapter = true)
+data class ExpoValidityResponse(
+    @Json(name = "expoId") val expoId: Long,
+    @Json(name = "standardFormCreatedStatus") val standardFormCreatedStatus: Boolean,
+    @Json(name = "traineeFormCreatedStatus") val traineeFormCreatedStatus: Boolean,
+    @Json(name = "StandardSurveyCreatedStatus") val standardSurveyCreatedStatus: Boolean,
+    @Json(name = "traineeSurveyCreatedStatus") val traineeSurveyCreatedStatus: Boolean
+)

--- a/core/network/src/main/java/com/school_of_company/network/mapper/expo/response/ExpoSurveyDynamicFormEnabledResponseMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/expo/response/ExpoSurveyDynamicFormEnabledResponseMapper.kt
@@ -1,0 +1,20 @@
+package com.school_of_company.network.mapper.expo.response
+
+import com.school_of_company.model.entity.expo.ExpoSurveyDynamicFormEnabledEntity
+import com.school_of_company.model.entity.expo.ExpoValidityEntity
+import com.school_of_company.network.dto.expo.response.ExpoSurveyDynamicFormEnabledResponse
+import com.school_of_company.network.dto.expo.response.ExpoValidityResponse
+
+fun ExpoSurveyDynamicFormEnabledResponse.toEntity(): ExpoSurveyDynamicFormEnabledEntity =
+    ExpoSurveyDynamicFormEnabledEntity(
+        expoValid = this.expoValid.map { it.toEntity() }
+    )
+
+fun ExpoValidityResponse.toEntity(): ExpoValidityEntity =
+    ExpoValidityEntity(
+        expoId = this.expoId,
+        standardFormCreatedStatus = this.standardFormCreatedStatus,
+        traineeFormCreatedStatus = this.traineeFormCreatedStatus,
+        standardSurveyCreatedStatus = this.standardSurveyCreatedStatus,
+        traineeSurveyCreatedStatus = this.traineeSurveyCreatedStatus
+    )

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/CheckExpoSurveyDynamicFormEnableUiState.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/CheckExpoSurveyDynamicFormEnableUiState.kt
@@ -1,0 +1,9 @@
+package com.school_of_company.expo.viewmodel.uistate
+
+import com.school_of_company.model.entity.expo.ExpoSurveyDynamicFormEnabledEntity
+
+sealed interface CheckExpoSurveyDynamicFormEnableUiState {
+    object Loading : CheckExpoSurveyDynamicFormEnableUiState
+    data class Success(val data: ExpoSurveyDynamicFormEnabledEntity) : CheckExpoSurveyDynamicFormEnableUiState
+    data class Error(val exception: Throwable) : CheckExpoSurveyDynamicFormEnableUiState
+}


### PR DESCRIPTION
## 💡 개요
- 박람회 동적폼, 만족도 조사 생성 여부 API가 추가되어 이를 반영할 필요가 있었습니다.
## 📃 작업내용
- 박람회 동적폼, 만족도 조사 생성 여부 네트워크 세팅을 하였습니다.
   - dto, entity, mapper 추가
   - api 반영
   - dataSource(Impl) 반영
   - repository(Impl) 반영
   - useCase 추가
   - uiState 추가
## 🔀 변경사항
<img width="739" alt="스크린샷 2025-04-11 오전 7 52 15" src="https://github.com/user-attachments/assets/b4774a99-357c-4862-aadf-e141ecfdf27b" />

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 전시회 관련 설문 동적 양식 활성화 상태를 확인할 수 있는 기능이 추가되었습니다.
  - 서버와 연동되어 실시간으로 설문 양식 활성화 여부가 업데이트되며, 사용자 인터페이스에서 로딩, 성공, 오류 상태를 명확하게 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->