### PR TITLE
🔀 :: (#538) - 앱에서 X, Y 좌표를 서로 반대되게 생성하고 및 변환을 하고 있는 문제를 해결하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoAddressSearchScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoAddressSearchScreen.kt
@@ -96,8 +96,8 @@ internal fun ExpoAddressSearchRoute(
     ExpoAddressSearchScreen(
         modifier = modifier,
         location = location,
-        coordinateX = coordinateX,
-        coordinateY = coordinateY,
+        coordinateX = coordinateY,
+        coordinateY = coordinateX,
         addressList = addressList,
         popUpBackStack = popUpBackStack,
         onLocationSearch = { viewModel.searchLocation(location) },

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -144,8 +144,8 @@ internal fun ExpoCreateRoute(
                         description = viewModel.introduce_title.value,
                         location = viewModel.location.value,
                         coverImage = (imageUpLoadUiState as ImageUpLoadUiState.Success).data.imageURL,
-                        x = viewModel.coordinateX.value,
-                        y = viewModel.coordinateY.value,
+                        x = viewModel.coordinateY.value,
+                        y = viewModel.coordinateX.value,
                         addStandardProRequestDto = standardProgramTextState,
                         addTrainingProRequestDto = trainingProgramTextState
                     )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -150,8 +150,8 @@ internal fun ExpoModifyRoute(
                         description = viewModel.introduce_title.value,
                         location = viewModel.location.value,
                         coverImage = (imageUpLoadUiState as ImageUpLoadUiState.Success).data.imageURL,
-                        x = viewModel.coordinateX.value,
-                        y = viewModel.coordinateY.value,
+                        x = viewModel.coordinateY.value,
+                        y = viewModel.coordinateX.value,
                         updateStandardProRequestDto = standardProgramTextState,
                         updateTrainingProRequestDto = trainingProgramTextState
                     )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoKakaoMapComponent.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoKakaoMapComponent.kt
@@ -29,11 +29,10 @@ internal fun HomeKakaoMap(
     val context = LocalContext.current
     val mapView = remember { MapView(context) }
     val fixedLatLng = remember {
-        // 고정 라벨 위치 (예: 특정 x, y 좌표)
         LatLng.from(
-            locationY,
-            locationX
-        ) // 고정 좌표 설정
+            locationX,
+            locationY
+        )
     }
 
     AndroidView(

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -227,8 +227,8 @@ internal class ExpoViewModel @Inject constructor(
                                 setSearchedData()
                             } else {
                                 onLocationChange(it.location)
-                                onCoordinateChange(x = it.x, y = it.y)
-                                convertXYToJibun(x = it.x, y = it.y)
+                                onCoordinateChange(x = it.y, y = it.x)
+                                convertXYToJibun(x = it.y, y = it.x)
                             }
                             onCoverImageChange(it.coverImage)
                         }


### PR DESCRIPTION
## 💡 개요
- 앱에서 X, Y 좌표를 서로 반대되게 생성하고 및 변환을 하고 있는 문제가 있었습니다.
## 📃 작업내용
- 앱에서 X, Y 좌표를 서로 반대되게 생성하고 및 변환을 하고 있는 문제를 해결하였습니다.
   - 간단하게 코드에서 X, Y 좌표를 변경해주었습니다.
   - before

       https://github.com/user-attachments/assets/b21cef14-a145-4fd3-b033-c3f6cdc06cc8

   - after
   
       https://github.com/user-attachments/assets/b1bdb385-7b2f-462c-be32-34a18eb11afd

## 🔀 변경사항
<img width="311" alt="스크린샷 2025-04-13 오전 4 53 51" src="https://github.com/user-attachments/assets/dab00a2b-a1f3-48ec-b541-dc06f7ac576d" />

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- 이전 pr이 병합된 이후에 생성시 위도 경도를 반대로 서버로 보내는 문제를 작업하겠습니다. (일단 변환하는쪽 이슈는 해결하였습니다.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 주소 검색, 등록, 수정 및 지도 기능에서 위치 좌표가 올바르게 표시되도록 좌표 전달 순서를 개선했습니다.
	- 이로 인해 위치 기반 서비스의 정확성과 신뢰성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->