### PR TITLE
🔀 :: (#620) - 박람회 폼 생성, 수정 파트 에러 핸들링을 자세히 하였습니다.

### DIFF
--- a/core/design-system/src/main/res/values/strings.xml
+++ b/core/design-system/src/main/res/values/strings.xml
@@ -93,6 +93,8 @@
     <string name="form_create_fail">폼 생성을 실패했습니다.</string>
     <string name="form_create_success">폼 생성을 성공했습니다.</string>
     <string name="form_modify_success">폼 수정을 성공했습니다.</string>
+    <string name="form_modify_not_found">폼을 먼저 생성해주세요.</string>
+    <string name="form_conflict_error">이미 폼이 생성되어 있습니다.</string>
 
     <string name="expo_image_fail">박람회 이미지가 유효하지 않습니다.</string>
 

--- a/feature/form/build.gradle.kts
+++ b/feature/form/build.gradle.kts
@@ -9,6 +9,4 @@ android {
 
 dependencies {
     implementation(libs.retrofit.core)
-    implementation(libs.retrofit.kotlin.serialization)
-    implementation(libs.retrofit.moshi.converter)
 }

--- a/feature/form/build.gradle.kts
+++ b/feature/form/build.gradle.kts
@@ -6,3 +6,9 @@ plugins {
 android {
     namespace = "com.school_of_company.form"
 }
+
+dependencies {
+    implementation(libs.retrofit.core)
+    implementation(libs.retrofit.kotlin.serialization)
+    implementation(libs.retrofit.moshi.converter)
+}

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
@@ -58,10 +58,12 @@ internal fun FormCreateRoute(
     LaunchedEffect(formUiState) {
         when (formUiState) {
             is FormUiState.Loading -> Unit
-            is FormUiState.Success -> {
-                navigateToExpoNavigationHome()
+            is FormUiState.Success -> navigateToExpoNavigationHome()
+            is FormUiState.NotFound -> Unit
+            is FormUiState.Conflict -> {
+                viewModel.setIsConflictError(true)
+                onErrorToast(null, R.string.form_conflict_error)
             }
-
             is FormUiState.Error -> {
                 onErrorToast(null, R.string.form_create_fail)
             }

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormModifyScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormModifyScreen.kt
@@ -39,6 +39,7 @@ import com.school_of_company.form.view.component.PersonaInformationFormCard
 import com.school_of_company.form.viewModel.FormViewModel
 import com.school_of_company.form.viewModel.uiState.FormUiState
 import com.school_of_company.model.model.form.DynamicFormModel
+import java.text.Normalizer.Form
 
 @Composable
 internal fun FormModifyRoute(
@@ -67,7 +68,11 @@ internal fun FormModifyRoute(
                 popUpBackStack()
                 onErrorToast(null, R.string.form_modify_success)
             }
-
+            is FormUiState.NotFound -> {
+                viewModel.setIsNotFoundError(true)
+                onErrorToast(null, R.string.form_modify_not_found)
+            }
+            is FormUiState.Conflict -> Unit
             is FormUiState.Error -> onErrorToast(null, R.string.form_modify_fail)
         }
     }

--- a/feature/form/src/main/java/com/school_of_company/form/viewModel/FormViewModel.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/viewModel/FormViewModel.kt
@@ -38,7 +38,6 @@ internal class FormViewModel @Inject constructor(
     internal val formUiState = _formUiState.asStateFlow()
 
     private val _getFormUiState = MutableStateFlow<GetFormUiState>(GetFormUiState.Loading)
-    internal val getFormUiState = _getFormUiState.asStateFlow()
 
     internal val formState = savedStateHandle.getStateFlow(FORM_STATE, listOf(DynamicFormModel.createDefault()))
     internal val informationTextState = savedStateHandle.getStateFlow(INFORMATION_TEXT_STATE, "")

--- a/feature/form/src/main/java/com/school_of_company/form/viewModel/FormViewModel.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/viewModel/FormViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -42,6 +43,16 @@ internal class FormViewModel @Inject constructor(
     internal val formState = savedStateHandle.getStateFlow(FORM_STATE, listOf(DynamicFormModel.createDefault()))
     internal val informationTextState = savedStateHandle.getStateFlow(INFORMATION_TEXT_STATE, "")
 
+    private var _isNotFoundError = MutableStateFlow(false)
+    internal fun setIsNotFoundError(value: Boolean) {
+        _isNotFoundError.value = value
+    }
+
+    private var _isConflictError = MutableStateFlow(false)
+    internal fun setIsConflictError(value: Boolean) {
+        _isConflictError.value = value
+    }
+
     internal fun createForm(
         expoId: String,
         participantType: String,
@@ -58,7 +69,13 @@ internal class FormViewModel @Inject constructor(
         )
             .onSuccess {
                 it.catch { remoteError ->
-                    _formUiState.value = FormUiState.Error(remoteError)
+                    _formUiState.value = when {
+                        remoteError is HttpException -> when (remoteError.code()) {
+                            409 -> FormUiState.Conflict
+                            else -> FormUiState.Error(remoteError)
+                        }
+                        else -> FormUiState.Error(remoteError)
+                    }
                 }.collect {
                     _formUiState.value = FormUiState.Success
                 }
@@ -84,7 +101,13 @@ internal class FormViewModel @Inject constructor(
         )
             .onSuccess {
                 it.catch { remoteError ->
-                    _formUiState.value = FormUiState.Error(remoteError)
+                    _formUiState.value = when {
+                        remoteError is HttpException -> when (remoteError.code()) {
+                            404 -> FormUiState.NotFound
+                            else -> FormUiState.Error(remoteError)
+                        }
+                        else -> FormUiState.Error(remoteError)
+                    }
                 }.collect {
                     _formUiState.value = FormUiState.Success
                 }

--- a/feature/form/src/main/java/com/school_of_company/form/viewModel/uiState/FormUiState.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/viewModel/uiState/FormUiState.kt
@@ -4,5 +4,6 @@ internal sealed interface FormUiState {
     object Loading : FormUiState
     object Success : FormUiState
     object NotFound : FormUiState
+    object Conflict : FormUiState
     data class Error(val exception: Throwable) : FormUiState
 }

--- a/feature/form/src/main/java/com/school_of_company/form/viewModel/uiState/FormUiState.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/viewModel/uiState/FormUiState.kt
@@ -3,5 +3,6 @@ package com.school_of_company.form.viewModel.uiState
 internal sealed interface FormUiState {
     object Loading : FormUiState
     object Success : FormUiState
+    object NotFound : FormUiState
     data class Error(val exception: Throwable) : FormUiState
 }


### PR DESCRIPTION
## 💡 개요
- 이미 폼 생성 관련된 필터 API가 있지만 사용자들이 인식을 하지 못하여 아래와 같은 상황이 여러번 보였습니다.
    - 생성되지 않은 폼을 수정하려고 할 경우 에러가(404 Not Found) 발생하지만 따로 핸들링을 하지 않았습니다.
    - 이미 폼을 생성하고 폼을 다시 생성하려고 하는 경우 에러가(409 Conflict) 발생하지만 따로 핸들링을 하지 않았습니다.
## 📃 작업내용
- 생성되지 않은 폼을 수정하려고 할 경우 에러가(404 Not Found) 발생하고 해당 에러는 토스트 메시지로 사용자에게 전달합니다.
- 이미 폼을 생성하고 폼을 다시 생성하려고 하는 경우 에러가(409 Conflict) 발생하고 해당 에러는 토스트 메시지로 사용자에게 전달합니다.
- before

    https://github.com/user-attachments/assets/3fb10e82-8b92-4eab-94b1-fcc5cb3055b2

    https://github.com/user-attachments/assets/d09d0952-c9fc-4932-941b-bdbf31633328

- after

    https://github.com/user-attachments/assets/50d19c2d-3840-48dd-8747-df3540417b4b

    https://github.com/user-attachments/assets/8444f74f-bcbb-4359-b795-fa8a5bbc8d04

## 🔀 변경사항
- chore FormCreateScreen
- chore FormModifyScreen
- chore FormViewModel
- chore strings.xml(:core:design-system)
- chore build.gradle.kts(:feature:form)
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 폼 생성 및 수정 시 "존재하지 않음" 및 "충돌" 오류 상태를 별도로 안내하는 메시지가 추가되었습니다.
    - 폼이 이미 존재하거나 먼저 생성해야 할 때 각각의 안내 토스트 메시지가 표시됩니다.

- **버그 수정**
    - 폼 관련 오류 발생 시 더 구체적인 안내 메시지가 제공되어 사용성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->