### PR TITLE
🔀 :: (586) - 현재 앱이 30의 API 수준을 타겟팅하고 있지만, 보안 및 성능에 최적화된 최신 API를 기반으로 앱을 빌드하려면 API 수준 34 이상을 타겟팅하도록 수정하였습니다.

### DIFF
--- a/build-logic/convention/src/main/java/com/school_of_company/convention/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/com/school_of_company/convention/AndroidApplicationConventionPlugin.kt
@@ -30,7 +30,7 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 defaultConfig {
                     applicationId = "com.school_of_company.expo_android"
                     minSdk = 26
-                    targetSdk = 30
+                    targetSdk = 34
                     versionCode = 1
                     versionName = "1.0"
                     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/build-logic/convention/src/main/java/com/school_of_company/convention/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/com/school_of_company/convention/AndroidApplicationConventionPlugin.kt
@@ -26,12 +26,15 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 // Apply common Kotlin Android settings
                 configureKotlinAndroid(this)
 
+                // Compile SDK - 34 Version
+                compileSdk = 34
+
                 // Configure default settings for the application
                 defaultConfig {
                     applicationId = "com.school_of_company.expo_android"
                     minSdk = 26
                     targetSdk = 34
-                    versionCode = 1
+                    versionCode = 20250424
                     versionName = "1.0"
                     testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
## 💡 개요
- 현재 앱이 30의 API 수준을 타겟팅하고 있지만, 보안 및 성능에 최적화된 최신 API를 기반으로 앱을 빌드하려면 API 수준 34 이상을 타겟팅해야 합니다.
## 📃 작업내용
- targetSDK 버전을 34로 변경해주었습니다.
- compileSDK를 추가하였습니다.
- versionCode = 20250424 즉, 날짜 기반으로 설정해 배포 일자를 파악할 수 있도록 하였습니다.
- versionName = 1.0로 설정하여 첫 배포임을 나타냈습니다.

## 🔀 변경사항
- chore AndroidApplicationConventionPlugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Android 앱의 기본 타겟 SDK 버전이 30에서 34로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->