### PR TITLE
🔀 :: (#528) - 동적폼 생성화면에 개인정보 동의문장 입력칸을 추가했습니다

### DIFF
--- a/core/model/src/main/java/com/school_of_company/model/model/form/FormRequestAndResponseModel.kt
+++ b/core/model/src/main/java/com/school_of_company/model/model/form/FormRequestAndResponseModel.kt
@@ -1,6 +1,7 @@
 package com.school_of_company.model.model.form
 
 data class FormRequestAndResponseModel(
+    val informationText: String,
     val participantType: String, // TRAINEE, STANDARD
     val dynamicForm: List<DynamicFormModel>,
 )

--- a/core/network/src/main/java/com/school_of_company/network/dto/form/all/FormRequestAndResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/form/all/FormRequestAndResponse.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class FormRequestAndResponse(
-    @Json(name = "informationText") val informationText: String = "",
+    @Json(name = "informationText") val informationText: String,
     @Json(name = "participantType") val participantType: String, // TRAINEE, STANDARD
     @Json(name = "dynamicForm") val dynamicForm: List<DynamicForm>
 )

--- a/core/network/src/main/java/com/school_of_company/network/dto/form/all/FormRequestAndResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/form/all/FormRequestAndResponse.kt
@@ -5,7 +5,7 @@ import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
 data class FormRequestAndResponse(
-    @Json(name = "informationImage") val informationImage: String = "",
+    @Json(name = "informationText") val informationText: String = "",
     @Json(name = "participantType") val participantType: String, // TRAINEE, STANDARD
     @Json(name = "dynamicForm") val dynamicForm: List<DynamicForm>
 )

--- a/core/network/src/main/java/com/school_of_company/network/mapper/form/request/FormRequestMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/form/request/FormRequestMapper.kt
@@ -8,8 +8,9 @@ import com.school_of_company.network.util.convertListToJsonMap
 
 fun FormRequestAndResponseModel.toModel(): FormRequestAndResponse =
     FormRequestAndResponse(
-        participantType = this.participantType,
-        dynamicForm = this.dynamicForm.map { it.toModel() }
+        informationText = informationText,
+        participantType = participantType,
+        dynamicForm = dynamicForm.map { it.toModel() }
     )
 
 fun DynamicFormModel.toModel(): DynamicForm =

--- a/core/network/src/main/java/com/school_of_company/network/mapper/form/request/FormRequestMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/form/request/FormRequestMapper.kt
@@ -8,9 +8,9 @@ import com.school_of_company.network.util.convertListToJsonMap
 
 fun FormRequestAndResponseModel.toModel(): FormRequestAndResponse =
     FormRequestAndResponse(
-        informationText = informationText,
-        participantType = participantType,
-        dynamicForm = dynamicForm.map { it.toModel() }
+        informationText = this.informationText,
+        participantType = this.participantType,
+        dynamicForm = this.dynamicForm.map { it.toModel() }
     )
 
 fun DynamicFormModel.toModel(): DynamicForm =

--- a/core/network/src/main/java/com/school_of_company/network/mapper/form/response/FormResponseMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/form/response/FormResponseMapper.kt
@@ -8,7 +8,7 @@ import com.school_of_company.network.util.convertJsonMapToList
 
 fun FormRequestAndResponse.toModel(): FormRequestAndResponseModel =
     FormRequestAndResponseModel(
-        informationText = informationText,
+        informationText = this.informationText,
         participantType = this.participantType,
         dynamicForm = this.dynamicForm.map { it.toModel() }
     )

--- a/core/network/src/main/java/com/school_of_company/network/mapper/form/response/FormResponseMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/form/response/FormResponseMapper.kt
@@ -8,6 +8,7 @@ import com.school_of_company.network.util.convertJsonMapToList
 
 fun FormRequestAndResponse.toModel(): FormRequestAndResponseModel =
     FormRequestAndResponseModel(
+        informationText = informationText,
         participantType = this.participantType,
         dynamicForm = this.dynamicForm.map { it.toModel() }
     )

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
@@ -33,6 +33,7 @@ import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.form.enum.FormType
 import com.school_of_company.form.view.component.FormAddButton
 import com.school_of_company.form.view.component.FormCard
+import com.school_of_company.form.view.component.PersonaInformationFormCard
 import com.school_of_company.form.viewModel.FormViewModel
 import com.school_of_company.form.viewModel.uiState.FormUiState
 import com.school_of_company.model.model.form.DynamicFormModel
@@ -48,6 +49,7 @@ internal fun FormCreateRoute(
 ) {
     val formState by viewModel.formState.collectAsStateWithLifecycle()
     val formUiState by viewModel.formUiState.collectAsStateWithLifecycle()
+    val informationTextState by viewModel.informationTextState.collectAsStateWithLifecycle()
 
     LaunchedEffect(formUiState) {
         when (formUiState) {
@@ -56,6 +58,7 @@ internal fun FormCreateRoute(
                 popUpBackStack()
                 onErrorToast(null, R.string.form_create_success)
             }
+
             is FormUiState.Error -> {
                 onErrorToast(null, R.string.form_create_fail)
             }
@@ -64,11 +67,13 @@ internal fun FormCreateRoute(
 
     FormCreateScreen(
         modifier = modifier,
+        informationTextState = informationTextState,
         formList = formState,
         popUpBackStack = popUpBackStack,
         addFormAtList = viewModel::addEmptyDynamicFormItem,
-        createForm = { viewModel.createForm(expoId, participantType) },
+        createForm = { viewModel.createForm(expoId, participantType, informationTextState) },
         deleteForm = viewModel::removeDynamicFormItem,
+        onInformationTextStateChange = viewModel::setInformationTextState,
         onFormDataChange = viewModel::updateDynamicFormItem
     )
 }
@@ -76,6 +81,7 @@ internal fun FormCreateRoute(
 @Composable
 private fun FormCreateScreen(
     modifier: Modifier = Modifier,
+    informationTextState: String,
     formList: List<DynamicFormModel>,
     focusManager: FocusManager = LocalFocusManager.current,
     scrollState: ScrollState = rememberScrollState(),
@@ -83,6 +89,7 @@ private fun FormCreateScreen(
     addFormAtList: () -> Unit,
     createForm: () -> Unit,
     deleteForm: (Int) -> Unit,
+    onInformationTextStateChange: (String) -> Unit,
     onFormDataChange: (Int, DynamicFormModel) -> Unit,
 ) {
     ExpoAndroidTheme { colors, _ ->
@@ -124,6 +131,11 @@ private fun FormCreateScreen(
                     )
                 }
 
+                PersonaInformationFormCard(
+                    value = informationTextState,
+                    onTextChange = onInformationTextStateChange
+                )
+
                 FormAddButton(onClick = addFormAtList)
             }
 
@@ -148,10 +160,7 @@ private fun FormCreateScreen(
 @Composable
 private fun FormCreateScreenPreview() {
     FormCreateScreen(
-        addFormAtList = { },
-        onFormDataChange = { _, _ -> },
-        createForm = {},
-        deleteForm = { _ -> },
+        informationTextState = "informationTextState",
         formList = listOf(
             DynamicFormModel(
                 title = "제목",
@@ -169,5 +178,10 @@ private fun FormCreateScreenPreview() {
             ),
         ),
         popUpBackStack = {},
+        addFormAtList = { },
+        createForm = {},
+        deleteForm = { _ -> },
+        onFormDataChange = { _, _ -> },
+        onInformationTextStateChange = { _ -> },
     )
 }

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormModifyScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormModifyScreen.kt
@@ -48,6 +48,7 @@ internal fun FormModifyRoute(
 ) {
     val formState by viewModel.formState.collectAsStateWithLifecycle()
     val formActionUiState by viewModel.formUiState.collectAsStateWithLifecycle()
+    val informationTextState by viewModel.informationTextState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
         viewModel.getForm(
@@ -71,6 +72,7 @@ internal fun FormModifyRoute(
 
     FormModifyScreen(
         modifier = modifier,
+        informationTextState = informationTextState,
         formList = formState,
         popUpBackStack = popUpBackStack,
         addFormAtList = viewModel::addEmptyDynamicFormItem,
@@ -78,9 +80,11 @@ internal fun FormModifyRoute(
             viewModel.modifyForm(
                 expoId,
                 participantType,
+                informationTextState,
             )
         },
         deleteForm = viewModel::removeDynamicFormItem,
+        onInformationTextStateChange = viewModel::setInformationTextState,
         onFormDataChange = viewModel::updateDynamicFormItem
     )
 }
@@ -88,6 +92,7 @@ internal fun FormModifyRoute(
 @Composable
 private fun FormModifyScreen(
     modifier: Modifier = Modifier,
+    informationTextState: String,
     formList: List<DynamicFormModel>,
     focusManager: FocusManager = LocalFocusManager.current,
     scrollState: ScrollState = rememberScrollState(),
@@ -95,6 +100,7 @@ private fun FormModifyScreen(
     addFormAtList: () -> Unit,
     submitForm: () -> Unit,
     deleteForm: (Int) -> Unit,
+    onInformationTextStateChange: (String) -> Unit,
     onFormDataChange: (Int, DynamicFormModel) -> Unit,
 ) {
     ExpoAndroidTheme { colors, _ ->
@@ -181,5 +187,7 @@ private fun FormModifyScreenPreview() {
         submitForm = {},
         deleteForm = { _ -> },
         onFormDataChange = { _, _ -> },
+        onInformationTextStateChange = { _ -> },
+        informationTextState = "",
     )
 }

--- a/feature/form/src/main/java/com/school_of_company/form/view/component/PersonaInformationFormCard.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/component/PersonaInformationFormCard.kt
@@ -45,7 +45,7 @@ internal fun PersonaInformationFormCard(
             verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically),
         ) {
             Text(
-                text = "개인정보 동의 안내 문장을 입력하세요.",
+                text = "개인정보 동의 안내 문장을 입력해주세요.",
                 style = typography.titleBold3,
                 fontWeight = FontWeight.W600,
                 color = colors.black,

--- a/feature/form/src/main/java/com/school_of_company/form/view/component/PersonaInformationFormCard.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/component/PersonaInformationFormCard.kt
@@ -31,6 +31,7 @@ internal fun PersonaInformationFormCard(
 ) {
     ExpoAndroidTheme { colors, typography ->
         Column(
+            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically),
             modifier = modifier
                 .border(
                     width = 1.dp,
@@ -42,7 +43,6 @@ internal fun PersonaInformationFormCard(
                     shape = RoundedCornerShape(size = 6.dp),
                 )
                 .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically),
         ) {
             Text(
                 text = "개인정보 동의 안내 문장을 입력해주세요.",

--- a/feature/form/src/main/java/com/school_of_company/form/view/component/PersonaInformationFormCard.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/component/PersonaInformationFormCard.kt
@@ -1,0 +1,82 @@
+package com.school_of_company.form.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.component.textfield.TransparentTextField
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+internal fun PersonaInformationFormCard(
+    modifier: Modifier = Modifier,
+    value: String,
+    onTextChange: (String) -> Unit,
+) {
+    ExpoAndroidTheme { colors, typography ->
+        Column(
+            modifier = modifier
+                .border(
+                    width = 1.dp,
+                    color = colors.gray200,
+                    shape = RoundedCornerShape(size = 6.dp),
+                )
+                .background(
+                    color = colors.white,
+                    shape = RoundedCornerShape(size = 6.dp),
+                )
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp, Alignment.CenterVertically),
+        ) {
+            Text(
+                text = "개인정보 동의 안내 문장을 입력하세요.",
+                style = typography.titleBold3,
+                fontWeight = FontWeight.W600,
+                color = colors.black,
+            )
+
+            Spacer(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(colors.gray100),
+            )
+
+            TransparentTextField(
+                placeholder = "문장을 입력해주세요",
+                value = value,
+                textStyle = typography.bodyRegular2,
+                placeholderTextStyle = typography.captionBold2.copy(color = colors.gray500),
+                updateTextValue = onTextChange
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PersonaInformationFormCardPreview() {
+    var value by remember { mutableStateOf("") }
+
+    PersonaInformationFormCard(
+        modifier = Modifier,
+        value = value,
+        onTextChange = { newValue -> value = newValue },
+    )
+}

--- a/feature/form/src/main/java/com/school_of_company/form/viewModel/FormViewModel.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/viewModel/FormViewModel.kt
@@ -28,6 +28,9 @@ internal class FormViewModel @Inject constructor(
     private val _formState = MutableStateFlow<List<DynamicFormModel>>(listOf(DynamicFormModel.createDefault()))
     internal val formState = _formState.asStateFlow()
 
+    private val _informationTextState = MutableStateFlow("")
+    internal val informationTextState = _informationTextState.asStateFlow()
+
     private val _formUiState = MutableStateFlow<FormUiState>(FormUiState.Loading)
     internal val formUiState = _formUiState.asStateFlow()
 
@@ -37,13 +40,15 @@ internal class FormViewModel @Inject constructor(
     internal fun createForm(
         expoId: String,
         participantType: String,
+        informationText: String,
     ) = viewModelScope.launch {
         _formUiState.value = FormUiState.Loading
         createFormUseCase(
             expoId = expoId,
             body = FormRequestAndResponseModel(
                 participantType = participantType,
-                dynamicForm = _formState.value
+                dynamicForm = _formState.value,
+                informationText = informationText
             ),
         )
             .onSuccess {
@@ -61,13 +66,15 @@ internal class FormViewModel @Inject constructor(
     internal fun modifyForm(
         expoId: String,
         participantType: String,
+        informationText: String,
     ) = viewModelScope.launch {
         _formUiState.value = FormUiState.Loading
         modifyFormUseCase(
             expoId = expoId,
             body = FormRequestAndResponseModel(
                 participantType = participantType,
-                dynamicForm = _formState.value
+                dynamicForm = _formState.value,
+                informationText = informationText
             ),
         )
             .onSuccess {
@@ -98,6 +105,7 @@ internal class FormViewModel @Inject constructor(
                     is Result.Success -> with(result.data) {
                         _getFormUiState.value = GetFormUiState.Success
                         _formState.value = dynamicForm
+                        _informationTextState.value = informationText
                     }
                     is Result.Error -> _getFormUiState.value = GetFormUiState.Error(result.exception)
                 }
@@ -122,5 +130,9 @@ internal class FormViewModel @Inject constructor(
 
     internal fun addEmptyDynamicFormItem() {
         _formState.value += DynamicFormModel.createDefault()
+    }
+
+    internal fun setInformationTextState(value: String) {
+        _informationTextState.value = value
     }
 }


### PR DESCRIPTION
## 💡 개요

동적폼 생성화면에 개인정보 동의문장 입력칸을 추가했습니다

![](https://cdn.discordapp.com/attachments/1291808784922185789/1359863862211379423/image.png?ex=67f90769&is=67f7b5e9&hm=40961bb62a2d712b94261d901ecc3ebceebff1d4421a6f8cc8026d23fe4ec064&)


![](https://cdn.discordapp.com/attachments/1291808784922185789/1359863862458847434/image.png?ex=67f90769&is=67f7b5e9&hm=d2037f098ba6bc1b5303f4930f8134e337811a5509614c198a0af2f0d852e999&)


## 📃 작업내용

PersonaInformationFormCard 퍼블리싱
form 생성, 수정 명세서 변경에 따라 model, dto, mapper 수정
폼 생성, 수정 screen에 PersonaInformationFormCard 를 적용하고 생성, 수정 함수에 informationText 적용

## 🔀 변경사항

FormRequestAndResponse
FormRequestAndResponseModel
modifyForm
createForm 
에 명세서 변경에 따라서 informationText를 추가했습니다

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 양식 작성 및 수정 시 추가 정보를 입력할 수 있는 "정보 텍스트" 필드가 도입되었습니다.
  - 새로운 인터페이스 컴포넌트를 통해 사용자에게 직관적인 추가 정보 입력 환경이 제공됩니다.
  - 입력된 정보는 양식 전송 과정에 반영되어 사용자 경험이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->