### PR TITLE
🔀 :: (#550) - 일반, 연수 프로그램별 출석 리스트가 명세서에 나온 스팩과 달라 통신이 되지 않는 문제를 해결하였습니다.

### DIFF
--- a/core/model/src/main/java/com/school_of_company/model/entity/standard/StandardAttendListResponseEntity.kt
+++ b/core/model/src/main/java/com/school_of_company/model/entity/standard/StandardAttendListResponseEntity.kt
@@ -3,8 +3,6 @@ package com.school_of_company.model.entity.standard
 data class StandardAttendListResponseEntity(
     val id: Long,
     val name: String,
-    val affiliation: String,
-    val position: String,
     val programName: String,
     val status: Boolean,
     val entryTime: String?,

--- a/core/model/src/main/java/com/school_of_company/model/entity/training/TeacherTrainingProgramResponseEntity.kt
+++ b/core/model/src/main/java/com/school_of_company/model/entity/training/TeacherTrainingProgramResponseEntity.kt
@@ -3,8 +3,6 @@ package com.school_of_company.model.entity.training
 data class TeacherTrainingProgramResponseEntity(
     val id: Long,
     val name: String,
-    val organization: String,
-    val position: String,
     val programName: String,
     val status: Boolean,
     val entryTime: String?,

--- a/core/network/src/main/java/com/school_of_company/network/dto/standard/response/StandardAttendListResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/standard/response/StandardAttendListResponse.kt
@@ -7,8 +7,6 @@ import com.squareup.moshi.JsonClass
 data class StandardAttendListResponse(
     @Json(name = "id") val id: Long,
     @Json(name = "name") val name: String,
-    @Json(name = "affiliation") val affiliation: String,
-    @Json(name = "position") val position: String,
     @Json(name = "programName") val programName: String,
     @Json(name = "status") val status: Boolean,
     @Json(name = "entryTime") val entryTime: String?,

--- a/core/network/src/main/java/com/school_of_company/network/dto/training/response/TeacherTrainingProgramResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/training/response/TeacherTrainingProgramResponse.kt
@@ -7,8 +7,6 @@ import com.squareup.moshi.JsonClass
 data class TeacherTrainingProgramResponse(
     @Json(name = "id") val id: Long,
     @Json(name = "name") val name: String,
-    @Json(name = "organization") val organization: String,
-    @Json(name = "position") val position: String,
     @Json(name = "programName") val programName: String,
     @Json(name = "status") val status: Boolean,
     @Json(name = "entryTime") val entryTime: String?,

--- a/core/network/src/main/java/com/school_of_company/network/mapper/standard/response/StandardAttendListResponseMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/standard/response/StandardAttendListResponseMapper.kt
@@ -7,8 +7,6 @@ fun StandardAttendListResponse.toModel(): StandardAttendListResponseEntity =
     StandardAttendListResponseEntity(
         id = id,
         name = this.name,
-        affiliation = this.affiliation,
-        position = this.position,
         programName = this.programName,
         status = this.status,
         entryTime = this.entryTime,

--- a/core/network/src/main/java/com/school_of_company/network/mapper/training/response/TeacherTrainingProgramResponseMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/training/response/TeacherTrainingProgramResponseMapper.kt
@@ -7,8 +7,6 @@ fun TeacherTrainingProgramResponse.toEntity(): TeacherTrainingProgramResponseEnt
     TeacherTrainingProgramResponseEntity(
         id = this.id,
         name = this.name,
-        organization = this.organization,
-        position = this.position,
         programName = this.programName,
         status = this.status,
         entryTime = this.entryTime,

--- a/feature/standard/src/main/java/com/school_of_company/standard/view/StandardProgramParticipantScreen.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/view/StandardProgramParticipantScreen.kt
@@ -227,17 +227,10 @@ private fun StandardProgramParticipantScreen(
                     )
 
                     Text(
-                        text = "소속",
+                        text = "프로그램 이름",
                         style = typography.captionBold1,
                         color = colors.gray600,
                         modifier = Modifier.width(100.dp)
-                    )
-
-                    Text(
-                        text = "직급",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(80.dp)
                     )
 
                     Text(
@@ -321,12 +314,10 @@ private fun StandardProgramParticipantScreenPreview() {
         standardProgramAttendListUiState = StandardProgramAttendListUiState.Success(
             listOf(
                 StandardAttendListResponseEntity(
-                    affiliation = "affiliation",
                     entryTime = "입장시간",
                     id = 1,
                     leaveTime = "퇴장시간",
                     name = "연수자 이름",
-                    position = "직위",
                     programName = "연수 이름",
                     status = true
                 )

--- a/feature/standard/src/main/java/com/school_of_company/standard/view/component/StandardParticipantList.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/view/component/StandardParticipantList.kt
@@ -46,12 +46,10 @@ private fun StandardParticipantListPreview() {
         horizontalScrollState = ScrollState(1),
         item = persistentListOf(
             StandardAttendListResponseEntity(
-                affiliation = "affiliation",
                 entryTime = "입장시간",
                 id = 1,
                 leaveTime = "퇴장시간",
                 name = "연수자 이름",
-                position = "직위",
                 programName = "연수 이름",
                 status = true
             )

--- a/feature/standard/src/main/java/com/school_of_company/standard/view/component/StandardProgramParticipantListItem.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/view/component/StandardProgramParticipantListItem.kt
@@ -53,17 +53,10 @@ internal fun StandardProgramParticipantListItem(
             )
 
             Text(
-                text = data.affiliation,
+                text = data.programName,
                 style = typography.captionRegular2,
                 color = colors.black,
                 modifier = Modifier.width(100.dp)
-            )
-
-            Text(
-                text = data.position,
-                style = typography.captionRegular2,
-                color = colors.black,
-                modifier = Modifier.width(80.dp)
             )
 
             Text(
@@ -95,12 +88,10 @@ internal fun StandardProgramParticipantListItem(
 private fun StandardProgramParticipantListItemPreview() {
     StandardProgramParticipantListItem(
         data = StandardAttendListResponseEntity(
-            affiliation = "affiliation",
             entryTime = "입장시간",
             id = 1,
             leaveTime = "퇴장시간",
             name = "연수자 이름",
-            position = "직위",
             programName = "연수 이름",
             status = true
         ),

--- a/feature/training/src/main/java/com/school_of_company/training/view/TrainingProgramParticipantScreen.kt
+++ b/feature/training/src/main/java/com/school_of_company/training/view/TrainingProgramParticipantScreen.kt
@@ -223,17 +223,10 @@ private fun TrainingProgramParticipantScreen(
                     )
 
                     Text(
-                        text = "소속",
+                        text = "프로그램 이름",
                         style = typography.captionBold1,
                         color = colors.gray600,
                         modifier = Modifier.width(100.dp)
-                    )
-
-                    Text(
-                        text = "직급",
-                        style = typography.captionBold1,
-                        color = colors.gray600,
-                        modifier = Modifier.width(80.dp)
                     )
 
                     Text(

--- a/feature/training/src/main/java/com/school_of_company/training/view/component/TrainingProgramParticipantList.kt
+++ b/feature/training/src/main/java/com/school_of_company/training/view/component/TrainingProgramParticipantList.kt
@@ -47,8 +47,6 @@ private fun HomeDetailProgramParticipantListPreview() {
             TeacherTrainingProgramResponseEntity(
                 id = 0,
                 name = "홍길동",
-                organization = "한국대학교",
-                position = "교사",
                 programName = "프로그램",
                 status = true,
                 entryTime = "2024-09-12 T 08:30",

--- a/feature/training/src/main/java/com/school_of_company/training/view/component/TrainingProgramParticipantListItem.kt
+++ b/feature/training/src/main/java/com/school_of_company/training/view/component/TrainingProgramParticipantListItem.kt
@@ -54,17 +54,10 @@ internal fun TrainingProgramParticipantListItem(
             )
 
             Text(
-                text = data.organization,
+                text = data.programName,
                 style = typography.captionRegular2,
                 color = colors.black,
                 modifier = Modifier.width(100.dp)
-            )
-
-            Text(
-                text = data.position,
-                style = typography.captionRegular2,
-                color = colors.black,
-                modifier = Modifier.width(80.dp)
             )
 
             Text(
@@ -99,8 +92,6 @@ private fun HomeDetailProgramParticipantListItemPreview() {
         data = TeacherTrainingProgramResponseEntity(
             id = 0,
             name = "홍길동",
-            organization = "한국대학교",
-            position = "교사",
             programName = "프로그램",
             status = true,
             entryTime = "2024-09-12 T 08:30",


### PR DESCRIPTION
## 💡 개요
- 일반, 연수 프로그램별 출석 리스트가 명세서에 나온 스팩과 달라 통신이 되지 않는 문제가 있었습니다.
## 📃 작업내용
- 일반, 연수 프로그램별 출석 리스트가 명세서에 나온 스팩과 달라 통신이 되지 않는 문제를 해결하였습니다.
   - 사용되지 않는 필드를 삭제한 이후 적용하였습니다.
   - before

       https://github.com/user-attachments/assets/872a6253-8b03-4ef7-bc8f-827b9219eab1

   - after

       https://github.com/user-attachments/assets/e4c86243-57c7-4a79-9447-8637653f1892

## 🔀 변경사항
<img width="300" alt="스크린샷 2025-04-16 오후 12 01 10" src="https://github.com/user-attachments/assets/faaf07c8-16ac-45c4-b4c6-2ac9223d306a" />

<img width="300" alt="스크린샷 2025-04-16 오후 12 01 21" src="https://github.com/user-attachments/assets/53b83f2a-4ffc-481c-9b1b-3a7b860d49b2" />

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
    - 참가자 목록 화면과 항목에서 소속 및 직급 정보가 제거되고, 프로그램 이름만 표시되도록 변경되었습니다.
    - UI 미리보기 데이터에서도 소속 및 직급 필드가 삭제되었습니다.
- **Style**
    - 참가자 목록 헤더에서 "소속"이 "프로그램 이름"으로 변경되고 "직급" 열이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->