### PR TITLE
🔀 :: (#554) - 박람회 동적폼, 만족도 조사 생성 여부 필터 기능을 구현하였습니다.

### DIFF
--- a/core/model/src/main/java/com/school_of_company/model/entity/expo/ExpoSurveyDynamicFormEnabledEntity.kt
+++ b/core/model/src/main/java/com/school_of_company/model/entity/expo/ExpoSurveyDynamicFormEnabledEntity.kt
@@ -5,7 +5,7 @@ data class ExpoSurveyDynamicFormEnabledEntity(
 )
 
 data class ExpoValidityEntity(
-    val expoId: Long,
+    val expoId: String,
     val standardFormCreatedStatus: Boolean,
     val traineeFormCreatedStatus: Boolean,
     val standardSurveyCreatedStatus: Boolean,

--- a/core/network/src/main/java/com/school_of_company/network/dto/expo/response/ExpoSurveyDynamicFormEnabledResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/expo/response/ExpoSurveyDynamicFormEnabledResponse.kt
@@ -10,7 +10,7 @@ data class ExpoSurveyDynamicFormEnabledResponse(
 
 @JsonClass(generateAdapter = true)
 data class ExpoValidityResponse(
-    @Json(name = "expoId") val expoId: Long,
+    @Json(name = "expoId") val expoId: String,
     @Json(name = "standardFormCreatedStatus") val standardFormCreatedStatus: Boolean,
     @Json(name = "traineeFormCreatedStatus") val traineeFormCreatedStatus: Boolean,
     @Json(name = "standardSurveyCreatedStatus") val standardSurveyCreatedStatus: Boolean,

--- a/feature/expo/src/main/java/com/school_of_company/expo/enum/FilterOptionEnum.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/enum/FilterOptionEnum.kt
@@ -1,0 +1,8 @@
+package com.school_of_company.expo.enum
+
+enum class FilterOptionEnum {
+    TRAINING_FORM_TRUE,
+    TRAINING_FORM_FALSE,
+    STUDENT_FORM_TRUE,
+    STUDENT_FORM_FALSE
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoDetailModifyDialog.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoDetailModifyDialog.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFormFilterDialog.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFormFilterDialog.kt
@@ -16,11 +16,13 @@ import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import com.school_of_company.expo.enum.FilterOptionEnum
+import com.school_of_company.expo.viewmodel.ExpoViewModel
 
 @Composable
 internal fun ExpoFormFilterDialog(
     modifier: Modifier = Modifier,
-    selectedOptions: List<FilterOption>,
+    selectedOptions: List<FilterOptionEnum?>,
     onTrainingFormTrueClick: () -> Unit,
     onTrainingFormFalseClick: () -> Unit,
     onStudentFormTrueClick: () -> Unit,
@@ -32,22 +34,22 @@ internal fun ExpoFormFilterDialog(
         val options = listOf(
             FilterOption(
                 label = "연수자 폼 (O)",
-                selected = selectedOptions.find { it.label == "연수자 폼 (O)" }?.selected == true,
+                selected = selectedOptions.contains(FilterOptionEnum.TRAINING_FORM_TRUE),
                 onClick = onTrainingFormTrueClick
             ),
             FilterOption(
                 label = "연수자 폼 (X)",
-                selected = selectedOptions.find { it.label == "연수자 폼 (X)" }?.selected == true,
+                selected = selectedOptions.contains(FilterOptionEnum.TRAINING_FORM_FALSE),
                 onClick = onTrainingFormFalseClick
             ),
             FilterOption(
                 label = "참가자 폼 (O)",
-                selected = selectedOptions.find { it.label == "참가자 폼 (O)" }?.selected == true,
+                selected = selectedOptions.contains(FilterOptionEnum.STUDENT_FORM_TRUE),
                 onClick = onStudentFormTrueClick
             ),
             FilterOption(
                 label = "참가자 폼 (X)",
-                selected = selectedOptions.find { it.label == "참가자 폼 (X)" }?.selected == true,
+                selected = selectedOptions.contains(FilterOptionEnum.STUDENT_FORM_FALSE),
                 onClick = onStudentFormFalseClick
             )
         )


### PR DESCRIPTION
## 💡 개요
- 박람회 동적폼, 만족도 조사 생성 여부 필터 기능 구현이 필요했습니다.
## 📃 작업내용
- 박람회 동적폼, 만족도 조사 생성 여부 필터 기능을 구현하였습니다.
- 동작영상

    https://github.com/user-attachments/assets/bed6b8fb-b9cc-471f-b9f9-43d7018f0155

## 🔀 변경사항
<img width="585" alt="스크린샷 2025-04-17 오전 11 31 24" src="https://github.com/user-attachments/assets/553fe87f-f09e-44cf-89cc-4cf44ec3501c" />

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 엑스포 목록에 설문지 활성화 상태를 기준으로 필터링할 수 있는 기능이 추가되었습니다. 필터 다이얼로그를 통해 '트레이닝 폼' 및 '학생 폼'의 활성/비활성 상태로 목록을 필터링할 수 있습니다.

- **버그 수정**
    - 없음

- **기타**
    - 일부 내부 데이터 타입이 변경되어 필터 기능과 관련된 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->