### PR TITLE
🔀 :: (#571) - 프로그램별 qr 인식에서 대기 시간 없이 바로 qr이 찍히는 문제가 발생하여 2초정도의 delay를 걸어 사용자 경험을 개선하였습니다.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,6 @@
     <application
         android:name=".ExpoApplication"
         android:allowBackup="true"
-        android:usesCleartextTraffic="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -48,9 +48,6 @@ dependencies {
     implementation(project(":core:model"))
     implementation(project(":core:datastore"))
 
-    debugImplementation(libs.debug.chuck)
-    releaseImplementation(libs.release.chuck)
-
     implementation(libs.kotlinx.datetime)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.okhttp.logging)

--- a/core/network/src/main/java/com/school_of_company/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/school_of_company/network/di/NetworkModule.kt
@@ -2,7 +2,6 @@ package com.school_of_company.network.di
 
 import android.content.Context
 import android.util.Log
-import com.readystatesoftware.chuck.ChuckInterceptor
 import com.school_of_company.network.BuildConfig
 import com.school_of_company.network.api.AddressAPI
 import com.school_of_company.network.api.AdminAPI
@@ -65,16 +64,6 @@ object NetworkModule {
             .writeTimeout(30, TimeUnit.SECONDS)
             .addInterceptor(httpLoggingInterceptor)
             .addInterceptor(authInterceptor)
-            .addInterceptor(
-                if (BuildConfig.DEBUG) {
-                    ChuckInterceptor(context)
-                        .showNotification(true)
-                        .maxContentLength(250000)
-                        .retainDataFor(ChuckInterceptor.Period.ONE_DAY)
-                } else {
-                    Interceptor { chain -> chain.proceed(chain.request()) }
-                }
-            )
             .authenticator(tokenAuthenticator)
             .build()
     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -545,8 +545,6 @@ private fun ExpoCreateScreen(
                             introduceTitleState.isNotEmpty() &&
                             addressState.isNotEmpty() &&
                             locationState.isNotEmpty() &&
-                            trainingProgramTextState.isNotEmpty() &&
-                            standardProgramTextState.isNotEmpty() &&
                             startedDateState.isValidDateSequence(endedDateState)
                         ) {
                             ButtonState.Enable

--- a/feature/program/src/main/java/com/school_of_company/program/view/QrScannerScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/QrScannerScreen.kt
@@ -1,12 +1,15 @@
 package com.school_of_company.program.view
 
 import android.Manifest
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.MaterialTheme.typography
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -15,8 +18,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -39,6 +44,7 @@ import com.school_of_company.program.util.QrReadScreenType
 import com.school_of_company.program.util.parseStandardQrScanModel
 import com.school_of_company.program.util.parseTrainingQr
 import com.school_of_company.ui.toast.makeToast
+import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalPermissionsApi::class)
 @Composable
@@ -144,7 +150,19 @@ private fun QrScannerScreen(
     onBackClick: () -> Unit,
     onQrcodeScan: (String) -> Unit,
 ) {
+    var qrSettingCountdown by rememberSaveable { mutableStateOf(3) }
+    var showCountdown by rememberSaveable { mutableStateOf(true) }
+
+    LaunchedEffect(Unit) {
+        while (qrSettingCountdown > 0) {
+            delay(1000)
+            qrSettingCountdown--
+        }
+        showCountdown = false
+    }
+
     ExpoAndroidTheme { colors, _ ->
+
         Box(contentAlignment = Alignment.Center) {
             QrcodeScanView(
                 onQrcodeScan = onQrcodeScan,
@@ -153,13 +171,29 @@ private fun QrScannerScreen(
 
             QrGuideImage()
 
+            if (showCountdown) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Black.copy(alpha = 0.7f))
+                ) {
+                    Text(
+                        text = "QR 스캔 준비중...$qrSettingCountdown",
+                        style = typography.bodyLarge,
+                        color = colors.white,
+                        fontSize = 24.sp
+                    )
+                }
+            }
+
             Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = modifier
                     .fillMaxSize()
                     .navigationBarsPadding()
                     .statusBarsPadding()
-                    .padding(horizontal = 16.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
+                    .padding(horizontal = 16.dp)
             ) {
                 ExpoTopBar(
                     startIcon = {

--- a/feature/program/src/main/java/com/school_of_company/program/view/QrScannerScreen.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/QrScannerScreen.kt
@@ -30,6 +30,7 @@ import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.google.accompanist.permissions.shouldShowRationale
 import com.school_of_company.design_system.R
+import com.school_of_company.design_system.component.loading.LoadingDot
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
 import com.school_of_company.design_system.icon.LeftArrowIcon
@@ -150,7 +151,7 @@ private fun QrScannerScreen(
     onBackClick: () -> Unit,
     onQrcodeScan: (String) -> Unit,
 ) {
-    var qrSettingCountdown by rememberSaveable { mutableStateOf(3) }
+    var qrSettingCountdown by rememberSaveable { mutableStateOf(2) }
     var showCountdown by rememberSaveable { mutableStateOf(true) }
 
     LaunchedEffect(Unit) {
@@ -164,47 +165,45 @@ private fun QrScannerScreen(
     ExpoAndroidTheme { colors, _ ->
 
         Box(contentAlignment = Alignment.Center) {
-            QrcodeScanView(
-                onQrcodeScan = onQrcodeScan,
-                lifecycleOwner = lifecycleOwner,
-            )
-
-            QrGuideImage()
 
             if (showCountdown) {
+
                 Box(
                     contentAlignment = Alignment.Center,
                     modifier = Modifier
                         .fillMaxSize()
                         .background(Color.Black.copy(alpha = 0.7f))
                 ) {
-                    Text(
-                        text = "QR 스캔 준비중...$qrSettingCountdown",
-                        style = typography.bodyLarge,
-                        color = colors.white,
-                        fontSize = 24.sp
+                    LoadingDot()
+                }
+            } else {
+
+                QrcodeScanView(
+                    onQrcodeScan = onQrcodeScan,
+                    lifecycleOwner = lifecycleOwner,
+                )
+
+                QrGuideImage()
+
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = modifier
+                        .fillMaxSize()
+                        .navigationBarsPadding()
+                        .statusBarsPadding()
+                        .padding(horizontal = 16.dp)
+                ) {
+                    ExpoTopBar(
+                        startIcon = {
+                            LeftArrowIcon(
+                                tint = colors.white,
+                                modifier = Modifier
+                                    .expoClickable { onBackClick() }
+                                    .padding(top = 16.dp)
+                            )
+                        }
                     )
                 }
-            }
-
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = modifier
-                    .fillMaxSize()
-                    .navigationBarsPadding()
-                    .statusBarsPadding()
-                    .padding(horizontal = 16.dp)
-            ) {
-                ExpoTopBar(
-                    startIcon = {
-                        LeftArrowIcon(
-                            tint = colors.white,
-                            modifier = Modifier
-                                .expoClickable { onBackClick() }
-                                .padding(top = 16.dp)
-                        )
-                    }
-                )
             }
         }
     }


### PR DESCRIPTION
## 💡 개요
- 프로그램별 qr 인식에서 대기 시간 없이 바로 qr이 찍히는 문제가 발생하여 2초정도의 delay를 걸어 사용자 경험을 개선할 필요가 있었습니다.
## 📃 작업내용
- 프로그램별 qr 인식에서 대기 시간 없이 바로 qr이 찍히는 문제가 발생하여 2초정도의 delay를 걸어 사용자 경험을 개선하였습니다.
   - qr 스캔 화면에 진입한 직후에 2초동안 로딩 화면이 띄워져 사용자가 의도하지 않은 상황에서 되도록이면 qr이 스캔되지 않도록 수정하였습니다.
   - before

      https://github.com/user-attachments/assets/d5b7899f-797a-4248-85f8-ea63dafe160e

   - after

      https://github.com/user-attachments/assets/f71d666c-e1e8-415b-b80d-ce1c4805336c

## 🔀 변경사항
- chore QrScannerScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - QR 스캐너 화면 진입 시 2초간 로딩 애니메이션이 표시됩니다. 로딩이 끝난 후 QR 코드 스캐너 화면이 정상적으로 노출됩니다.
- **개선 사항**
  - Expo 생성 화면에서 "생성하기" 버튼 활성화 조건이 간소화되어, 특정 프로그램 리스트 입력 없이도 버튼을 활성화할 수 있습니다.
- **기타 변경**
  - 앱의 보안 설정에서 cleartext 트래픽 허용이 제거되었습니다.
  - 네트워크 모듈에서 디버그용 네트워크 인터셉터가 제거되어, 앱의 네트워크 로깅 방식이 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->