### PR TITLE
🔀 :: (#566) - 참가자 조회의 api와 퍼블리싱 변경 적용

### DIFF
--- a/core/data/src/main/java/com/school_of_company/data/repository/participant/ParticipantRepository.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/participant/ParticipantRepository.kt
@@ -5,9 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface ParticipantRepository {
     fun getParticipantInformationList(
-        type: String,
         expoId: String,
-        name: String? = null,
         page: Int? = null,
         size: Int? = null,
         localDate: String? = null

--- a/core/data/src/main/java/com/school_of_company/data/repository/participant/ParticipantRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/participant/ParticipantRepositoryImpl.kt
@@ -11,17 +11,13 @@ class ParticipantRepositoryImpl @Inject constructor(
     private val dataSource: ParticipantDataSource
 ) : ParticipantRepository {
     override fun getParticipantInformationList(
-        type: String,
         expoId: String,
-        name: String?,
         page: Int?,
         size: Int?,
         localDate: String?
     ): Flow<ParticipantInformationResponseEntity> {
         return dataSource.getParticipantInformationList(
-            type = type,
             expoId = expoId,
-            name = name,
             page = page,
             size = size,
             localDate = localDate

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/participant/ParticipantInformationResponseUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/participant/ParticipantInformationResponseUseCase.kt
@@ -9,17 +9,13 @@ class ParticipantInformationResponseUseCase @Inject constructor(
     private val repository: ParticipantRepository
 ) {
     operator fun invoke(
-        type: String,
         expoId: String,
-        name: String? = null,
         page: Int? = null,
         size: Int? = null,
         localDate: String? = null
     ): Flow<ParticipantInformationResponseEntity> =
         repository.getParticipantInformationList(
-            type = type,
             expoId = expoId,
-            name = name,
             page = page,
             size = size,
             localDate = localDate

--- a/core/network/src/main/java/com/school_of_company/network/api/ParticipantAPI.kt
+++ b/core/network/src/main/java/com/school_of_company/network/api/ParticipantAPI.kt
@@ -10,8 +10,6 @@ interface ParticipantAPI {
     @GET("/participant/{expo_id}")
     suspend fun getParticipantInformationList(
         @Path("expo_id") expoId: String,
-        @Query("type") type: String,
-        @Query("name") name: String? = null,
         @Query("page") page: Int? = null,
         @Query("size") size: Int? = null,
         @Query("LocalDate") localDate: String? = null

--- a/core/network/src/main/java/com/school_of_company/network/datasource/participant/ParticipantDataSource.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/participant/ParticipantDataSource.kt
@@ -5,9 +5,7 @@ import kotlinx.coroutines.flow.Flow
 
 interface ParticipantDataSource {
     fun getParticipantInformationList(
-        type: String,
         expoId: String,
-        name: String? = null,
         page: Int? = null,
         size: Int? = null,
         localDate: String? = null

--- a/core/network/src/main/java/com/school_of_company/network/datasource/participant/ParticipantDataSourceImpl.kt
+++ b/core/network/src/main/java/com/school_of_company/network/datasource/participant/ParticipantDataSourceImpl.kt
@@ -10,17 +10,13 @@ class ParticipantDataSourceImpl @Inject constructor(
     private val service: ParticipantAPI
 ) : ParticipantDataSource {
     override fun getParticipantInformationList(
-        type: String,
         expoId: String,
-        name: String?,
         page: Int?,
         size: Int?,
         localDate: String?
     ): Flow<ParticipantInformationResponse> =
         performApiRequest { service.getParticipantInformationList(
-            type = type,
             expoId = expoId,
-            name = name,
             page = page,
             size = size,
             localDate = localDate

--- a/core/network/src/main/java/com/school_of_company/network/dto/participant/response/ParticipantInformationResponse.kt
+++ b/core/network/src/main/java/com/school_of_company/network/dto/participant/response/ParticipantInformationResponse.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class ParticipantInformationResponse(
     @Json(name = "info") val info: PageInfo,
-    @Json(name = "participant") val participant: List<ParticipantResponse>
+    @Json(name = "participants") val participants: List<ParticipantResponse>
 )
 
 @JsonClass(generateAdapter = true)

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -51,7 +51,6 @@ import com.school_of_company.design_system.icon.SearchIcon
 import com.school_of_company.design_system.icon.UpArrowIcon
 import com.school_of_company.design_system.icon.WarnIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
-import com.school_of_company.program.enum.ParticipantEnum
 import com.school_of_company.program.view.component.LocalDateButton
 import com.school_of_company.program.view.component.ProgramDetailParticipantDropdownMenu
 import com.school_of_company.program.view.component.ProgramDetailParticipantManagementList
@@ -76,8 +75,7 @@ internal fun ProgramDetailParticipantManagementRoute(
     val swipeRefreshLoading by viewModel.swipeRefreshLoading.collectAsStateWithLifecycle()
     val swipeRefreshState = rememberSwipeRefreshState(isRefreshing = swipeRefreshLoading)
 
-    val participantAheadResponseListUiState by viewModel.participantAheadResponseListUiState.collectAsStateWithLifecycle()
-    val participantFieldResponseListUiState by viewModel.participantFieldResponseListUiState.collectAsStateWithLifecycle()
+    val participantListUiState by viewModel.participantListUiState.collectAsStateWithLifecycle()
     val traineeInformationUiState by viewModel.traineeResponseListUiState.collectAsStateWithLifecycle()
 
     val traineeName by viewModel.traineeName.collectAsStateWithLifecycle()
@@ -85,15 +83,7 @@ internal fun ProgramDetailParticipantManagementRoute(
 
     LaunchedEffect(id) {
 
-        viewModel.getParticipantInformationList(
-            expoId = id,
-            type = ParticipantEnum.PRE
-        )
-
-        viewModel.getParticipantInformationList(
-            expoId = id,
-            type = ParticipantEnum.FIELD
-        )
+        viewModel.getParticipantInformationList(expoId = id)
 
         viewModel.getTraineeList(expoId = id)
     }
@@ -110,12 +100,6 @@ internal fun ProgramDetailParticipantManagementRoute(
         delay(300L)
         viewModel.getParticipantInformationList(
             expoId = id,
-            type = ParticipantEnum.FIELD,
-            localDate = selectedDate.toString(),
-        )
-        viewModel.getParticipantInformationList(
-            expoId = id,
-            type = ParticipantEnum.PRE,
             localDate = selectedDate.toString(),
         )
     }
@@ -123,8 +107,7 @@ internal fun ProgramDetailParticipantManagementRoute(
     ProgramDetailParticipantManagementScreen(
         modifier = modifier,
         swipeRefreshState = swipeRefreshState,
-        participantAheadResponseListUiState = participantAheadResponseListUiState,
-        participantFieldResponseListUiState = participantFieldResponseListUiState,
+        participantListUiState = participantListUiState,
         traineeInformationUiState = traineeInformationUiState,
         selectedDate = selectedDate,
         startDate = LocalDate.parse(startDate),
@@ -133,17 +116,9 @@ internal fun ProgramDetailParticipantManagementRoute(
         onBackClick = onBackClick,
         onSelectedDateChange = { selectedDate = it },
         onTraineeNameChange = viewModel::onTraineeNameChange,
-        getAheadParticipantList = {
+        getParticipantList = {
             viewModel.getParticipantInformationList(
                 expoId = id,
-                type = ParticipantEnum.PRE,
-                localDate = selectedDate.toString()
-            )
-        },
-        getFieldParticipantList = {
-            viewModel.getParticipantInformationList(
-                expoId = id,
-                type = ParticipantEnum.FIELD,
                 localDate = selectedDate.toString()
             )
         },
@@ -166,14 +141,12 @@ private fun ProgramDetailParticipantManagementScreen(
     startDate: LocalDate,
     endDate: LocalDate,
     traineeName: String,
-    participantAheadResponseListUiState: ParticipantResponseListUiState,
-    participantFieldResponseListUiState: ParticipantResponseListUiState,
+    participantListUiState: ParticipantResponseListUiState,
     traineeInformationUiState: TraineeResponseListUiState,
     onBackClick: () -> Unit,
     onSelectedDateChange: (LocalDate?) -> Unit,
     onTraineeNameChange: (String) -> Unit,
-    getAheadParticipantList: () -> Unit,
-    getFieldParticipantList: () -> Unit,
+    getParticipantList: () -> Unit,
     getTraineeList: () -> Unit,
 ) {
     var participantTextState by rememberSaveable { mutableStateOf("사전 행사 참가자") }
@@ -292,7 +265,7 @@ private fun ProgramDetailParticipantManagementScreen(
 
                     when (selectedItem) {
                         0 -> {
-                            when (participantAheadResponseListUiState) {
+                            when (participantListUiState) {
                                 is ParticipantResponseListUiState.Loading -> {
                                     Text(
                                         text = "로딩중..",
@@ -303,7 +276,7 @@ private fun ProgramDetailParticipantManagementScreen(
 
                                 is ParticipantResponseListUiState.Success -> {
                                     Text(
-                                        text = "${participantAheadResponseListUiState.data.participant.size}명",
+                                        text = "${participantListUiState.data.participant.size}명",
                                         style = typography.captionRegular2,
                                         color = colors.main
                                     )
@@ -328,7 +301,7 @@ private fun ProgramDetailParticipantManagementScreen(
                         }
 
                         1 -> {
-                            when (participantFieldResponseListUiState) {
+                            when (participantListUiState) {
                                 is ParticipantResponseListUiState.Loading -> {
                                     Text(
                                         text = "로딩중..",
@@ -339,7 +312,7 @@ private fun ProgramDetailParticipantManagementScreen(
 
                                 is ParticipantResponseListUiState.Success -> {
                                     Text(
-                                        text = "${participantFieldResponseListUiState.data}명",
+                                        text = "${participantListUiState.data}명",
                                         style = typography.captionRegular2,
                                         color = colors.main
                                     )
@@ -456,8 +429,8 @@ private fun ProgramDetailParticipantManagementScreen(
                 state = swipeRefreshState,
                 onRefresh = {
                     when (selectedItem) {
-                        0 -> getAheadParticipantList()
-                        1 -> getFieldParticipantList()
+                        0 -> getParticipantList()
+                        1 -> getParticipantList()
                         2 -> getTraineeList()
                     }
                 },
@@ -471,7 +444,7 @@ private fun ProgramDetailParticipantManagementScreen(
             ) {
                 when (selectedItem) {
                     0 -> {
-                        when (participantAheadResponseListUiState) {
+                        when (participantListUiState) {
                             is ParticipantResponseListUiState.Loading -> Unit
                             is ParticipantResponseListUiState.Success -> {
                                 Column {
@@ -479,7 +452,7 @@ private fun ProgramDetailParticipantManagementScreen(
 
                                     ProgramDetailParticipantManagementList(
                                         scrollState = scrollState,
-                                        item = participantAheadResponseListUiState.data
+                                        item = participantListUiState.data
                                     )
                                 }
                             }
@@ -501,7 +474,7 @@ private fun ProgramDetailParticipantManagementScreen(
                     }
 
                     1 -> {
-                        when (participantFieldResponseListUiState) {
+                        when (participantListUiState) {
                             is ParticipantResponseListUiState.Loading -> Unit
                             is ParticipantResponseListUiState.Success -> {
                                 Column {
@@ -509,7 +482,7 @@ private fun ProgramDetailParticipantManagementScreen(
 
                                     ProgramDetailParticipantManagementList(
                                         scrollState = scrollState,
-                                        item = participantFieldResponseListUiState.data
+                                        item = participantListUiState.data
                                     )
                                 }
                             }
@@ -574,13 +547,11 @@ private fun HomeDetailParticipantManagementScreenPreview() {
         swipeRefreshState = rememberSwipeRefreshState(isRefreshing = false),
         selectedDate = LocalDate.now(),
         traineeName = "",
-        participantAheadResponseListUiState = ParticipantResponseListUiState.Loading,
-        participantFieldResponseListUiState = ParticipantResponseListUiState.Loading,
+        participantListUiState = ParticipantResponseListUiState.Loading,
         traineeInformationUiState = TraineeResponseListUiState.Loading,
         onBackClick = {},
         onTraineeNameChange = {},
-        getAheadParticipantList = {},
-        getFieldParticipantList = {},
+        getParticipantList = {},
         getTraineeList = {},
         onSelectedDateChange = { _ -> },
         endDate = LocalDate.of(2025, 5, 30),

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -247,9 +247,8 @@ private fun ProgramDetailParticipantManagementScreen(
                             isDropdownExpanded = false
 
                             participantTextState = when (index) {
-                                0 -> "사전 행사 참가자"
-                                1 -> "현장 행사 참가자"
-                                2 -> "사전 교원 원수 참가자"
+                                0 -> "사전 & 현장 행사 참가자"
+                                1 -> "교원 원수 참가자"
                                 else -> participantTextState
                             }
                         },

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -209,11 +209,16 @@ private fun ProgramDetailParticipantManagementScreen(
                 }
             }
 
-            Box(modifier = Modifier.padding(start = 16.dp, top = 10.dp)) {
+            Box(
+                modifier = Modifier.padding(
+                    start = 16.dp,
+                    top = 10.dp
+                ),
+            ) {
                 if (isDropdownExpanded) {
+
                     ProgramDetailParticipantDropdownMenu(
                         onCancelClick = { isDropdownExpanded = false },
-                        onExpandClick = isDropdownExpanded,
                         selectedItem = selectedItem,
                         onItemSelected = { index ->
                             selectedItem = index

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -301,42 +301,6 @@ private fun ProgramDetailParticipantManagementScreen(
                         }
 
                         1 -> {
-                            when (participantListUiState) {
-                                is ParticipantResponseListUiState.Loading -> {
-                                    Text(
-                                        text = "로딩중..",
-                                        style = typography.captionRegular2,
-                                        color = colors.main
-                                    )
-                                }
-
-                                is ParticipantResponseListUiState.Success -> {
-                                    Text(
-                                        text = "${participantListUiState.data}명",
-                                        style = typography.captionRegular2,
-                                        color = colors.main
-                                    )
-                                }
-
-                                is ParticipantResponseListUiState.Error -> {
-                                    Text(
-                                        text = "데이터를 불러올 수 없습니다..",
-                                        style = typography.captionRegular2,
-                                        color = colors.main
-                                    )
-                                }
-
-                                is ParticipantResponseListUiState.Empty -> {
-                                    Text(
-                                        text = "0명",
-                                        style = typography.captionRegular2,
-                                        color = colors.main
-                                    )
-                                }
-                            }
-                        }
-
-                        2 -> {
                             when (traineeInformationUiState) {
                                 is TraineeResponseListUiState.Loading -> {
                                     Text(
@@ -430,8 +394,7 @@ private fun ProgramDetailParticipantManagementScreen(
                 onRefresh = {
                     when (selectedItem) {
                         0 -> getParticipantList()
-                        1 -> getParticipantList()
-                        2 -> getTraineeList()
+                        1 -> getTraineeList()
                     }
                 },
                 indicator = { state, refreshTrigger ->
@@ -459,14 +422,14 @@ private fun ProgramDetailParticipantManagementScreen(
 
                             is ParticipantResponseListUiState.Error -> {
                                 ShowErrorState(
-                                    errorText = "사전 행사 참가자를 불러올 수 없습니다..",
+                                    errorText = "행사 참가자를 불러올 수 없습니다..",
                                     scrollState = scrollState
                                 )
                             }
 
                             is ParticipantResponseListUiState.Empty -> {
                                 ShowEmptyState(
-                                    emptyMessage = "사전 행사 참가자가 존재하지 않습니다..",
+                                    emptyMessage = "행사 참가자가 존재하지 않습니다..",
                                     scrollState = scrollState
                                 )
                             }
@@ -474,38 +437,6 @@ private fun ProgramDetailParticipantManagementScreen(
                     }
 
                     1 -> {
-                        when (participantListUiState) {
-                            is ParticipantResponseListUiState.Loading -> Unit
-                            is ParticipantResponseListUiState.Success -> {
-                                Column {
-                                    ProgramDetailParticipantTable(scrollState = scrollState)
-
-                                    ProgramDetailParticipantManagementList(
-                                        scrollState = scrollState,
-                                        item = participantListUiState.data
-                                    )
-                                }
-                            }
-
-                            is ParticipantResponseListUiState.Error -> {
-                                ShowErrorState(
-                                    errorText = "현장 행사 참가자를 불러올 수 없습니다..",
-                                    scrollState = scrollState
-                                )
-                            }
-
-                            is ParticipantResponseListUiState.Empty -> {
-
-                                ShowEmptyState(
-                                    emptyMessage = "현장 행사 참가자가 존재하지 않습니다..",
-                                    scrollState = scrollState
-                                )
-
-                            }
-                        }
-                    }
-
-                    2 -> {
                         when (traineeInformationUiState) {
                             is TraineeResponseListUiState.Loading -> Unit
                             is TraineeResponseListUiState.Success -> {
@@ -521,14 +452,14 @@ private fun ProgramDetailParticipantManagementScreen(
 
                             is TraineeResponseListUiState.Error -> {
                                 ShowErrorState(
-                                    errorText = "사전 교원 원수를 불러올 수 없습니다..",
+                                    errorText = "교원 원수를 불러올 수 없습니다..",
                                     scrollState = scrollState
                                 )
                             }
 
                             is TraineeResponseListUiState.Empty -> {
                                 ShowEmptyState(
-                                    emptyMessage = "사전 교원 원수가 존재하지 않습니다..",
+                                    emptyMessage = "교원 원수가 존재하지 않습니다..",
                                     scrollState = scrollState
                                 )
                             }

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -206,7 +206,7 @@ private fun ProgramDetailParticipantManagementScreen(
                         modifier = Modifier.expoClickable { onBackClick() }
                     )
                 },
-                betweenText = "참가자 관리",
+                betweenText = "참가자 조회",
                 modifier = Modifier.padding(horizontal = 16.dp)
             )
 

--- a/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/ProgramDetailParticipantManagementScreen.kt
@@ -149,7 +149,7 @@ private fun ProgramDetailParticipantManagementScreen(
     getParticipantList: () -> Unit,
     getTraineeList: () -> Unit,
 ) {
-    var participantTextState by rememberSaveable { mutableStateOf("사전 행사 참가자") }
+    var participantTextState by rememberSaveable { mutableStateOf("사전 & 현장 행사 참가자") }
     var isDropdownExpanded by rememberSaveable { mutableStateOf(false) }
     var selectedItem by rememberSaveable { mutableIntStateOf(0) }
 

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantDropdownMenu.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantDropdownMenu.kt
@@ -3,7 +3,6 @@ package com.school_of_company.program.view.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -30,7 +29,7 @@ internal fun ProgramDetailParticipantDropdownMenu(
             modifier = modifier.background(color = colors.white)
         ) {
 
-            val menuItems = listOf("사전 행사 참가자", "현장 행사 참가자", "사전 교원 원수 참가자")
+            val menuItems = listOf("사전 & 현장 행사 참가자", "교원 원수 참가자")
 
             menuItems.forEachIndexed { index, title ->
                 DropdownMenuItem(

--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantDropdownMenu.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantDropdownMenu.kt
@@ -16,7 +16,6 @@ import com.school_of_company.design_system.theme.ExpoAndroidTheme
 @Composable
 internal fun ProgramDetailParticipantDropdownMenu(
     modifier: Modifier = Modifier,
-    onExpandClick: Boolean,
     selectedItem: Int?,
     onCancelClick: () -> Unit,
     onItemSelected: (Int) -> Unit
@@ -24,8 +23,8 @@ internal fun ProgramDetailParticipantDropdownMenu(
     ExpoAndroidTheme { colors, typography ->
 
         DropdownMenu(
-            expanded = onExpandClick,
-            onDismissRequest = { onCancelClick() },
+            expanded = true,
+            onDismissRequest = onCancelClick,
             modifier = modifier.background(color = colors.white)
         ) {
 


### PR DESCRIPTION
## 💡 개요

참가자 조회api와 퍼블리싱 변경을 적용했습니다 

![image](https://github.com/user-attachments/assets/f8c8e1fc-479a-4754-a894-f31de4173d78)

api 변경사항 적용 
- 참가자 검색 api의 name 쿼리 삭제, type 쿼리 삭제

## 📃 작업내용


![image](https://github.com/user-attachments/assets/2ca29c37-8c26-4646-8561-b2a0c101fa1f)

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타
