### PR TITLE
🔀 :: (#542) - 박람회 관련 화면에서 다자인 변동사항이 있어 수정합니다.

### DIFF
--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -124,7 +124,7 @@
     <string name="cancel">취소</string>
     <string name="filter">필터</string>
     <string name="not_image_description">이미지 없음</string>
-    <string name="register_temp">모집 기간</string>
+    <string name="register_temp">행사 기간</string>
 
     <string name="id_hint">아이디를 입력해주세요.</string>
     <string name="wrong_id">아이디를 잘못 입력하셨습니다.</string>

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -403,7 +403,7 @@ private fun ExpoCreateScreen(
 
                 Row(horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.Start)) {
                     LimitedLengthTextField(
-                        label = "모집기간",
+                        label = "행사 기간",
                         value = startedDateState,
                         lengthLimit = 8,
                         showLengthCounter = false,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -220,7 +220,7 @@ private fun ExpoDetailScreen(
 
                         Column(verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Bottom)) {
                             Text(
-                                text = "모집 기간",
+                                text = "행사 기간",
                                 style = typography.bodyRegular2,
                                 color = colors.gray600,
                                 fontWeight = FontWeight(600),

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -434,7 +434,7 @@ private fun ExpoModifyScreen(
 
                 Row(horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.Start)) {
                     LimitedLengthTextField(
-                        label = "모집기간",
+                        label = "행사 기간",
                         value = startedDateState,
                         lengthLimit = 8,
                         placeholder = "시작일",


### PR DESCRIPTION
## 💡 개요
-  박람회 전체보기 및 자세히 보기 화면에서 다자인 변동사항이 있어 수정이 필요했습니다.
## 📃 작업내용
-  박람회 전체보기 및 자세히 보기 화면에서 다자인 변동사항이 있어 수정합니다.
   - 모집 기간에서 행사 기간으로 디자인이 변경되어 수정하였습니다.
   - before

        https://github.com/user-attachments/assets/25190927-5d39-4c07-9784-71984d93186b

   - after

        https://github.com/user-attachments/assets/2692337b-bfad-43e4-9e07-c3770f144bbc

## 🔀 변경사항
* chore strings.xml(design-system Module Res File)
* chore ExpoDetailScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 사용자 인터페이스에 표시되는 기간 문구가 "모집 기간"에서 "행사 기간"으로 변경되어, 이벤트 관련 정보 전달이 보다 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->