### PR TITLE
🔀 :: (#613) - 디자인과 실제 앱에서 다른 부분이 있어 수정하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -513,7 +513,7 @@ private fun ExpoCreateScreen(
 
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top)) {
                     Text(
-                        text = "참가자 연수 종류",
+                        text = "참가자 프로그램",
                         style = typography.bodyBold2,
                         color = colors.black,
                     )
@@ -537,7 +537,7 @@ private fun ExpoCreateScreen(
                     Spacer(modifier = Modifier.padding(top = 28.dp))
 
                     Text(
-                        text = "연수자 연수 종류",
+                        text = "연수자 프로그램",
                         style = typography.bodyBold2,
                         color = colors.black,
                     )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -529,7 +529,7 @@ private fun ExpoModifyScreen(
 
                 Column(verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.Top)) {
                     Text(
-                        text = "참가자 연수 종류",
+                        text = "참가자 프로그램",
                         style = typography.bodyBold2,
                         color = colors.black,
                     )
@@ -553,7 +553,7 @@ private fun ExpoModifyScreen(
                     Spacer(modifier = Modifier.padding(top = 28.dp))
 
                     Text(
-                        text = "연수자 연수 종류",
+                        text = "연수자 프로그램",
                         style = typography.bodyBold2,
                         color = colors.black,
                     )

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -137,7 +137,7 @@ internal fun ExpoModifyRoute(
 
     DisposableEffect(Unit) {
         onDispose {
-            viewModel.initModifyExpo()
+            viewModel.resetExpoInformation()
         }
     }
 
@@ -173,8 +173,6 @@ internal fun ExpoModifyRoute(
             is ModifyExpoInformationUiState.Loading -> Unit
             is ModifyExpoInformationUiState.Success -> {
                 onBackClick()
-                viewModel.resetExpoInformation()
-                viewModel.initModifyExpo()
                 makeToast(context, "박람회 수정을 완료하였습니다.")
             }
 
@@ -206,7 +204,6 @@ internal fun ExpoModifyRoute(
         navigateToExpoAddressSearch = navigateToExpoAddressSearch,
         onAddStandardProgram = viewModel::addStandardProgramModifyText,
         onAddTrainingProgram = viewModel::addTrainingProgramModifyText,
-        clearExpoInformation = viewModel::resetExpoInformation,
         onStartedDateChange = viewModel::onStartedDateChange,
         onEndedDateChange = viewModel::onEndedDateChange,
         onModifyTitleChange = viewModel::onModifyTitleChange,
@@ -242,7 +239,6 @@ private fun ExpoModifyScreen(
     navigateToExpoAddressSearch: () -> Unit,
     onAddStandardProgram: () -> Unit,
     onAddTrainingProgram: () -> Unit,
-    clearExpoInformation: () -> Unit,
     onStartedDateChange: (String) -> Unit,
     onEndedDateChange: (String) -> Unit,
     onModifyTitleChange: (String) -> Unit,
@@ -293,10 +289,7 @@ private fun ExpoModifyScreen(
                 startIcon = {
                     LeftArrowIcon(
                         tint = colors.black,
-                        modifier = Modifier.expoClickable {
-                            onBackClick()
-                            clearExpoInformation()
-                        }
+                        modifier = Modifier.expoClickable { onBackClick() }
                     )
                 },
                 betweenText = "박람회 수정하기"
@@ -704,7 +697,6 @@ private fun HomeDetailModifyScreenPreview() {
         locationState = "",
         onModifyTitleChange = {},
         onLocationChange = {},
-        clearExpoInformation = {},
         onStartedDateChange = {},
         onEndedDateChange = {},
         onIntroduceTitleChange = {},

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -317,12 +317,10 @@ internal class ExpoViewModel @Inject constructor(
             }
     }
 
-    internal fun initModifyExpo() {
+    internal fun resetExpoInformation() {
         _imageUpLoadUiState.value = ImageUpLoadUiState.Loading
         _modifyExpoInformationUiState.value = ModifyExpoInformationUiState.Loading
-    }
 
-    internal fun resetExpoInformation() {
         onCoordinateChange("", "")
         onSearchedCoordinateChange("", "")
         onIntroduceTitleChange("")

--- a/feature/user/src/main/java/com/school_of_company/user/view/UserScreen.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/UserScreen.kt
@@ -38,6 +38,7 @@ import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.school_of_company.design_system.R
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
 import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
+import com.school_of_company.design_system.component.modifier.padding.paddingVertical
 import com.school_of_company.design_system.component.uistate.empty.ShowEmptyState
 import com.school_of_company.design_system.component.uistate.error.ShowErrorState
 import com.school_of_company.design_system.icon.LogoutIcon
@@ -407,7 +408,10 @@ private fun UserScreen(
                         color = colors.white
                     )
                     .fillMaxWidth()
-                    .padding(vertical = 16.dp)
+                    .paddingVertical(
+                        vertical = 16.dp,
+                        start = 8.dp
+                    )
             ) {
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(20.dp),

--- a/feature/user/src/main/java/com/school_of_company/user/view/component/SignUpRequestList.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/component/SignUpRequestList.kt
@@ -36,7 +36,7 @@ internal fun SignUpRequestList(
         LazyColumn(
             modifier = modifier
                 .background(color = colors.white)
-                .padding(start = 16.dp)
+                .padding(horizontal = 16.dp)
         ) {
             itemsIndexed(item) { index, item ->
                SignUpRequestListItem(

--- a/feature/user/src/main/java/com/school_of_company/user/view/component/SignUpRequestListItem.kt
+++ b/feature/user/src/main/java/com/school_of_company/user/view/component/SignUpRequestListItem.kt
@@ -43,7 +43,7 @@ internal fun SignUpRequestListItem(
                     color = if (selectedIndex == data.id) colors.main100 else colors.white,
                     shape = RoundedCornerShape(size = 4.dp)
                 )
-                .padding(vertical = 8.dp)
+                .padding(all = 8.dp)
                 .horizontalScroll(horizontalScrollState)
                 .expoClickable { onClick(data.id) }
         ) {


### PR DESCRIPTION
## 💡 개요
* 프로필 화면에서 회원가입요청 리스트 아이템을 클릭했을때 간격이 간격이 맞지 않아 수정이 필요했습니다.
* 박람회 생성 화면에서 참가자(연수자) 연수 종류가 아닌 참가자(연수자) 프로그램으로 수정이 필요했습니다.
## 📃 작업내용
* 프로필 화면에서 회원가입요청 리스트 아이템을 클릭했을때 간격이 간격이 맞지 않아 수정하였습니다.
* 박람회 생성 화면에서 참가자(연수자) 연수 종류가 아닌 참가자(연수자) 프로그램으로 수정하였습니다.
## 🔀 변경사항
- chore ExpoCreateScreen
- chore ExpoModifyScreen
- chore UserScreen
- chore SignUpRequestList
- chore SignUpRequestListItem
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
    - Expo 생성 및 수정 화면에서 "참가자 연수 종류"와 "연수자 연수 종류" 라벨이 각각 "참가자 프로그램"과 "연수자 프로그램"으로 변경되었습니다.
    - 사용자 화면에서 박스 컴포넌트의 패딩이 상하 16dp, 좌측 8dp로 조정되었습니다.
    - 회원가입 요청 리스트의 좌우 패딩이 16dp로 변경되어 리스트 양쪽에 동일한 여백이 적용됩니다.
    - 회원가입 요청 리스트 아이템의 패딩이 상하 8dp에서 모든 방향 8dp로 확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->