### PR TITLE
🔀 :: (#609) - 박람회 생성시 필수 항목에 *표시를 하였습니다.

### DIFF
--- a/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
+++ b/core/design-system/src/main/java/com/school_of_company/design_system/component/textfield/ExpoTextField.kt
@@ -238,6 +238,7 @@ fun LimitedLengthTextField(
     placeholder: String,
     overflowErrorMessage: String = "",
     label: String = "",
+    labelComposable: @Composable () -> Unit,
     isError: Boolean,
     showLengthCounter: Boolean = true,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
@@ -252,13 +253,18 @@ fun LimitedLengthTextField(
             horizontalAlignment = Alignment.Start,
             modifier = modifier.background(color = Color.Transparent)
         ) {
-            Text(
-                text = label,
-                style = typography.bodyBold2,
-                color = colors.black,
-                fontWeight = FontWeight(600),
-                modifier = Modifier.padding(bottom = 10.dp)
-            )
+
+            if (label.isNotEmpty()) {
+                Text(
+                    text = label,
+                    style = typography.bodyBold2,
+                    color = colors.black,
+                    fontWeight = FontWeight(600),
+                    modifier = Modifier.padding(bottom = 10.dp)
+                )
+            } else {
+                labelComposable()
+            }
 
             Box(
                 modifier = Modifier
@@ -573,10 +579,12 @@ fun ExpoOutlinedTextFieldPreview() {
                 label = "비밀번호"
             )
             LimitedLengthTextField(
+                labelComposable = {},
                 value = "",
                 placeholder = "",
                 isError = false,
-                updateTextValue = {})
+                updateTextValue = {}
+            )
 
             NoneLimitedLengthTextField(value = "", placeholder = "", updateTextValue = {})
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -436,7 +436,8 @@ private fun ExpoCreateScreen(
                                 },
                                 style = typography.bodyBold2
                             )
-                        },                        value = startedDateState,
+                        },
+                        value = startedDateState,
                         lengthLimit = 8,
                         showLengthCounter = false,
                         placeholder = "시작일",

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -46,8 +46,11 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -274,9 +277,15 @@ private fun ExpoCreateScreen(
         ) {
             Column(modifier = Modifier.verticalScroll(scrollState)) {
                 Text(
-                    text = "사진",
-                    style = typography.bodyBold2,
-                    color = colors.black,
+                    text = buildAnnotatedString {
+                        withStyle(style = SpanStyle(color = colors.black)) {
+                            append("사진")
+                        }
+                        withStyle(style = SpanStyle(color = colors.main)) {
+                            append(" *")
+                        }
+                    },
+                    style = typography.bodyBold2
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -392,7 +401,19 @@ private fun ExpoCreateScreen(
                 Spacer(modifier = Modifier.padding(top = 28.dp))
 
                 LimitedLengthTextField(
-                    label = "제목",
+                    labelComposable = {
+                        Text(
+                            text = buildAnnotatedString {
+                                withStyle(style = SpanStyle(color = colors.black)) {
+                                    append("제목")
+                                }
+                                withStyle(style = SpanStyle(color = colors.main)) {
+                                    append(" *")
+                                }
+                            },
+                            style = typography.bodyBold2
+                        )
+                    },
                     value = modifyTitleState,
                     placeholder = "제목을 입력해주세요.",
                     isError = false,
@@ -403,8 +424,19 @@ private fun ExpoCreateScreen(
 
                 Row(horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.Start)) {
                     LimitedLengthTextField(
-                        label = "행사 기간",
-                        value = startedDateState,
+                        labelComposable = {
+                            Text(
+                                text = buildAnnotatedString {
+                                    withStyle(style = SpanStyle(color = colors.black)) {
+                                        append("행사 기간")
+                                    }
+                                    withStyle(style = SpanStyle(color = colors.main)) {
+                                        append(" *")
+                                    }
+                                },
+                                style = typography.bodyBold2
+                            )
+                        },                        value = startedDateState,
                         lengthLimit = 8,
                         showLengthCounter = false,
                         placeholder = "시작일",
@@ -416,6 +448,13 @@ private fun ExpoCreateScreen(
                     )
 
                     LimitedLengthTextField(
+                        labelComposable = {
+                            Text(
+                                text = "행사기간",
+                                color = colors.white,
+                                style = typography.bodyBold2
+                            )
+                        },
                         value = endedDateState,
                         lengthLimit = 8,
                         showLengthCounter = false,
@@ -449,8 +488,19 @@ private fun ExpoCreateScreen(
                 Spacer(modifier = Modifier.padding(top = 28.dp))
 
                 LimitedLengthTextField(
-                    label = "소개글",
-                    value = introduceTitleState,
+                    labelComposable = {
+                        Text(
+                            text = buildAnnotatedString {
+                                withStyle(style = SpanStyle(color = colors.black)) {
+                                    append("소개글")
+                                }
+                                withStyle(style = SpanStyle(color = colors.main)) {
+                                    append(" *")
+                                }
+                            },
+                            style = typography.bodyBold2
+                        )
+                    },                    value = introduceTitleState,
                     placeholder = "소개글을 작성해주세요.",
                     isError = false,
                     updateTextValue = onIntroduceTitleChange,
@@ -511,10 +561,15 @@ private fun ExpoCreateScreen(
 
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top)) {
                         Text(
-                            text = "장소",
-                            style = typography.bodyRegular2,
-                            color = colors.black,
-                            fontWeight = FontWeight.W600,
+                            text = buildAnnotatedString {
+                                withStyle(style = SpanStyle(color = colors.black)) {
+                                    append("장소")
+                                }
+                                withStyle(style = SpanStyle(color = colors.main)) {
+                                    append(" *")
+                                }
+                            },
+                            style = typography.bodyBold2
                         )
 
                         ExpoLocationIconTextField(

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -46,8 +46,11 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -305,9 +308,15 @@ private fun ExpoModifyScreen(
                 modifier = Modifier.verticalScroll(scrollState)
             ) {
                 Text(
-                    text = "사진",
-                    style = typography.bodyBold2,
-                    color = colors.black,
+                    text = buildAnnotatedString {
+                        withStyle(style = SpanStyle(color = colors.black)) {
+                            append("사진")
+                        }
+                        withStyle(style = SpanStyle(color = colors.main)) {
+                            append(" *")
+                        }
+                    },
+                    style = typography.bodyBold2
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -423,8 +432,19 @@ private fun ExpoModifyScreen(
                 Spacer(modifier = Modifier.padding(top = 28.dp))
 
                 LimitedLengthTextField(
-                    label = "제목",
-                    value = modifyTitleState,
+                    labelComposable = {
+                        Text(
+                            text = buildAnnotatedString {
+                                withStyle(style = SpanStyle(color = colors.black)) {
+                                    append("제목")
+                                }
+                                withStyle(style = SpanStyle(color = colors.main)) {
+                                    append(" *")
+                                }
+                            },
+                            style = typography.bodyBold2
+                        )
+                    },                    value = modifyTitleState,
                     placeholder = "제목을 입력해주세요.",
                     isError = false,
                     updateTextValue = onModifyTitleChange,
@@ -434,8 +454,19 @@ private fun ExpoModifyScreen(
 
                 Row(horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.Start)) {
                     LimitedLengthTextField(
-                        label = "행사 기간",
-                        value = startedDateState,
+                        labelComposable = {
+                            Text(
+                                text = buildAnnotatedString {
+                                    withStyle(style = SpanStyle(color = colors.black)) {
+                                        append("행사 기간")
+                                    }
+                                    withStyle(style = SpanStyle(color = colors.main)) {
+                                        append(" *")
+                                    }
+                                },
+                                style = typography.bodyBold2
+                            )
+                        },                        value = startedDateState,
                         lengthLimit = 8,
                         placeholder = "시작일",
                         isError = false,
@@ -447,6 +478,7 @@ private fun ExpoModifyScreen(
                     )
 
                     LimitedLengthTextField(
+                        labelComposable = {},
                         value = endedDateState,
                         lengthLimit = 8,
                         placeholder = "마감일",
@@ -480,8 +512,19 @@ private fun ExpoModifyScreen(
                 Spacer(modifier = Modifier.padding(top = 28.dp))
 
                 LimitedLengthTextField(
-                    label = "소개글",
-                    value = introduceTitleState,
+                    labelComposable = {
+                        Text(
+                            text = buildAnnotatedString {
+                                withStyle(style = SpanStyle(color = colors.black)) {
+                                    append("소개글")
+                                }
+                                withStyle(style = SpanStyle(color = colors.main)) {
+                                    append(" *")
+                                }
+                            },
+                            style = typography.bodyBold2
+                        )
+                    },                    value = introduceTitleState,
                     placeholder = "소개글을 작성해주세요.",
                     isError = false,
                     updateTextValue = onIntroduceTitleChange,
@@ -542,10 +585,15 @@ private fun ExpoModifyScreen(
 
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top)) {
                         Text(
-                            text = "장소",
-                            style = typography.bodyRegular2,
-                            color = colors.black,
-                            fontWeight = FontWeight.W600,
+                            text = buildAnnotatedString {
+                                withStyle(style = SpanStyle(color = colors.black)) {
+                                    append("장소")
+                                }
+                                withStyle(style = SpanStyle(color = colors.main)) {
+                                    append(" *")
+                                }
+                            },
+                            style = typography.bodyBold2
                         )
 
                         ExpoLocationIconTextField(

--- a/feature/sms/src/main/java/com/school_of_company/sms/view/SendMessageScreen.kt
+++ b/feature/sms/src/main/java/com/school_of_company/sms/view/SendMessageScreen.kt
@@ -125,6 +125,7 @@ private fun SendMessageScreen(
 
             LimitedLengthTextField(
                 label = "제목",
+                labelComposable = {},
                 value = title,
                 placeholder = "제목을 입력해주세요.",
                 isError = false,
@@ -137,6 +138,7 @@ private fun SendMessageScreen(
 
             LimitedLengthTextField(
                 label = "내용",
+                labelComposable = {},
                 value = content,
                 placeholder = "내용을 입력해주세요.",
                 isError = false,


### PR DESCRIPTION
## 💡 개요
- 박람회 생성시 필수 항목에 *표시하여 사용자가 박람회를 생성할때 헷갈리지 않도록 합니다.
## 📃 작업내용
- 박람회 생성시 필수 항목에 *표시를 하였습니다.
   - "__" "*"를 따로 스타일을 하기 위해 AnnotatedString를 사용하였습니다.
   - label 파라미터를 String 말고 @Composable () -> Unit으로 받도록 하여 AnnotatedString을 사용할 수 있었습니다.
   - 하지만 "*" 표시를 하지 않는 경우도 있어 label이 있으면 기존처럼 String 찍고, 없으면 labelComposable()을 호출해서 Composable 찍도록 수정하였습니다.
   - before

      https://github.com/user-attachments/assets/43899d05-3404-460b-8684-32bf85aeaa07

   - after

      https://github.com/user-attachments/assets/76f10ab4-b10f-4795-b972-825a546c22aa

## 🔀 변경사항
- chore ExpoTextField
- chore ExpoCreateScreen
- chore ExpoModifyScreen
- chore SendMessageScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 필드 라벨에 커스텀 스타일(예: 색상 강조, 별표 등)을 적용할 수 있도록 라벨 커스터마이징 기능이 추가되었습니다.

- **스타일**
    - 필수 입력 항목에 별표(*) 및 색상 강조가 적용되어 시각적으로 구분이 쉬워졌습니다.
    - 일부 화면의 라벨 텍스트 스타일이 일관되게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->