### PR TITLE
🔀 :: (#532) - 폼 생성 및 수정 화면에 디자인과 다른 부분이 있어 수정하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -178,7 +178,6 @@ private fun ExpoDetailScreen(
 
                     Spacer(modifier = Modifier.height(28.dp))
 
-
                     Column(modifier = Modifier.verticalScroll(scrollState)) {
                         if (getExpoInformationUiState.data.coverImage != null) {
                             Image(

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.button.ExpoButton
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
+import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
 import com.school_of_company.design_system.icon.LeftArrowIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
@@ -95,10 +96,10 @@ private fun FormCreateScreen(
     ExpoAndroidTheme { colors, _ ->
         Column(
             modifier = modifier
-                .verticalScroll(scrollState)
                 .fillMaxSize()
+                .verticalScroll(scrollState)
                 .background(color = colors.white)
-                .padding(16.dp)
+                .padding(horizontal = 16.dp,)
                 .pointerInput(Unit) {
                     detectTapGestures(
                         onTap = {
@@ -115,7 +116,10 @@ private fun FormCreateScreen(
                     )
                 },
                 betweenText = "신정차 폼",
-                modifier = Modifier.padding(vertical = 16.dp),
+                modifier = Modifier.padding(
+                    top = 68.dp,
+                    bottom = 16.dp
+                ),
             )
 
             Column(
@@ -150,8 +154,9 @@ private fun FormCreateScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(46.dp)
-                    .padding(vertical = 12.dp),
             )
+
+            Spacer(modifier = Modifier.padding(bottom = 28.dp))
         }
     }
 }
@@ -162,13 +167,6 @@ private fun FormCreateScreenPreview() {
     FormCreateScreen(
         informationTextState = "informationTextState",
         formList = listOf(
-            DynamicFormModel(
-                title = "제목",
-                formType = FormType.DROPDOWN.name,
-                itemList = listOf("예시", "예시 1"),
-                requiredStatus = true,
-                otherJson = true,
-            ),
             DynamicFormModel(
                 title = "제목",
                 formType = FormType.DROPDOWN.name,

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormModifyScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormModifyScreen.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.button.ExpoButton
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
+import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
 import com.school_of_company.design_system.icon.LeftArrowIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
@@ -106,10 +107,10 @@ private fun FormModifyScreen(
     ExpoAndroidTheme { colors, _ ->
         Column(
             modifier = modifier
-                .verticalScroll(scrollState)
                 .fillMaxSize()
+                .verticalScroll(scrollState)
                 .background(color = colors.white)
-                .padding(16.dp)
+                .padding(horizontal = 16.dp,)
                 .pointerInput(Unit) {
                     detectTapGestures(
                         onTap = {
@@ -126,7 +127,10 @@ private fun FormModifyScreen(
                     )
                 },
                 betweenText = "폼 수정하기",
-                modifier = Modifier.padding(vertical = 16.dp),
+                modifier = Modifier.padding(
+                    top = 68.dp,
+                    bottom = 16.dp
+                ),
             )
 
             Column(
@@ -156,8 +160,9 @@ private fun FormModifyScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(46.dp)
-                    .padding(vertical = 12.dp),
             )
+
+            Spacer(modifier = Modifier.padding(bottom = 28.dp))
         }
     }
 }


### PR DESCRIPTION
## 💡 개요
- 폼 생성 및 수정 화면에 디자인과 다른 부분이 있어 수정이 필요했습니다.
## 🔀 변경사항
- 폼 생성 및 수정 화면에 디자인과 다른 부분이 있어 수정하였습니다.
   - 탑바의 top padding의 간격을 68.dp로 다른 화면과 동일하게 처리하였습니다.
   - before
       <img width="265" alt="스크린샷 2025-04-11 오후 2 28 39" src="https://github.com/user-attachments/assets/2cbf7c68-6267-458e-b223-a1939b6e6032" />

   - after
     <img width="270" alt="스크린샷 2025-04-11 오후 2 29 10" src="https://github.com/user-attachments/assets/5a889860-4aa6-4e10-bbca-fa58613795d0" />

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **스타일**
	- Expo 상세 화면의 불필요한 공백 제거로 더욱 깔끔한 레이아웃 구현.
	- 폼 생성 화면에서 스크롤 순서 및 패딩 조정을 통해 인터페이스 배치가 최적화됨.
	- 폼 수정 화면에서도 간격 및 패딩 수정으로 일관된 시각적 구성을 제공함.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->