### PR TITLE
🔀 :: (#618) - 엑스포 수정시에 이미지를 무조건 제업로드 해야하는 문제를 해결했습니다

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -164,11 +164,7 @@ internal fun ExpoModifyRoute(
     ExpoModifyScreen(
         imageUri = selectedImageUri?.toString() ?: coverImageState,
         modifyCallBack = {
-            if (selectedImageUri != null) {
-                viewModel.imageUpLoad(context, selectedImageUri!!)
-            } else {
-                onErrorToast(null, R.string.expo_image_size_fail)
-            }
+            viewModel.modifyExpoInformation(id)
         },
         onBackClick = onBackClick,
         onImageClick = { galleryLauncher.launch("image/*") },

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -97,7 +97,6 @@ internal fun ExpoModifyRoute(
     viewModel: ExpoViewModel = hiltViewModel(LocalContext.current as ComponentActivity)
 ) {
     val modifyExpoInformationUiState by viewModel.modifyExpoInformationUiState.collectAsStateWithLifecycle()
-    val imageUpLoadUiState by viewModel.imageUpLoadUiState.collectAsStateWithLifecycle()
 
     val modifyTitleState by viewModel.modify_title.collectAsStateWithLifecycle()
     val startedDateState by viewModel.started_date.collectAsStateWithLifecycle()
@@ -435,7 +434,8 @@ private fun ExpoModifyScreen(
                                 },
                                 style = typography.bodyBold2
                             )
-                        },                        value = startedDateState,
+                        },
+                        value = startedDateState,
                         lengthLimit = 8,
                         placeholder = "시작일",
                         isError = false,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -412,7 +412,8 @@ private fun ExpoModifyScreen(
                             },
                             style = typography.bodyBold2
                         )
-                    },                    value = modifyTitleState,
+                    },
+                    value = modifyTitleState,
                     placeholder = "제목을 입력해주세요.",
                     isError = false,
                     updateTextValue = onModifyTitleChange,
@@ -498,7 +499,7 @@ private fun ExpoModifyScreen(
                             },
                             style = typography.bodyBold2
                         )
-                    },                    value = introduceTitleState,
+                    }, value = introduceTitleState,
                     placeholder = "소개글을 작성해주세요.",
                     isError = false,
                     updateTextValue = onIntroduceTitleChange,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -141,30 +141,6 @@ internal fun ExpoModifyRoute(
         }
     }
 
