### PR TITLE
🔀 :: (#544) - 폼 생성하기에서 일반 ExpoButton을 사용하여 빈 텍스트여도 요청이 가는 문제를 해결하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoAddressSearchScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoAddressSearchScreen.kt
@@ -217,9 +217,8 @@ private fun ExpoAddressSearchScreen(
                 } else {
                     ButtonState.Disable
                 },
-                modifier = Modifier
-                    .fillMaxWidth(),
-                onClick = popUpBackStack
+                onClick = popUpBackStack,
+                modifier = Modifier.fillMaxWidth()
             )
         }
     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -553,10 +553,9 @@ private fun ExpoCreateScreen(
                         } else {
                             ButtonState.Disable
                         },
+                        onClick = onExpoCreateCallBack,
                         modifier = Modifier.fillMaxWidth(),
-                        onClick = onExpoCreateCallBack
                     )
-
 
                     Spacer(modifier = Modifier.height(48.dp))
                 }

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
@@ -26,6 +26,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.button.ExpoButton
+import com.school_of_company.design_system.component.button.ExpoStateButton
+import com.school_of_company.design_system.component.button.state.ButtonState
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
@@ -147,13 +149,22 @@ private fun FormCreateScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            ExpoButton(
-                text = "다음",
-                color = colors.main,
+            ExpoStateButton(
+                text = "생성 완료",
+                state = if (
+                    informationTextState.isNotEmpty() &&
+                    formList.isNotEmpty() &&
+                    formList.all { form ->
+                        when (FormType.valueOf(form.formType)) {
+                            FormType.SENTENCE -> form.title.isNotEmpty()
+                            FormType.CHECKBOX, FormType.DROPDOWN, FormType.MULTIPLE ->
+                                form.title.isNotEmpty() &&
+                                form.itemList.isNotEmpty() &&
+                                form.itemList.all { it.isNotEmpty() }
+                        }
+                    }) ButtonState.Enable else ButtonState.Disable,
                 onClick = createForm,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(46.dp)
+                modifier = Modifier.fillMaxWidth()
             )
 
             Spacer(modifier = Modifier.padding(bottom = 28.dp))

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormModifyScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormModifyScreen.kt
@@ -26,6 +26,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.button.ExpoButton
+import com.school_of_company.design_system.component.button.ExpoStateButton
+import com.school_of_company.design_system.component.button.state.ButtonState
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
 import com.school_of_company.design_system.icon.LeftArrowIcon
@@ -157,13 +159,22 @@ private fun FormModifyScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            ExpoButton(
-                text = "다음",
-                color = colors.main,
+            ExpoStateButton(
+                text = "수정 완료",
+                state = if (
+                    informationTextState.isNotEmpty() &&
+                    formList.isNotEmpty() &&
+                    formList.all { form ->
+                        when (FormType.valueOf(form.formType)) {
+                            FormType.SENTENCE -> form.title.isNotEmpty()
+                            FormType.CHECKBOX, FormType.DROPDOWN, FormType.MULTIPLE ->
+                                form.title.isNotEmpty() &&
+                                form.itemList.isNotEmpty() &&
+                                form.itemList.all { it.isNotEmpty() }
+                        }
+                    }) ButtonState.Enable else ButtonState.Disable,
                 onClick = submitForm,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(46.dp)
+                modifier = Modifier.fillMaxWidth()
             )
 
             Spacer(modifier = Modifier.padding(bottom = 28.dp))


### PR DESCRIPTION
## 💡 개요
- 폼 생성하기에서 일반 ExpoButton을 사용하여 빈 텍스트여도 요청이 가는 문제가 있어 해결하였습니다.
## 📃 작업내용
- 폼 생성하기에서 일반 ExpoButton을 사용하여 빈 텍스트여도 요청이 가는 문제를 해결하였습니다.
   - ExpoButton 사용대신 상태를 관리할 수 있는 ExpoStateButton을 사용하여 조건을 걸어 조건에 맞으면 버튼이 활성화 되도록 수정하였습니다.
   - 줄 정리가 되지 않은 부분이 존재하여 수정하였습니다.
   - before

        https://github.com/user-attachments/assets/47840325-5d64-4baa-8c7d-ca2c4471d1ed

   - after

        https://github.com/user-attachments/assets/178d858c-17f8-433d-a5fc-9bbe17a4faaf

## 🔀 변경사항
- chore FormModifyScreen
- chore FormCreateScreen
- chore ExpoAddressSearchScreen
- chore ExpoCreateScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x