### PR TITLE
🔀 :: (#564) - 참가자 조회의 필터부분을 수정했습니다

### DIFF
--- a/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
+++ b/app/src/main/java/com/school_of_company/expo_android/navigation/ExpoNavHost.kt
@@ -16,7 +16,6 @@ import com.school_of_company.expo.navigation.expoCreatedRoute
 import com.school_of_company.expo.navigation.expoCreatedScreen
 import com.school_of_company.expo.navigation.expoDetailScreen
 import com.school_of_company.expo.navigation.expoModifyScreen
-import com.school_of_company.expo.navigation.expoNavigationHomeRoute
 import com.school_of_company.expo.navigation.expoNavigationHomeScreen
 import com.school_of_company.expo.navigation.expoScreen
 import com.school_of_company.expo.navigation.homeRoute
@@ -114,15 +113,9 @@ fun ExpoNavHost(
 
         expoDetailScreen(
             onBackClick = navController::popBackStack,
-            onCheckClick = { id ->
-                navController.navigateToProgramDetailParticipantManagement(id)
-            },
-            onModifyClick = { id ->
-                navController.navigateToExpoModify(id)
-            },
-            onProgramClick = { id ->
-                navController.navigateToProgramDetailProgram(id)
-            },
+            onCheckClick = navController::navigateToProgramDetailParticipantManagement,
+            onModifyClick = navController::navigateToExpoModify,
+            onProgramClick = navController::navigateToProgramDetailProgram,
             onMessageClick = navController::navigateToSmsSendMessage,
             navigationToFormCreate = navController::navigationToCreateForm,
             navigationToFormModify = navController::navigationToModifyForm,

--- a/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/navigation/ExpoNavigation.kt
@@ -72,7 +72,7 @@ fun NavGraphBuilder.expoScreen(
 
 fun NavGraphBuilder.expoDetailScreen(
     onBackClick: () -> Unit,
-    onCheckClick: (String) -> Unit,
+    onCheckClick: (String, String, String) -> Unit,
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit,
     onMessageClick: (String, String) -> Unit,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -65,7 +65,7 @@ internal fun ExpoDetailRoute(
     modifier: Modifier = Modifier,
     id: String,
     onBackClick: () -> Unit,
-    onCheckClick: (String) -> Unit,
+    onCheckClick: (String, String, String) -> Unit,
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit,
     onMessageClick: (String, String) -> Unit,
@@ -86,6 +86,7 @@ internal fun ExpoDetailRoute(
                 null,
                 R.string.convert_coordinates_to_address_success
             )
+
             is GetCoordinatesToAddressUiState.Error -> onErrorToast(
                 null,
                 R.string.convert_coordinates_to_address_fail
@@ -104,7 +105,7 @@ internal fun ExpoDetailRoute(
         onMessageClick = { authority ->
             onMessageClick(id, authority)
         },
-        onCheckClick = onCheckClick,
+        onCheckClick = { start, end -> onCheckClick(id, start, end) },
         onModifyClick = onModifyClick,
         onProgramClick = onProgramClick,
         navigationToFormCreate = { type ->
@@ -139,9 +140,9 @@ private fun ExpoDetailScreen(
     scrollState: ScrollState = rememberScrollState(),
     onBackClick: () -> Unit,
     onMessageClick: (String) -> Unit,
-    onCheckClick: (String) -> Unit,
     onModifyClick: (String) -> Unit,
     onProgramClick: (String) -> Unit,
+    onCheckClick: (String, String) -> Unit,
     navigationToFormCreate: (String) -> Unit,
     navigationToFormModify: (String) -> Unit,
 ) {
@@ -272,7 +273,10 @@ private fun ExpoDetailScreen(
                                             .align(Alignment.BottomCenter)
                                             .background(
                                                 brush = Brush.verticalGradient(
-                                                    colors = listOf(Color.Transparent, colors.white),
+                                                    colors = listOf(
+                                                        Color.Transparent,
+                                                        colors.white
+                                                    ),
                                                     startY = 0f,
                                                     endY = 120f
                                                 )
@@ -286,7 +290,8 @@ private fun ExpoDetailScreen(
                                     text = if (expandedExpoIntroductionTextState) "접기" else "더보기",
                                     color = if (expandedExpoIntroductionTextState) colors.main else colors.gray200,
                                     modifier = Modifier.expoClickable {
-                                        expandedExpoIntroductionTextState = !expandedExpoIntroductionTextState
+                                        expandedExpoIntroductionTextState =
+                                            !expandedExpoIntroductionTextState
                                     },
                                     style = typography.bodyRegular2
                                 )
@@ -426,7 +431,12 @@ private fun ExpoDetailScreen(
                                     text = "조회하기",
                                     textColor = colors.main,
                                     backgroundColor = colors.white,
-                                    onClick = { onCheckClick(id) },
+                                    onClick = {
+                                        onCheckClick(
+                                            getExpoInformationUiState.data.startedDay,
+                                            getExpoInformationUiState.data.finishedDay,
+                                        )
+                                    },
                                     modifier = Modifier
                                         .weight(1f)
                                         .border(
@@ -615,7 +625,7 @@ private fun HomeDetailScreenPreview() {
         scrollState = ScrollState(0),
         onBackClick = {},
         onMessageClick = {},
-        onCheckClick = {},
+        onCheckClick = { _, _ -> },
         onModifyClick = {},
         onProgramClick = {},
         navigationToFormCreate = { _ -> },

--- a/feature/program/src/main/java/com/school_of_company/program/navigation/ProgramNavigation.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/navigation/ProgramNavigation.kt
@@ -62,7 +62,7 @@ fun NavGraphBuilder.programDetailProgramScreen(
 }
 
 fun NavGraphBuilder.programDetailParticipantManagementScreen(onBackClick: () -> Unit) {
-    composable(route = "$programDetailParticipantManagementRoute/{id}") { backStackEntry ->
+    composable(route = "$programDetailParticipantManagementRoute/{id}/{startDate}/{endDate}") { backStackEntry ->
         val id = backStackEntry.arguments?.getString("id") ?: ""
         val startDate = backStackEntry.arguments?.getString("startDate") ?: ""
         val endDate = backStackEntry.arguments?.getString("endDate") ?: ""

--- a/feature/program/src/main/java/com/school_of_company/program/navigation/ProgramNavigation.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/navigation/ProgramNavigation.kt
@@ -24,10 +24,12 @@ fun NavController.navigateToProgramDetailProgram(
 
 fun NavController.navigateToProgramDetailParticipantManagement(
     id: String,
+    startDate: String,
+    endDate: String,
     navOptions: NavOptions? = null
 ) {
     this.navigate(
-        route = "$programDetailParticipantManagementRoute/${id}",
+        route = "$programDetailParticipantManagementRoute/${id}/${startDate}/${endDate}",
         navOptions
     )
 }
@@ -62,8 +64,12 @@ fun NavGraphBuilder.programDetailProgramScreen(
 fun NavGraphBuilder.programDetailParticipantManagementScreen(onBackClick: () -> Unit) {
     composable(route = "$programDetailParticipantManagementRoute/{id}") { backStackEntry ->
         val id = backStackEntry.arguments?.getString("id") ?: ""
+        val startDate = backStackEntry.arguments?.getString("startDate") ?: ""
+        val endDate = backStackEntry.arguments?.getString("endDate") ?: ""
         ProgramDetailParticipantManagementRoute(
             id = id,
+            startDate = startDate,
+            endDate = endDate,
             onBackClick = onBackClick
         )
     }

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -51,6 +52,7 @@ import com.school_of_company.design_system.icon.UpArrowIcon
 import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.program.enum.ParticipantEnum
+import com.school_of_company.program.view.component.LocalDateButton
 import com.school_of_company.program.view.component.ProgramDetailParticipantDropdownMenu
 import com.school_of_company.program.view.component.ProgramDetailParticipantManagementList
 import com.school_of_company.program.view.component.ProgramDetailParticipantTable
@@ -102,6 +104,20 @@ internal fun ProgramDetailParticipantManagementRoute(
         )
     }
 
+    LaunchedEffect(selectedDate) {
+        delay(300L)
+        viewModel.getParticipantInformationList(
+            expoId = id,
+            type = ParticipantEnum.FIELD,
+            localDate = selectedDate.toString(),
+        )
+        viewModel.getParticipantInformationList(
+            expoId = id,
+            type = ParticipantEnum.PRE,
+            localDate = selectedDate.toString(),
+        )
+    }
+
     ProgramDetailParticipantManagementScreen(
         modifier = modifier,
         swipeRefreshState = swipeRefreshState,
@@ -111,6 +127,7 @@ internal fun ProgramDetailParticipantManagementRoute(
         selectedDate = selectedDate,
         traineeName = traineeName,
         onBackClick = onBackClick,
+        onSelectedDateChange = { selectedDate = it },
         onTraineeNameChange = viewModel::onTraineeNameChange,
         getAheadParticipantList = {
             viewModel.getParticipantInformationList(
@@ -147,6 +164,7 @@ private fun ProgramDetailParticipantManagementScreen(
     participantFieldResponseListUiState: ParticipantResponseListUiState,
     traineeInformationUiState: TraineeResponseListUiState,
     onBackClick: () -> Unit,
+    onSelectedDateChange: (LocalDate?) -> Unit,
     onTraineeNameChange: (String) -> Unit,
     getAheadParticipantList: () -> Unit,
     getFieldParticipantList: () -> Unit,
@@ -384,12 +402,28 @@ private fun ProgramDetailParticipantManagementScreen(
 
             Spacer(modifier = Modifier.height(18.dp))
 
-            LazyRow(
-                modifier = Modifier
-                    .padding(16.dp)
-                    .fillMaxWidth()
-            ) {
+            if (selectedItem != 2) {
 
+                LazyRow(
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(dateList) { date: LocalDate ->
+                        LocalDateButton(
+                            date = date,
+                            selected = selectedDate == date,
+                            onClick = {
+                                if (selectedDate == date) {
+                                    onSelectedDateChange(null)
+                                } else {
+                                    onSelectedDateChange(date)
+                                }
+                            }
+                        )
+                    }
+                }
             }
 
             if (selectedItem == 2) {
@@ -536,6 +570,7 @@ private fun ProgramDetailParticipantManagementScreen(
 private fun HomeDetailParticipantManagementScreenPreview() {
     ProgramDetailParticipantManagementScreen(
         swipeRefreshState = rememberSwipeRefreshState(isRefreshing = false),
+        selectedDate = LocalDate.now(),
         traineeName = "",
         participantAheadResponseListUiState = ParticipantResponseListUiState.Loading,
         participantFieldResponseListUiState = ParticipantResponseListUiState.Loading,
@@ -545,6 +580,6 @@ private fun HomeDetailParticipantManagementScreenPreview() {
         getAheadParticipantList = {},
         getFieldParticipantList = {},
         getTraineeList = {},
-        selectedDate = LocalDate.now(),
+        onSelectedDateChange = { _ -> },
     )
 }

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -107,24 +107,24 @@ internal fun ProgramDetailParticipantManagementRoute(
         traineeName = traineeName,
         onBackClick = onBackClick,
         onTraineeNameChange = viewModel::onTraineeNameChange,
-        getAheadParticipantList = { name ->
+        getAheadParticipantList = {
             viewModel.getParticipantInformationList(
                 expoId = id,
                 type = ParticipantEnum.PRE,
                 name = null
             )
         },
-        getFieldParticipantList = { name ->
+        getFieldParticipantList = {
             viewModel.getParticipantInformationList(
                 expoId = id,
                 type = ParticipantEnum.FIELD,
-                name = name
+                name = null
             )
         },
-        getTraineeList = { name ->
+        getTraineeList = {
             viewModel.getTraineeList(
                 expoId = id,
-                name = name
+                name = traineeName
             )
         },
     )
@@ -142,9 +142,9 @@ private fun ProgramDetailParticipantManagementScreen(
     traineeInformationUiState: TraineeResponseListUiState,
     onBackClick: () -> Unit,
     onTraineeNameChange: (String) -> Unit,
-    getAheadParticipantList: (String?) -> Unit,
-    getFieldParticipantList: (String?) -> Unit,
-    getTraineeList: (String?) -> Unit,
+    getAheadParticipantList: () -> Unit,
+    getFieldParticipantList: () -> Unit,
+    getTraineeList: () -> Unit,
 ) {
     var participantTextState by rememberSaveable { mutableStateOf("사전 행사 참가자") }
     var isDropdownExpanded by rememberSaveable { mutableStateOf(false) }
@@ -381,9 +381,7 @@ private fun ProgramDetailParticipantManagementScreen(
                     trailingIcon = {
                         SearchIcon(
                             tint = colors.black,
-                            modifier = Modifier.clickable {
-                                getTraineeList(traineeName)
-                            }
+                            modifier = Modifier.clickable(onClick = getTraineeList)
                         )
                     },
                     modifier = Modifier
@@ -400,9 +398,9 @@ private fun ProgramDetailParticipantManagementScreen(
                 state = swipeRefreshState,
                 onRefresh = {
                     when (selectedItem) {
-                        0 -> getAheadParticipantList(null)
-                        1 -> getFieldParticipantList(null)
-                        2 -> getTraineeList(null)
+                        0 -> getAheadParticipantList()
+                        1 -> getFieldParticipantList()
+                        2 -> getTraineeList()
                     }
                 },
                 indicator = { state, refreshTrigger ->

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,7 +25,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -64,15 +62,16 @@ import com.school_of_company.program.viewmodel.ProgramViewModel
 import com.school_of_company.program.viewmodel.uistate.ParticipantResponseListUiState
 import com.school_of_company.program.viewmodel.uistate.TraineeResponseListUiState
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import java.time.LocalDate
 
 @Composable
 internal fun ProgramDetailParticipantManagementRoute(
     modifier: Modifier = Modifier,
     id: String,
+    startDate: String,
+    endDate: String,
     onBackClick: () -> Unit,
-    viewModel: ProgramViewModel = hiltViewModel()
+    viewModel: ProgramViewModel = hiltViewModel(),
 ) {
     val swipeRefreshLoading by viewModel.swipeRefreshLoading.collectAsStateWithLifecycle()
     val swipeRefreshState = rememberSwipeRefreshState(isRefreshing = swipeRefreshLoading)
@@ -128,6 +127,8 @@ internal fun ProgramDetailParticipantManagementRoute(
         participantFieldResponseListUiState = participantFieldResponseListUiState,
         traineeInformationUiState = traineeInformationUiState,
         selectedDate = selectedDate,
+        startDate = LocalDate.parse(startDate),
+        endDate = LocalDate.parse(endDate),
         traineeName = traineeName,
         onBackClick = onBackClick,
         onSelectedDateChange = { selectedDate = it },
@@ -162,6 +163,8 @@ private fun ProgramDetailParticipantManagementScreen(
     scrollState: ScrollState = rememberScrollState(),
     focusManager: FocusManager = LocalFocusManager.current,
     selectedDate: LocalDate?,
+    startDate: LocalDate,
+    endDate: LocalDate,
     traineeName: String,
     participantAheadResponseListUiState: ParticipantResponseListUiState,
     participantFieldResponseListUiState: ParticipantResponseListUiState,
@@ -178,11 +181,8 @@ private fun ProgramDetailParticipantManagementScreen(
     var selectedItem by rememberSaveable { mutableIntStateOf(0) }
 
     val dateList = remember {
-        val start = LocalDate.of(2025, 5, 19)
-        val end = LocalDate.of(2025, 5, 30)
-
-        generateSequence(start) { it.plusDays(1) }
-            .takeWhile { !it.isAfter(end) }
+        generateSequence(startDate) { it.plusDays(1) }
+            .takeWhile { !it.isAfter(endDate) }
             .toList()
     }
 
@@ -584,5 +584,7 @@ private fun HomeDetailParticipantManagementScreenPreview() {
         getFieldParticipantList = {},
         getTraineeList = {},
         onSelectedDateChange = { _ -> },
+        endDate = LocalDate.of(2025, 5, 30),
+        startDate = LocalDate.of(2025, 5, 19),
     )
 }

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -177,13 +177,12 @@ private fun ProgramDetailParticipantManagementScreen(
     var isDropdownExpanded by rememberSaveable { mutableStateOf(false) }
     var selectedItem by rememberSaveable { mutableIntStateOf(0) }
 
-    val dateList = remember(selectedDate) {
-        val selectedDateNotNull = selectedDate ?: LocalDate.now()
-        val startDate = selectedDateNotNull.minusDays(10)
-        val endDate = selectedDateNotNull.plusDays(10)
+    val dateList = remember {
+        val start = LocalDate.of(2025, 5, 19)
+        val end = LocalDate.of(2025, 5, 20)
 
-        generateSequence(startDate) { it.plusDays(1) }
-            .takeWhile { !it.isAfter(endDate) }
+        generateSequence(start) { it.plusDays(1) }
+            .takeWhile { !it.isAfter(end) }
             .toList()
     }
 

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -179,7 +179,7 @@ private fun ProgramDetailParticipantManagementScreen(
 
     val dateList = remember {
         val start = LocalDate.of(2025, 5, 19)
-        val end = LocalDate.of(2025, 5, 20)
+        val end = LocalDate.of(2025, 5, 30)
 
         generateSequence(start) { it.plusDays(1) }
             .takeWhile { !it.isAfter(end) }

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -176,8 +176,6 @@ private fun ProgramDetailParticipantManagementScreen(
     var participantTextState by rememberSaveable { mutableStateOf("사전 행사 참가자") }
     var isDropdownExpanded by rememberSaveable { mutableStateOf(false) }
     var selectedItem by rememberSaveable { mutableIntStateOf(0) }
-    val dateTagLazyRowState = rememberLazyListState(initialFirstVisibleItemIndex = 10)
-    val coroutineScope = rememberCoroutineScope()
 
     val dateList = remember(selectedDate) {
         val selectedDateNotNull = selectedDate ?: LocalDate.now()
@@ -414,7 +412,6 @@ private fun ProgramDetailParticipantManagementScreen(
                     modifier = Modifier
                         .padding(16.dp)
                         .fillMaxWidth(),
-                    state = dateTagLazyRowState,
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     items(dateList) { date: LocalDate ->
@@ -426,10 +423,6 @@ private fun ProgramDetailParticipantManagementScreen(
                                     onSelectedDateChange(null)
                                 } else {
                                     onSelectedDateChange(date)
-                                }
-
-                                coroutineScope.launch {
-                                    dateTagLazyRowState.scrollToItem(10)
                                 }
                             }
                         )

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -73,8 +73,6 @@ internal fun ProgramDetailParticipantManagementRoute(
     val participantFieldResponseListUiState by viewModel.participantFieldResponseListUiState.collectAsStateWithLifecycle()
     val traineeInformationUiState by viewModel.traineeResponseListUiState.collectAsStateWithLifecycle()
 
-    val fieldParticipantName by viewModel.fieldParticipantName.collectAsStateWithLifecycle()
-    val preParticipantName by viewModel.preParticipantName.collectAsStateWithLifecycle()
     val traineeName by viewModel.traineeName.collectAsStateWithLifecycle()
 
     LaunchedEffect(id) {
@@ -92,24 +90,6 @@ internal fun ProgramDetailParticipantManagementRoute(
         viewModel.getTraineeList(expoId = id)
     }
 
-    LaunchedEffect(preParticipantName) {
-        delay(300L)
-        viewModel.getParticipantInformationList(
-            expoId = id,
-            type = ParticipantEnum.PRE,
-            name = preParticipantName
-        )
-    }
-
-    LaunchedEffect(fieldParticipantName) {
-        delay(300L)
-        viewModel.getParticipantInformationList(
-            expoId = id,
-            type = ParticipantEnum.FIELD,
-            name = fieldParticipantName
-        )
-    }
-
     LaunchedEffect(traineeName) {
         delay(300L)
         viewModel.getTraineeList(
@@ -124,18 +104,14 @@ internal fun ProgramDetailParticipantManagementRoute(
         participantAheadResponseListUiState = participantAheadResponseListUiState,
         participantFieldResponseListUiState = participantFieldResponseListUiState,
         traineeInformationUiState = traineeInformationUiState,
-        fieldParticipantName = fieldParticipantName,
-        preParticipantName = preParticipantName,
         traineeName = traineeName,
         onBackClick = onBackClick,
-        onFieldParticipantNameChange = viewModel::onFieldParticipantNameChange,
-        onPreParticipantNameChange = viewModel::onPreParticipantNameChange,
         onTraineeNameChange = viewModel::onTraineeNameChange,
         getAheadParticipantList = { name ->
             viewModel.getParticipantInformationList(
                 expoId = id,
                 type = ParticipantEnum.PRE,
-                name = name
+                name = null
             )
         },
         getFieldParticipantList = { name ->
@@ -160,15 +136,11 @@ private fun ProgramDetailParticipantManagementScreen(
     swipeRefreshState: SwipeRefreshState,
     scrollState: ScrollState = rememberScrollState(),
     focusManager: FocusManager = LocalFocusManager.current,
-    fieldParticipantName: String,
-    preParticipantName: String,
     traineeName: String,
     participantAheadResponseListUiState: ParticipantResponseListUiState,
     participantFieldResponseListUiState: ParticipantResponseListUiState,
     traineeInformationUiState: TraineeResponseListUiState,
     onBackClick: () -> Unit,
-    onFieldParticipantNameChange: (String) -> Unit,
-    onPreParticipantNameChange: (String) -> Unit,
     onTraineeNameChange: (String) -> Unit,
     getAheadParticipantList: (String?) -> Unit,
     getFieldParticipantList: (String?) -> Unit,
@@ -548,11 +520,7 @@ private fun HomeDetailParticipantManagementScreenPreview() {
         participantAheadResponseListUiState = ParticipantResponseListUiState.Loading,
         participantFieldResponseListUiState = ParticipantResponseListUiState.Loading,
         traineeInformationUiState = TraineeResponseListUiState.Loading,
-        fieldParticipantName = "",
-        preParticipantName = "",
         traineeName = "",
-        onFieldParticipantNameChange = {},
-        onPreParticipantNameChange = {},
         onTraineeNameChange = {},
         getAheadParticipantList = {},
         getFieldParticipantList = {},

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,6 +23,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -58,6 +60,7 @@ import com.school_of_company.program.viewmodel.ProgramViewModel
 import com.school_of_company.program.viewmodel.uistate.ParticipantResponseListUiState
 import com.school_of_company.program.viewmodel.uistate.TraineeResponseListUiState
 import kotlinx.coroutines.delay
+import java.time.LocalDate
 
 @Composable
 internal fun ProgramDetailParticipantManagementRoute(
@@ -74,6 +77,7 @@ internal fun ProgramDetailParticipantManagementRoute(
     val traineeInformationUiState by viewModel.traineeResponseListUiState.collectAsStateWithLifecycle()
 
     val traineeName by viewModel.traineeName.collectAsStateWithLifecycle()
+    var selectedDate by remember { mutableStateOf<LocalDate?>(null) }
 
     LaunchedEffect(id) {
 
@@ -104,6 +108,7 @@ internal fun ProgramDetailParticipantManagementRoute(
         participantAheadResponseListUiState = participantAheadResponseListUiState,
         participantFieldResponseListUiState = participantFieldResponseListUiState,
         traineeInformationUiState = traineeInformationUiState,
+        selectedDate = selectedDate,
         traineeName = traineeName,
         onBackClick = onBackClick,
         onTraineeNameChange = viewModel::onTraineeNameChange,
@@ -136,6 +141,7 @@ private fun ProgramDetailParticipantManagementScreen(
     swipeRefreshState: SwipeRefreshState,
     scrollState: ScrollState = rememberScrollState(),
     focusManager: FocusManager = LocalFocusManager.current,
+    selectedDate: LocalDate?,
     traineeName: String,
     participantAheadResponseListUiState: ParticipantResponseListUiState,
     participantFieldResponseListUiState: ParticipantResponseListUiState,
@@ -149,7 +155,15 @@ private fun ProgramDetailParticipantManagementScreen(
     var participantTextState by rememberSaveable { mutableStateOf("사전 행사 참가자") }
     var isDropdownExpanded by rememberSaveable { mutableStateOf(false) }
     var selectedItem by rememberSaveable { mutableIntStateOf(0) }
+    val dateList = remember(selectedDate) {
+        val selectedDateNotNull = selectedDate ?: LocalDate.now()
+        val startDate = selectedDateNotNull.minusDays(10)
+        val endDate = selectedDateNotNull.plusDays(10)
 
+        generateSequence(startDate) { it.plusDays(1) }
+            .takeWhile { !it.isAfter(endDate) }
+            .toList()
+    }
 
     ExpoAndroidTheme { colors, typography ->
 
@@ -370,7 +384,6 @@ private fun ProgramDetailParticipantManagementScreen(
 
             Spacer(modifier = Modifier.height(18.dp))
             if (selectedItem == 2) {
-
                 ExpoNoneLabelTextField(
                     placeholder = "참가자 이름을 입력해주세요.",
                     isError = false,
@@ -513,15 +526,16 @@ private fun ProgramDetailParticipantManagementScreen(
 @Composable
 private fun HomeDetailParticipantManagementScreenPreview() {
     ProgramDetailParticipantManagementScreen(
-        onBackClick = {},
         swipeRefreshState = rememberSwipeRefreshState(isRefreshing = false),
+        traineeName = "",
         participantAheadResponseListUiState = ParticipantResponseListUiState.Loading,
         participantFieldResponseListUiState = ParticipantResponseListUiState.Loading,
         traineeInformationUiState = TraineeResponseListUiState.Loading,
-        traineeName = "",
+        onBackClick = {},
         onTraineeNameChange = {},
         getAheadParticipantList = {},
         getFieldParticipantList = {},
         getTraineeList = {},
+        selectedDate = LocalDate.now(),
     )
 }

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -63,6 +64,7 @@ import com.school_of_company.program.viewmodel.ProgramViewModel
 import com.school_of_company.program.viewmodel.uistate.ParticipantResponseListUiState
 import com.school_of_company.program.viewmodel.uistate.TraineeResponseListUiState
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import java.time.LocalDate
 
 @Composable
@@ -175,6 +177,8 @@ private fun ProgramDetailParticipantManagementScreen(
     var isDropdownExpanded by rememberSaveable { mutableStateOf(false) }
     var selectedItem by rememberSaveable { mutableIntStateOf(0) }
     val dateTagLazyRowState = rememberLazyListState(initialFirstVisibleItemIndex = 10)
+    val coroutineScope = rememberCoroutineScope()
+
     val dateList = remember(selectedDate) {
         val selectedDateNotNull = selectedDate ?: LocalDate.now()
         val startDate = selectedDateNotNull.minusDays(10)
@@ -422,6 +426,10 @@ private fun ProgramDetailParticipantManagementScreen(
                                     onSelectedDateChange(null)
                                 } else {
                                     onSelectedDateChange(date)
+                                }
+
+                                coroutineScope.launch {
+                                    dateTagLazyRowState.scrollToItem(10)
                                 }
                             }
                         )

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -116,20 +116,20 @@ internal fun ProgramDetailParticipantManagementRoute(
             viewModel.getParticipantInformationList(
                 expoId = id,
                 type = ParticipantEnum.PRE,
-                name = null
+                localDate = selectedDate.toString()
             )
         },
         getFieldParticipantList = {
             viewModel.getParticipantInformationList(
                 expoId = id,
                 type = ParticipantEnum.FIELD,
-                name = null
+                localDate = selectedDate.toString()
             )
         },
         getTraineeList = {
             viewModel.getTraineeList(
                 expoId = id,
-                name = traineeName
+                name = traineeName,
             )
         },
     )
@@ -383,6 +383,15 @@ private fun ProgramDetailParticipantManagementScreen(
             }
 
             Spacer(modifier = Modifier.height(18.dp))
+
+            LazyRow(
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth()
+            ) {
+
+            }
+
             if (selectedItem == 2) {
                 ExpoNoneLabelTextField(
                     placeholder = "참가자 이름을 입력해주세요.",

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -397,41 +397,29 @@ private fun ProgramDetailParticipantManagementScreen(
             }
 
             Spacer(modifier = Modifier.height(18.dp))
+            if (selectedItem == 2) {
 
-            ExpoNoneLabelTextField(
-                placeholder = "참가자 이름을 입력해주세요.",
-                isError = false,
-                isDisabled = false,
-                errorText = "",
-                value = when (selectedItem) {
-                    0 -> preParticipantName
-                    1 -> fieldParticipantName
-                    2 -> traineeName
-                    else -> ""
-                },
-                onValueChange = when (selectedItem) {
-                    0 -> onPreParticipantNameChange
-                    1 -> onFieldParticipantNameChange
-                    2 -> onTraineeNameChange
-                    else -> ({})
-                },
-                trailingIcon = {
-                    SearchIcon(
-                        tint = colors.black,
-                        modifier = Modifier.clickable {
-                            when (selectedItem) {
-                                0 -> getAheadParticipantList(preParticipantName)
-                                1 -> getFieldParticipantList(fieldParticipantName)
-                                2 -> getTraineeList(traineeName)
+                ExpoNoneLabelTextField(
+                    placeholder = "참가자 이름을 입력해주세요.",
+                    isError = false,
+                    isDisabled = false,
+                    errorText = "",
+                    value = traineeName,
+                    onValueChange = onTraineeNameChange,
+                    trailingIcon = {
+                        SearchIcon(
+                            tint = colors.black,
+                            modifier = Modifier.clickable {
+                                getTraineeList(traineeName)
                             }
-                        }
-                    )
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(44.dp)
-                    .padding(horizontal = 16.dp)
-            )
+                        )
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(44.dp)
+                        .padding(horizontal = 16.dp)
+                )
+            }
 
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -173,6 +174,7 @@ private fun ProgramDetailParticipantManagementScreen(
     var participantTextState by rememberSaveable { mutableStateOf("사전 행사 참가자") }
     var isDropdownExpanded by rememberSaveable { mutableStateOf(false) }
     var selectedItem by rememberSaveable { mutableIntStateOf(0) }
+    val dateTagLazyRowState = rememberLazyListState(initialFirstVisibleItemIndex = 10)
     val dateList = remember(selectedDate) {
         val selectedDateNotNull = selectedDate ?: LocalDate.now()
         val startDate = selectedDateNotNull.minusDays(10)
@@ -408,6 +410,7 @@ private fun ProgramDetailParticipantManagementScreen(
                     modifier = Modifier
                         .padding(16.dp)
                         .fillMaxWidth(),
+                    state = dateTagLazyRowState,
                     horizontalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     items(dateList) { date: LocalDate ->

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -82,7 +82,7 @@ internal fun ProgramDetailParticipantManagementRoute(
     val traineeInformationUiState by viewModel.traineeResponseListUiState.collectAsStateWithLifecycle()
 
     val traineeName by viewModel.traineeName.collectAsStateWithLifecycle()
-    var selectedDate by remember { mutableStateOf<LocalDate?>(null) }
+    var selectedDate by rememberSaveable { mutableStateOf<LocalDate?>(null) }
 
     LaunchedEffect(id) {
 

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/LocalDateButton.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/LocalDateButton.kt
@@ -3,7 +3,10 @@ package com.school_of_company.program.view.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -60,10 +63,19 @@ internal fun LocalDateButton(
 @Composable
 @Preview
 private fun LocalDateButtonPreview() {
-    LocalDateButton(
-        modifier = Modifier,
-        date = LocalDate.now(),
-        selected = false,
-        onClick = {},
-    )
+    Column {
+        LocalDateButton(
+            modifier = Modifier,
+            date = LocalDate.now(),
+            selected = false,
+            onClick = {},
+        )
+        Spacer(Modifier.height(16.dp))
+        LocalDateButton(
+            modifier = Modifier,
+            date = LocalDate.now(),
+            selected = true,
+            onClick = {},
+        )
+    }
 }

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/LocalDateButton.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/LocalDateButton.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -55,7 +54,6 @@ internal fun LocalDateButton(
             Text(
                 text = date.toString(),
                 style = typography.captionRegular2,
-                fontWeight = FontWeight.W400,
                 color = textColor,
                 textAlign = TextAlign.Center,
             )

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/LocalDateButton.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/LocalDateButton.kt
@@ -47,7 +47,10 @@ internal fun LocalDateButton(
                     color = outlineColor,
                     shape = RoundedCornerShape(size = 6.dp)
                 )
-                .padding(horizontal = 12.dp, vertical = 8.dp),
+                .padding(
+                    horizontal = 12.dp,
+                    vertical = 8.dp,
+                ),
         ) {
             Text(
                 text = date.toString(),

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/LocalDateButton.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/LocalDateButton.kt
@@ -1,0 +1,69 @@
+package com.school_of_company.program.view.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.school_of_company.design_system.component.modifier.clickable.expoClickable
+import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import java.time.LocalDate
+
+@Composable
+internal fun LocalDateButton(
+    modifier: Modifier = Modifier,
+    date: LocalDate,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    ExpoAndroidTheme { colors, typography ->
+        val outlineColor = if (selected) colors.main else colors.gray200
+        val textColor = if (selected) colors.white else colors.main
+        val backGroundColor = if (selected) colors.main else colors.white
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = modifier
+                .expoClickable(onClick = onClick)
+                .background(
+                    color = backGroundColor,
+                    shape = RoundedCornerShape(size = 6.dp)
+                )
+                .border(
+                    width = 1.dp,
+                    color = outlineColor,
+                    shape = RoundedCornerShape(size = 6.dp)
+                )
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+        ) {
+            Text(
+                text = date.toString(),
+                style = typography.captionRegular2,
+                fontWeight = FontWeight.W400,
+                color = textColor,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun LocalDateButtonPreview() {
+    LocalDateButton(
+        modifier = Modifier,
+        date = LocalDate.now(),
+        selected = false,
+        onClick = {},
+    )
+}

--- a/feature/program/src/main/java/com/school_of_company/program/viewmodel/ProgramViewModel.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/viewmodel/ProgramViewModel.kt
@@ -219,7 +219,6 @@ internal class ProgramViewModel @Inject constructor(
     internal fun getParticipantInformationList(
         expoId: String,
         type: ParticipantEnum,
-        name: String? = null,
         localDate: String? = null
     ) = viewModelScope.launch {
         _swipeRefreshLoading.value = true
@@ -232,7 +231,6 @@ internal class ProgramViewModel @Inject constructor(
         getParticipantListInformationUseCase(
             type = type.name,
             expoId = expoId,
-            name = name,
             localDate = localDate
         )
             .asResult()

--- a/feature/program/src/main/java/com/school_of_company/program/viewmodel/ProgramViewModel.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/viewmodel/ProgramViewModel.kt
@@ -40,8 +40,6 @@ internal class ProgramViewModel @Inject constructor(
 ) : ViewModel() {
     companion object {
         private const val REQUEST_DELAY_MS = 2000L
-        private const val FIELD_PARTICIPANT_NAME = "field_participant_name"
-        private const val PRE_PARTICIPANT_NAME = "pre_participant_name"
         private const val TRAINEE_NAME = "trainee_name"
     }
 
@@ -68,8 +66,6 @@ internal class ProgramViewModel @Inject constructor(
     private val _participantAheadResponseListUiState = MutableStateFlow<ParticipantResponseListUiState>(ParticipantResponseListUiState.Loading)
     internal val participantAheadResponseListUiState = _participantAheadResponseListUiState.asStateFlow()
 
-    internal val fieldParticipantName = savedStateHandle.getStateFlow(FIELD_PARTICIPANT_NAME, "")
-    internal val preParticipantName = savedStateHandle.getStateFlow(PRE_PARTICIPANT_NAME, "")
     internal val traineeName = savedStateHandle.getStateFlow(TRAINEE_NAME, "")
 
     internal fun trainingProgramList(expoId: String) = viewModelScope.launch {
@@ -255,14 +251,6 @@ internal class ProgramViewModel @Inject constructor(
                     }
                 }
             }
-    }
-
-    internal fun onFieldParticipantNameChange(value: String) {
-        savedStateHandle[FIELD_PARTICIPANT_NAME] = value
-    }
-
-    internal fun onPreParticipantNameChange(value: String) {
-        savedStateHandle[PRE_PARTICIPANT_NAME] = value
     }
 
     internal fun onTraineeNameChange(value: String) {

--- a/feature/program/src/main/java/com/school_of_company/program/viewmodel/ProgramViewModel.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/viewmodel/ProgramViewModel.kt
@@ -12,13 +12,13 @@ import com.school_of_company.domain.usecase.standard.StandardProgramListUseCase
 import com.school_of_company.domain.usecase.trainee.TraineeResponseListUseCase
 import com.school_of_company.domain.usecase.training.TrainingProgramListUseCase
 import com.school_of_company.model.param.attendance.StandardQrCodeRequestParam
-import com.school_of_company.program.viewmodel.uistate.StandardProgramListUiState
-import com.school_of_company.program.viewmodel.uistate.TrainingProgramListUiState
-import com.school_of_company.program.viewmodel.uistate.ReadQrCodeUiState
 import com.school_of_company.model.param.attendance.TrainingQrCodeRequestParam
 import com.school_of_company.program.enum.ParticipantEnum
 import com.school_of_company.program.viewmodel.uistate.ParticipantResponseListUiState
+import com.school_of_company.program.viewmodel.uistate.ReadQrCodeUiState
+import com.school_of_company.program.viewmodel.uistate.StandardProgramListUiState
 import com.school_of_company.program.viewmodel.uistate.TraineeResponseListUiState
+import com.school_of_company.program.viewmodel.uistate.TrainingProgramListUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
@@ -35,7 +36,7 @@ internal class ProgramViewModel @Inject constructor(
     private val traineeResponseListUseCase: TraineeResponseListUseCase,
     private val trainingQrCodeRequestUseCase: TrainingQrCodeRequestUseCase,
     private val standardQrCodeRequestUseCase: StandardQrCodeRequestUseCase,
-    private val participantInformationResponseUseCase: ParticipantInformationResponseUseCase,
+    private val getParticipantListInformationUseCase: ParticipantInformationResponseUseCase,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     companion object {
@@ -218,7 +219,8 @@ internal class ProgramViewModel @Inject constructor(
     internal fun getParticipantInformationList(
         expoId: String,
         type: ParticipantEnum,
-        name: String? = null
+        name: String? = null,
+        localDate: String? = null
     ) = viewModelScope.launch {
         _swipeRefreshLoading.value = true
 
@@ -227,10 +229,11 @@ internal class ProgramViewModel @Inject constructor(
             ParticipantEnum.FIELD -> _participantFieldResponseListUiState
         }
 
-        participantInformationResponseUseCase(
+        getParticipantListInformationUseCase(
             type = type.name,
             expoId = expoId,
-            name = name
+            name = name,
+            localDate = localDate
         )
             .asResult()
             .collectLatest { result ->


### PR DESCRIPTION
## 💡 개요

화면

https://github.com/user-attachments/assets/796f4d5a-92b3-4b16-b528-d818eeb93d8c

요청사진

![image](https://github.com/user-attachments/assets/2610a34e-6efb-44ff-afab-4ec688e8267c)

## 📃 작업내용

standard참가자 조회시에 검색 컴포넌트가 보이지 않도록 수정,
연수자 조회시에만 검색 컴포넌트를 사용하도록 수정

날짜 태그기반 검색 추가
- 태그 컴포넌트 퍼블리싱, 
- standard 참가자 검색시에 날짜 태그를 띄우도록 추가
- 태그 클릭시 LaunChedEffect를 이용하여 자동으로 요청을 보내도록 수정

## 🔀 변경사항

![image](https://github.com/user-attachments/assets/ff74ad2b-4061-43d0-b2d7-12a9beb8aab2)

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - "사전" 및 "현장" 참가자 관리 화면에 날짜 기반 필터(날짜 선택 버튼)를 도입하였습니다.
    - 날짜 버튼 컴포넌트가 추가되어 날짜별로 참가자 목록을 쉽게 조회할 수 있습니다.

- **Refactor**
    - "사전" 및 "현장" 참가자 검색 방식을 이름 필터에서 날짜 필터로 변경하였습니다.
    - 연수생(트레이니) 검색은 기존과 같이 이름으로만 필터링됩니다.
    - UI가 개선되어, "사전"/"현장"은 날짜 선택, 연수생은 이름 입력 방식으로 구분됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->