### PR TITLE
🔀 :: (#605) - 박람회 생성 -> 프로그램 생성시 날짜 설정을 하지 않으면 박람회 생성이 불가능하도록 설정하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -538,18 +538,24 @@ private fun ExpoCreateScreen(
 
                     ExpoStateButton(
                         text = "생성하기",
-                        state = if (
+                        state = when {
                             modifyTitleState.isNotEmpty() &&
-                            startedDateState.isNotEmpty() &&
-                            endedDateState.isNotEmpty() &&
-                            introduceTitleState.isNotEmpty() &&
-                            addressState.isNotEmpty() &&
-                            locationState.isNotEmpty() &&
-                            startedDateState.isValidDateSequence(endedDateState)
-                        ) {
-                            ButtonState.Enable
-                        } else {
-                            ButtonState.Disable
+                                    startedDateState.isNotEmpty() &&
+                                    endedDateState.isNotEmpty() &&
+                                    introduceTitleState.isNotEmpty() &&
+                                    addressState.isNotEmpty() &&
+                                    locationState.isNotEmpty() &&
+                                    startedDateState.isValidDateSequence(endedDateState) -> {
+                                if (trainingProgramTextState.isEmpty() && standardProgramTextState.isEmpty()) {
+                                    ButtonState.Enable
+                                } else if (trainingProgramTextState.all { it.title.isNotEmpty() && it.startedAt.isNotEmpty() && it.endedAt.isNotEmpty() } &&
+                                    standardProgramTextState.all { it.title.isNotEmpty() && it.startedAt.isNotEmpty() && it.endedAt.isNotEmpty() }) {
+                                    ButtonState.Enable
+                                } else {
+                                    ButtonState.Disable
+                                }
+                            }
+                            else -> ButtonState.Disable
                         },
                         onClick = onExpoCreateCallBack,
                         modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
## 💡 개요
- 프로그램 생성시 날짜 설정을 하지 않고 생성하여 생성이후 박람회 자세히보기로 이동시 앱이 터지는 문제가 있었습니다.
## 📃 작업내용
- 박람회 생성 -> 프로그램 생성시 날짜 설정을 하지 않으면 박람회 생성이 불가능하도록 설정하였습니다.
   - 박람회 생성시 프로그램 생성은 유무가 아니라서 프로그램 생성을 유무에 따라 버튼 상태를 설정하였습니다.
   - before

       https://github.com/user-attachments/assets/b58dac2d-730e-4d80-9c95-405f7dc44ae7

   - after

       https://github.com/user-attachments/assets/1076bc07-541a-45bc-b0ba-28846fb06226

## 🔀 변경사항
- chore ExpoCreateScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x