### PR TITLE
🔀 :: (#598) - 회원가입 요청 리스트 아이템이 fillMaxWidth의 크기를 넘어갔을때 bottom padding 적용이 되어있지 않은 문제를 해결하였습니다.

### DIFF
--- a/feature/user/src/main/java/com/school_of_company/user/view/component/SignUpRequestList.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/component/SignUpRequestList.kt
@@ -57,7 +57,9 @@ internal fun SignUpRequestList(
                         Alignment.CenterHorizontally
                     ),
                     verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 74.dp)
                 ) {
                     UserAllowButton(
                         enabled = selectedId != 0L,


### PR DESCRIPTION
## 💡 개요
- 회원가입 요청 리스트 아이템이 fillMaxWidth의 크기를 넘어갔을때 bottom padding 적용이 되어있지 않은 문제가 있었습니다.
## 📃 작업내용
- 회원가입 요청 리스트 아이템이 fillMaxWidth의 크기를 넘어갔을때 bottom padding 적용이 되어있지 않은 문제를 해결하였습니다.
   - SignUpRequestList의 마지막 버튼 아이템에 bottom padding을 74.dp 만큼 추가해주었습니다.
## 🔀 변경사항
- chore SignUpRequestList
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
    - 사용자 승인 및 삭제 버튼 행(Row)에 하단 패딩이 추가되어 버튼과 하단 요소 간의 간격이 넓어졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->