### PR TITLE
🔀 :: (#552) - 메인 스크린에서 사용되는 필터 버튼 디자인과 모달이 추가되어 퍼블리싱하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoScreen.kt
@@ -66,7 +66,6 @@ internal fun ExpoRoute(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ExpoScreen(
     modifier: Modifier = Modifier,
@@ -76,21 +75,6 @@ private fun ExpoScreen(
     getExpoList: () -> Unit,
     navigationToDetail: (String) -> Unit
 ) {
-    var filterButtonText by rememberSaveable { mutableStateOf("최신순") }
-
-    val (openBottomSheet, isOpenBottomSheet) = rememberSaveable { mutableStateOf(false) }
-    var arrayList by rememberSaveable { mutableStateOf(ArrayHomeListEnum.RECENT) }
-
-    val sortedItems = when (getExpoListData) {
-        is GetExpoListUiState.Success -> {
-            when (arrayList) {
-                ArrayHomeListEnum.RECENT -> getExpoListData.data.sortedByDescending { it.startedDay }
-                ArrayHomeListEnum.OLDER -> getExpoListData.data.sortedBy { it.startedDay }
-            }
-        }
-
-        else -> emptyList()
-    }
 
     ExpoAndroidTheme { colors, typography ->
         Column(
@@ -121,7 +105,10 @@ private fun ExpoScreen(
                     color = colors.black
                 )
 
-                HomeFilterButton(text = filterButtonText) { isOpenBottomSheet(true) }
+                HomeFilterButton(
+                    text = "필터",
+                    onClick = {}
+                )
             }
 
             Spacer(modifier = Modifier.padding(bottom = 24.dp))
@@ -140,7 +127,7 @@ private fun ExpoScreen(
                 when (getExpoListData) {
                     is GetExpoListUiState.Success -> {
                         ExpoList(
-                            item = sortedItems.toImmutableList(),
+                            item = getExpoListData.data.toImmutableList(),
                             emptyList = false,
                             navigateToExpoDetail = navigationToDetail
                         )
@@ -189,22 +176,6 @@ private fun ExpoScreen(
                 }
             }
         }
-    }
-
-    if (openBottomSheet) {
-        HomeBottomSheet(
-            onRecentClick = {
-                arrayList = ArrayHomeListEnum.RECENT
-                filterButtonText = "최신순"
-                isOpenBottomSheet(false)
-            },
-            onOldClick = {
-                arrayList = ArrayHomeListEnum.OLDER
-                filterButtonText = "오래된 순"
-                isOpenBottomSheet(false)
-            },
-            onCancelClick = { isOpenBottomSheet(false) }
-        )
     }
 }
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFilterButton.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFilterButton.kt
@@ -1,9 +1,11 @@
 package com.school_of_company.expo.view.component
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -14,6 +16,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.icon.DownArrowIcon
+import com.school_of_company.design_system.icon.FilterIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 
 @Composable
@@ -29,8 +32,13 @@ internal fun HomeFilterButton(
             verticalAlignment = Alignment.CenterVertically,
             modifier = modifier
                 .background(
+                    color = colors.white,
+                    shape = RoundedCornerShape(8.dp),
+                )
+                .border(
+                    width = 1.dp,
                     color = colors.main,
-                    shape = RoundedCornerShape(10.dp),
+                    shape = RoundedCornerShape(8.dp),
                 )
                 .expoClickable(
                     onClick = onClick,
@@ -38,21 +46,23 @@ internal fun HomeFilterButton(
                 )
         ) {
             Row(
-                horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.Start),
+                horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.Start),
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.padding(
-                    horizontal = 10.dp,
-                    vertical = 6.dp
+                    horizontal = 16.dp,
+                    vertical = 12.dp
                 )
             ) {
-                Text(
-                    text = text,
-                    style = typography.bodyBold2,
-                    fontWeight = FontWeight.SemiBold,
-                    color = colors.white,
+                FilterIcon(
+                    tint = colors.main,
+                    modifier = Modifier.size(20.dp)
                 )
 
-                DownArrowIcon(tint = colors.white)
+                Text(
+                    text = text,
+                    style = typography.captionRegular1,
+                    color = colors.main,
+                )
             }
         }
     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFormFilterDialog.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFormFilterDialog.kt
@@ -46,7 +46,7 @@ internal fun ExpoFormFilterDialog(
                 onClick = onStudentFormTrueClick
             ),
             FilterOption(
-                label = "연수자 폼 (X)",
+                label = "참가자 폼 (X)",
                 selected = selectedOptions.find { it.label == "참가자 폼 (X)" }?.selected == true,
                 onClick = onStudentFormFalseClick
             )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFormFilterDialog.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFormFilterDialog.kt
@@ -1,0 +1,111 @@
+package com.school_of_company.expo.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.component.modifier.clickable.expoClickable
+import com.school_of_company.design_system.icon.XIcon
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+@Composable
+internal fun ExpoFormFilterDialog(
+    modifier: Modifier = Modifier,
+    selectedOptions: List<FilterOption>,
+    onTrainingFormTrueClick: () -> Unit,
+    onTrainingFormFalseClick: () -> Unit,
+    onStudentFormTrueClick: () -> Unit,
+    onStudentFormFalseClick: () -> Unit,
+    onDismissClick: () -> Unit
+) {
+    ExpoAndroidTheme { colors, typography ->
+
+        val options = listOf(
+            FilterOption(
+                label = "연수자 폼 (O)",
+                selected = selectedOptions.find { it.label == "연수자 폼 (O)" }?.selected == true,
+                onClick = onTrainingFormTrueClick
+            ),
+            FilterOption(
+                label = "연수자 폼 (X)",
+                selected = selectedOptions.find { it.label == "연수자 폼 (X)" }?.selected == true,
+                onClick = onTrainingFormFalseClick
+            ),
+            FilterOption(
+                label = "참가자 폼 (O)",
+                selected = selectedOptions.find { it.label == "참가자 폼 (O)" }?.selected == true,
+                onClick = onStudentFormTrueClick
+            ),
+            FilterOption(
+                label = "연수자 폼 (X)",
+                selected = selectedOptions.find { it.label == "참가자 폼 (X)" }?.selected == true,
+                onClick = onStudentFormFalseClick
+            )
+        )
+
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = modifier
+                .background(
+                    color = colors.white,
+                    shape = RoundedCornerShape(6.dp)
+                )
+                .padding(all = 28.dp)
+        ) {
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(40.dp, Alignment.Start),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "필터",
+                    color = colors.black,
+                    style = typography.titleBold3
+                )
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                XIcon(
+                    tint = colors.black,
+                    modifier = Modifier.expoClickable { onDismissClick() }
+                )
+            }
+
+            Spacer(modifier = Modifier.padding(bottom = 32.dp))
+
+            Column(horizontalAlignment = Alignment.Start,) {
+                Text(
+                    text = "폼 생성",
+                    color = colors.black,
+                    style = typography.bodyRegular1
+                )
+
+                ExpoFormFilterGroupButton(
+                    options = options
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ExpoFormFilterDialogPreview() {
+    ExpoFormFilterDialog(
+        selectedOptions = listOf(),
+        onTrainingFormTrueClick = {},
+        onTrainingFormFalseClick = {},
+        onStudentFormTrueClick = {},
+        onStudentFormFalseClick = {},
+        onDismissClick = {}
+    )
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFormFilterGroupButton.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFormFilterGroupButton.kt
@@ -1,0 +1,94 @@
+package com.school_of_company.expo.view.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+
+internal data class FilterOption(
+    val label: String,
+    val selected: Boolean,
+    val onClick: () -> Unit
+)
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun ExpoFormFilterGroupButton(
+    modifier: Modifier = Modifier,
+    options: List<FilterOption>
+) {
+    ExpoAndroidTheme { colors, typography ->
+        FlowRow(
+            modifier = modifier.fillMaxWidth(),
+            maxItemsInEachRow = 2
+        ) {
+            options.forEach { option ->
+                ExpoFormFilterButton(
+                    selected = option.selected,
+                    onClick = option.onClick,
+                    buttonLabel = option.label,
+                    modifier = Modifier.padding(
+                        end = 16.dp,
+                        top = 16.dp
+                    )
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExpoFormFilterButton(
+    modifier: Modifier = Modifier,
+    selected: Boolean,
+    onClick: () -> Unit,
+    buttonLabel: String
+) {
+    ExpoAndroidTheme { colors, typography ->
+        FilterChip(
+            selected = selected,
+            label = {
+                Text(
+                    text = buttonLabel,
+                    style = typography.bodyRegular2,
+                    color = if (selected) colors.white else colors.gray400
+                )
+            },
+            shape = RoundedCornerShape(6.dp),
+            border = BorderStroke(
+                1.dp,
+                if (selected) colors.main else colors.gray400
+            ),
+            colors = FilterChipDefaults.filterChipColors(
+                containerColor = colors.white,
+                selectedContainerColor = colors.main,
+            ),
+            onClick = onClick,
+            modifier = modifier.height(46.dp)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun ExpoFormFilterButtonPreview() {
+    ExpoFormFilterGroupButton(
+        options = listOf(
+            FilterOption("현장실습 O", true) {  },
+            FilterOption("현장실습 X", false) { },
+            FilterOption("학생참여 O", false) {  },
+            FilterOption("학생참여 X", false) { },
+        )
+    )
+}


### PR DESCRIPTION
## 💡 개요
- 메인 스크린에서 사용되는 필터 버튼 디자인과 모달이 추가되어 반영이 필요했습니다.
## 📃 작업내용
- 메인 스크린에서 사용되는 필터 버튼 디자인과 모달이 추가되어 퍼블리싱하였습니다.
   - 최신순, 오래된순으로 나오던 필터 버튼을 디자인 변경사항에 맞게 수정하였습니다.
   - 필터 버튼시 나오는 모달을 퍼블리싱하였습니다.
   - 모달 안에서 사용되는 버튼을 퍼블리싱하였습니다.
   - 퍼블리싱 화면
   
       <img width="538" alt="스크린샷 2025-04-16 오후 7 30 55" src="https://github.com/user-attachments/assets/1bcf0180-6f3a-4334-8c13-3730c8485953" />

       <img width="188" alt="스크린샷 2025-04-16 오후 7 31 19" src="https://github.com/user-attachments/assets/2bc4c95d-f1ef-4680-b9a6-77cf56095c3d" />

       <img width="401" alt="스크린샷 2025-04-16 오후 7 31 29" src="https://github.com/user-attachments/assets/0769a9df-1930-422f-9fca-4dd5305240d5" />

## 🔀 변경사항
- chore ExpoFilterButton
- add ExpoFormFilterGroupButton
- add ExpoFormFilterButton
- add ExpoFormFilterDialog
- chore ExpoScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 연수자/참가자 폼 필터를 선택할 수 있는 새로운 필터 다이얼로그와 필터 그룹 버튼 UI가 추가되었습니다.

- **스타일**
  - 필터 버튼의 디자인이 흰색 배경과 컬러 테두리, 아이콘이 포함된 형태로 개선되었습니다.

- **기능 변경**
  - 기존의 최신순/오래된 순 정렬 및 필터 UI가 제거되어, 엑스포 목록은 필터 없이 기본으로만 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->