### PR TITLE
🔀 :: (#596) - 앱 이름이 Expo가 아닌 Expo-Android로 되어있어 수정하였습니다.

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">Expo-Android</string>
+    <string name="app_name">Expo</string>
 </resources>


### PR DESCRIPTION
## 💡 개요
- 앱 이름이 Expo가 아닌 Expo-Android로 되어있어있었습니다.
## 📃 작업내용
- 앱 이름이 Expo가 아닌 Expo-Android로 되어있어 수정하였습니다.
    - before
        <img width="56" alt="스크린샷 2025-04-27 오전 1 43 22" src="https://github.com/user-attachments/assets/e5139131-bdfb-46a3-be43-0e2bc959f178" />

    - after
        <img width="53" alt="스크린샷 2025-04-27 오전 1 42 56" src="https://github.com/user-attachments/assets/c021829c-ee83-4ba7-bafb-2a27b35ef310" />

## 🔀 변경사항
chore strings.xml(:app)
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - 앱 이름이 "Expo-Android"에서 "Expo"로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->