### PR TITLE
🔀 :: (#611) - 박람회 상세 데이터들이 수정 및 생성할때 데이터가 초기화되지 않는 문제를 해결하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -137,7 +137,7 @@ internal fun ExpoModifyRoute(
 
     DisposableEffect(Unit) {
         onDispose {
-            viewModel.initModifyExpo()
+            viewModel.resetExpoInformation()
         }
     }
 
@@ -173,8 +173,6 @@ internal fun ExpoModifyRoute(
             is ModifyExpoInformationUiState.Loading -> Unit
             is ModifyExpoInformationUiState.Success -> {
                 onBackClick()
-                viewModel.resetExpoInformation()
-                viewModel.initModifyExpo()
                 makeToast(context, "박람회 수정을 완료하였습니다.")
             }
 
@@ -206,7 +204,6 @@ internal fun ExpoModifyRoute(
         navigateToExpoAddressSearch = navigateToExpoAddressSearch,
         onAddStandardProgram = viewModel::addStandardProgramModifyText,
         onAddTrainingProgram = viewModel::addTrainingProgramModifyText,
-        clearExpoInformation = viewModel::resetExpoInformation,
         onStartedDateChange = viewModel::onStartedDateChange,
         onEndedDateChange = viewModel::onEndedDateChange,
         onModifyTitleChange = viewModel::onModifyTitleChange,
@@ -242,7 +239,6 @@ private fun ExpoModifyScreen(
     navigateToExpoAddressSearch: () -> Unit,
     onAddStandardProgram: () -> Unit,
     onAddTrainingProgram: () -> Unit,
-    clearExpoInformation: () -> Unit,
     onStartedDateChange: (String) -> Unit,
     onEndedDateChange: (String) -> Unit,
     onModifyTitleChange: (String) -> Unit,
@@ -293,10 +289,7 @@ private fun ExpoModifyScreen(
                 startIcon = {
                     LeftArrowIcon(
                         tint = colors.black,
-                        modifier = Modifier.expoClickable {
-                            onBackClick()
-                            clearExpoInformation()
-                        }
+                        modifier = Modifier.expoClickable { onBackClick() }
                     )
                 },
                 betweenText = "박람회 수정하기"
@@ -704,7 +697,6 @@ private fun HomeDetailModifyScreenPreview() {
         locationState = "",
         onModifyTitleChange = {},
         onLocationChange = {},
-        clearExpoInformation = {},
         onStartedDateChange = {},
         onEndedDateChange = {},
         onIntroduceTitleChange = {},

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -317,12 +317,10 @@ internal class ExpoViewModel @Inject constructor(
             }
     }
 
-    internal fun initModifyExpo() {
+    internal fun resetExpoInformation() {
         _imageUpLoadUiState.value = ImageUpLoadUiState.Loading
         _modifyExpoInformationUiState.value = ModifyExpoInformationUiState.Loading
-    }
 
-    internal fun resetExpoInformation() {
         onCoordinateChange("", "")
         onSearchedCoordinateChange("", "")
         onIntroduceTitleChange("")


### PR DESCRIPTION
## 💡 개요
- 홈에서 박람회 아무거나 클릭 후 수정하기 페이지 갔다가 안드로이드 네비게이션바 뒤로가기 버튼을 클릭하여 생성 페이지로 이동하면 데이터가 초기화 되지 않는 문제가 있었습니다.
## 📃 작업내용
- 박람회 상세 데이터들이 수정 및 생성할때 데이터가 초기화되지 않는 문제를 해결하였습니다.
   - DisposableEffect로 ExpoModifyRoute Composable이 화면에서 사라질 때 resetExpoInformation 함수를 실행하도록 하여 해결하였습니다.
   - initModifyExpo 함수와 resetExpoInformation 함수의 목적이 같아 하나의 함수로 합쳤습니다.
   - before

      https://github.com/user-attachments/assets/cb3de2a7-da61-4f51-8d86-e3394605d8b6

   - after
   
      https://github.com/user-attachments/assets/c2dde2cf-6f30-42d5-9916-d814bf2a5077

## 🔀 변경사항
* chore ExpoModifyScreen
* chore ExpoViewModel
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 전시 수정 화면에서 뒤로 가기 시 전시 정보가 더 이상 초기화되지 않습니다.
  - 전시 수정 완료 후 불필요한 상태 초기화 동작이 제거되어, 성공 시 뒤로 이동과 안내 메시지만 표시됩니다.

- **리팩터링**
  - 전시 정보 초기화 함수 명칭이 보다 명확하게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->