### PR TITLE
🔀 :: (#559) - 박람회 동적폼, 만족도 조사 생성 여부 API에서 사용하지 않는 필드를 삭제하였습니다.

### DIFF
--- a/core/model/src/main/java/com/school_of_company/model/entity/expo/ExpoSurveyDynamicFormEnabledEntity.kt
+++ b/core/model/src/main/java/com/school_of_company/model/entity/expo/ExpoSurveyDynamicFormEnabledEntity.kt
@@ -8,6 +8,4 @@ data class ExpoValidityEntity(
     val expoId: String,
     val standardFormCreatedStatus: Boolean,
     val traineeFormCreatedStatus: Boolean,
-    val standardSurveyCreatedStatus: Boolean,
-    val traineeSurveyCreatedStatus: Boolean,
 )

--- a/core/network/src/main/java/com/school_of_company/network/dto/expo/response/ExpoSurveyDynamicFormEnabledResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/expo/response/ExpoSurveyDynamicFormEnabledResponse.kt
@@ -13,6 +13,4 @@ data class ExpoValidityResponse(
     @Json(name = "expoId") val expoId: String,
     @Json(name = "standardFormCreatedStatus") val standardFormCreatedStatus: Boolean,
     @Json(name = "traineeFormCreatedStatus") val traineeFormCreatedStatus: Boolean,
-    @Json(name = "standardSurveyCreatedStatus") val standardSurveyCreatedStatus: Boolean,
-    @Json(name = "traineeSurveyCreatedStatus") val traineeSurveyCreatedStatus: Boolean,
 )

--- a/core/network/src/main/java/com/school_of_company/network/mapper/expo/response/ExpoSurveyDynamicFormEnabledResponseMapper.kt
+++ b/core/network/src/main/java/com/school_of_company/network/mapper/expo/response/ExpoSurveyDynamicFormEnabledResponseMapper.kt
@@ -15,6 +15,4 @@ fun ExpoValidityResponse.toEntity(): ExpoValidityEntity =
         expoId = this.expoId,
         standardFormCreatedStatus = this.standardFormCreatedStatus,
         traineeFormCreatedStatus = this.traineeFormCreatedStatus,
-        standardSurveyCreatedStatus = this.standardSurveyCreatedStatus,
-        traineeSurveyCreatedStatus = this.traineeSurveyCreatedStatus
     )


### PR DESCRIPTION
## 💡 개요
- 박람회 동적폼, 만족도 조사 생성 여부 API에서 사용하지 않는 필드를 포함시키고 있어 삭제할 필요가 있었습니다.
## 📃 작업내용
- 박람회 동적폼, 만족도 조사 생성 여부 API에서 사용하지 않는 필드를 삭제하였습니다.
     - 만족도 조사 생성은 앱에 없는 기능이여서 Trainee(Standard)SurveyStatus 필드를 삭제하였습니다.
## 🔀 변경사항
- chore ExpoSurveyDynamicFormEnableEntity
- chore ExpoSurveyDynamicFormEnableEntityResponse
- chore ExpoSurveyDynamicFormEnableMapper
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x