### PR TITLE
🔀 :: (#597) - 회원가입 로직에서 companion object에 상수 NAME과 NICKNAME이 같은 값을 향하고 있는 문제를 해결하였습니다.

### DIFF
--- a/feature/signup/src/main/java/com/school_of_company/signup/viewmodel/SignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/viewmodel/SignUpViewModel.kt
@@ -34,7 +34,7 @@ internal class SignUpViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     companion object {
-        private const val NAME = "nickname"
+        private const val NAME = "name"
         private const val NICKNAME = "nickname"
         private const val EMAIL = "email"
         private const val PASSWORD = "password"


### PR DESCRIPTION
## 💡 개요
- companion object에 상수 NAME과 NICKNAME이 같은 값을 향하고 있어 실제 요청에서 name와 nickname이 같은 값으로 가버리는 문제가 발생하여 해결해야했습니다.
## 📃 작업내용
- 회원가입 로직에서 companion object에 상수 NAME과 NICKNAME이 같은 값을 향하고 있는 문제를 해결하였습니다.
## 🔀 변경사항
- chore SignUpViewModel
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 회원가입 과정에서 사용자의 이름이 올바르게 저장 및 불러와지도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->