-    LaunchedEffect(imageUpLoadUiState) {
-        when (imageUpLoadUiState) {
-            is ImageUpLoadUiState.Loading -> Unit
-            is ImageUpLoadUiState.Success -> {
-                viewModel.modifyExpoInformation(
-                    expoId = id,
-                    body = ExpoModifyRequestParam(
-                        title = viewModel.modify_title.value,
-                        startedDay = viewModel.started_date.value,
-                        finishedDay = viewModel.ended_date.value,
-                        description = viewModel.introduce_title.value,
-                        location = viewModel.location.value,
-                        coverImage = (imageUpLoadUiState as ImageUpLoadUiState.Success).data.imageURL,
-                        x = viewModel.coordinateX.value,
-                        y = viewModel.coordinateY.value,
-                        updateStandardProRequestDto = standardProgramTextState,
-                        updateTrainingProRequestDto = trainingProgramTextState
-                    )
-                )
-            }
-
-            is ImageUpLoadUiState.Error -> {
-                onErrorToast(null, R.string.expo_image_fail)
-            }
     LaunchedEffect(selectedImageUri) {
         if (selectedImageUri != null) {
             viewModel.imageUpLoad(context, selectedImageUri!!)

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -165,6 +165,9 @@ internal fun ExpoModifyRoute(
             is ImageUpLoadUiState.Error -> {
                 onErrorToast(null, R.string.expo_image_fail)
             }
+    LaunchedEffect(selectedImageUri) {
+        if (selectedImageUri != null) {
+            viewModel.imageUpLoad(context, selectedImageUri!!)
         }
     }
 

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -97,6 +97,7 @@ internal fun ExpoModifyRoute(
     viewModel: ExpoViewModel = hiltViewModel(LocalContext.current as ComponentActivity)
 ) {
     val modifyExpoInformationUiState by viewModel.modifyExpoInformationUiState.collectAsStateWithLifecycle()
+    val imageUpLoadUiState by viewModel.imageUpLoadUiState.collectAsStateWithLifecycle()
 
     val modifyTitleState by viewModel.modify_title.collectAsStateWithLifecycle()
     val startedDateState by viewModel.started_date.collectAsStateWithLifecycle()
@@ -123,6 +124,15 @@ internal fun ExpoModifyRoute(
                 }
             }
         }
+
+    LaunchedEffect(imageUpLoadUiState) {
+        when (imageUpLoadUiState) {
+            is ImageUpLoadUiState.Error -> {
+                onErrorToast(null, R.string.expo_image_fail)
+            }
+            else -> Unit
+        }
+    }
 
     LaunchedEffect(Unit) {
         viewModel.setCurrentScreen(CurrentScreen.MODIFY)

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -90,6 +90,7 @@ internal class ExpoViewModel @Inject constructor(
         private const val CREATE_ADDRESS = "create_address"
         private const val CREATE_LOCATION = "create_location"
         private const val CURRENT_SCREEN = "current_screen"
+        private const val IMAGE_URL = "image_url"
     }
 
     internal var currentScreen = savedStateHandle.getStateFlow(CURRENT_SCREEN, CurrentScreen.NONE.name)
@@ -168,6 +169,8 @@ internal class ExpoViewModel @Inject constructor(
     internal var coordinateX = savedStateHandle.getStateFlow(key = COORDINATEX, initialValue = "")
 
     internal var coordinateY = savedStateHandle.getStateFlow(key = COORDINATEY, initialValue = "")
+
+    private var imageUrl = savedStateHandle.getStateFlow(key = IMAGE_URL, initialValue = "")
 
     val expoListSize: StateFlow<Int> = getExpoListUiState
         .map { state ->
@@ -726,5 +729,9 @@ internal class ExpoViewModel @Inject constructor(
 
     internal fun setCurrentScreen(screen: CurrentScreen) {
         savedStateHandle[CURRENT_SCREEN] = screen.name
+    }
+
+    private fun setImageUrl(url: String) {
+        savedStateHandle[IMAGE_URL] = url
     }
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -741,7 +741,7 @@ internal class ExpoViewModel @Inject constructor(
         savedStateHandle[CURRENT_SCREEN] = screen.name
     }
 
-    private fun setImageUrl(url: String) {
-        savedStateHandle[IMAGE_URL] = url
+    private fun setImageUrl(value: String) {
+        savedStateHandle[IMAGE_URL] = value
     }
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -225,6 +225,7 @@ internal class ExpoViewModel @Inject constructor(
                         _getExpoInformationUiState.value = GetExpoInformationUiState.Success(result.data)
 
                         result.data.let {
+                            setImageUrl(it.coverImage ?: "")
                             onModifyTitleChange(it.title)
                             onStartedDateChange(it.startedDay.formatNoneHyphenServerDate())
                             onEndedDateChange(it.finishedDay.formatNoneHyphenServerDate())

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -287,21 +287,30 @@ internal class ExpoViewModel @Inject constructor(
 
     internal fun modifyExpoInformation(
         expoId: String,
-        body: ExpoModifyRequestParam
     ) = viewModelScope.launch {
+        val imageUrlToUse = when (val state = imageUpLoadUiState.value) {
+            is ImageUpLoadUiState.Success -> state.data.imageURL
+            else -> imageUrl.value
+        }
         _modifyExpoInformationUiState.value = ModifyExpoInformationUiState.Loading
         modifyExpoInformationUseCase(
             expoId = expoId,
-            body = body.copy(
-                startedDay = body.startedDay.autoFormatToDateTime(),
-                finishedDay = body.finishedDay.autoFormatToDateTime(),
-                updateStandardProRequestDto = body.updateStandardProRequestDto.map { list ->
+            body = ExpoModifyRequestParam(
+                title = modify_title.value,
+                startedDay = started_date.value.autoFormatToDateTime(),
+                finishedDay = ended_date.value.autoFormatToDateTime(),
+                description = introduce_title.value,
+                location = location.value,
+                coverImage = imageUrlToUse,
+                x = coordinateX.value,
+                y = coordinateY.value,
+                updateStandardProRequestDto = standardProgramModifyTextState.value.map { list ->
                     list.copy(
                         startedAt = list.startedAt.autoFormatToDateTime(),
                         endedAt = list.endedAt.autoFormatToDateTime(),
                     )
                 },
-                updateTrainingProRequestDto = body.updateTrainingProRequestDto.map { list ->
+                updateTrainingProRequestDto = trainingProgramModifyTextState.value.map { list ->
                     list.copy(
                         startedAt = list.startedAt.autoFormatToDateTime(),
                         endedAt = list.endedAt.autoFormatToDateTime(),


### PR DESCRIPTION
## 💡 개요

https://github.com/user-attachments/assets/3b33eea5-89eb-4df4-9bed-3b988523b8a7

## 📃 작업내용

getExpo 함수 포출시에 imageUrl을 저장하고 modifyExpo 함수에서 이미지 변경이 없을시에 저장한 imageUrl을 보내도록 작업

## 🔀 변경사항

![image](https://github.com/user-attachments/assets/2a143887-9d5d-488b-a09f-90d1c87f4a12)

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 이미지 업로드 중 오류 발생 시 오류 메시지가 표시됩니다.

- **리팩터링**
  - 이미지 업로드와 전시 정보 수정 절차가 분리되어, 이미지는 선택 즉시 업로드되고, 정보 수정은 별도로 진행됩니다.
  - 이미지 URL 관리가 개선되어 전시 정보 수정 시 최신 이미지가 반영됩니다.

- **스타일**
  - 일부 화면 구성 요소의 코드 가독성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->