### PR TITLE
🔀 :: (#615) - 박람회 수정하기 시작일과 마감일 텍스트필드의 정렬이 맞지않아 수정하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -471,7 +471,13 @@ private fun ExpoModifyScreen(
                     )
 
                     LimitedLengthTextField(
-                        labelComposable = {},
+                        labelComposable = {
+                            Text(
+                                text = "행사기간",
+                                color = colors.white,
+                                style = typography.bodyBold2
+                            )
+                        },
                         value = endedDateState,
                         lengthLimit = 8,
                         placeholder = "마감일",


### PR DESCRIPTION
## 💡 개요
- 박람회 수정하기 시작일과 마감일 텍스트필드의 정렬이 맞지않는 문제가 있었습니다.
## 📃 작업내용
- 박람회 수정하기 시작일과 마감일 텍스트필드의 정렬이 맞지않아 수정하였습니다.
- before

    https://github.com/user-attachments/assets/54a278c3-8128-4d1e-ae48-46f8350a1f84

- after

    https://github.com/user-attachments/assets/b18ba9ac-6da3-4963-a941-2d7d247f7b87

## 🔀 변경사항
chore ExpoModifyScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
    - "행사기간" 레이블이 이벤트 종료일 입력란에 추가되어 입력 필드가 더 명확하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->