### PR TITLE
🔀 :: (#595) - 휴대전화 인증 성공 이후에는 버튼 Disable 처리하였습니다.

### DIFF
--- a/feature/signup/src/main/java/com/school_of_company/signup/view/SignUpScreen.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/view/SignUpScreen.kt
@@ -180,7 +180,8 @@ internal fun SignUpRoute(
         onRePasswordChange = viewModel::onRePasswordChange,
         onPhoneNumberChange = viewModel::onPhoneNumberChange,
         onCertificationNumberChange = viewModel::onCertificationNumberChange,
-        smsSignUpCertificationSendCodeUiState = smsSignUpCertificationSendCodeUiState
+        smsSignUpCertificationSendCodeUiState = smsSignUpCertificationSendCodeUiState,
+        smsSignUpCertificationCodeUiState = smsSignUpCertificationCodeUiState
     )
 }
 
@@ -190,6 +191,7 @@ private fun SignUpScreen(
     isPasswordValidError: Boolean,
     isPasswordMismatchError: Boolean,
     isEmailValidError: Boolean,
+    smsSignUpCertificationCodeUiState: SmsSignUpCertificationCodeUiState,
     smsSignUpCertificationSendCodeUiState: SmsSignUpCertificationSendCodeUiState,
     isCertificationCodeError: Boolean,
     name: String,
@@ -411,7 +413,11 @@ private fun SignUpScreen(
 
                     ExpoStateButton(
                         text = stringResource(id = R.string.check),
-                        state = if (certificationNumber.isNotBlank()) ButtonState.Enable else ButtonState.Disable,
+                        state = when {
+                            smsSignUpCertificationCodeUiState is SmsSignUpCertificationCodeUiState.Success -> ButtonState.Disable
+                            certificationNumber.isNotBlank() -> ButtonState.Enable
+                            else -> ButtonState.Disable
+                        },
                         modifier = Modifier.fillMaxWidth()
                     ) {
                         certificationCallBack()
@@ -460,6 +466,7 @@ private fun SignUpScreenPreview() {
         certificationCallBack = {},
         sendCertificationCodeCallBack = {},
         isCertificationCodeError = false,
-        smsSignUpCertificationSendCodeUiState = SmsSignUpCertificationSendCodeUiState.Loading
+        smsSignUpCertificationSendCodeUiState = SmsSignUpCertificationSendCodeUiState.Loading,
+        smsSignUpCertificationCodeUiState = SmsSignUpCertificationCodeUiState.Loading
     )
 }


### PR DESCRIPTION
## 💡 개요
- 휴대전화 인증 성공 이후에도 인증 버튼이 계속 활성화 되어있어 요청이 가는 문제를 처리해야했습니다.
## 📃 작업내용
- 휴대전화 인증 성공 이후에는 버튼 Disable 처리하였습니다.
    - before

       https://github.com/user-attachments/assets/6bc70538-d98c-4c25-811f-1be941fd5e3c

    - after

       https://github.com/user-attachments/assets/85ed30b7-c6a7-43b6-8326-6f7e008eece6

## 🔀 변경사항
- chore SignUpScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 회원가입 화면에 인증번호 확인 버튼의 활성화 상태가 인증 코드 검증 결과에 따라 동적으로 변경됩니다.  
- **버그 수정**
  - 인증번호 입력란이 비어 있을 때 확인 버튼이 비활성화되도록 동작이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->