### PR TITLE
🔀 :: (#606) - 박람회 자세히 -> 문자보내기 버튼 Disable 처리하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoDetailScreen.kt
@@ -444,8 +444,8 @@ private fun ExpoDetailScreen(
                             }
 
                             ExpoEnableButton(
-                                text = "문자 보내기",
-                                onClick = { isOpenDialog(true) },
+                                text = "문자 보내기(사용X)",
+                                onClick = { isOpenDialog(false) },
                                 textColor = colors.main,
                                 backgroundColor = colors.white,
                                 modifier = Modifier


### PR DESCRIPTION
## 💡 개요
- 현재 프로젝트의 상황에서는 문자보내기 기능을 사용하기에 비용적인 무리가 있어 해당 기능을 Disable 해야했습니다.
## 📃 작업내용
- 현재 프로젝트의 상황에서는 문자보내기 기능을 사용하기에 비용적인 무리가 있어 해당 기능을 Disable 처리하였습니다.
     - 문자 보내기 버튼에서 onClick 동작시 아무런 이벤트가 일어나지 않도록 수정하였습니다.
     - 문자 보내기 -> 문자 보내기(사용X)
## 🔀 변경사항
- chore ExpoDetailScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
    - "문자 보내기" 버튼의 텍스트가 "문자 보내기(사용X)"로 변경되었습니다.
    - 해당 버튼을 눌러도 더 이상 대화 상자가 열리지 않도록 동작이 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->