### PR TITLE
🔀 :: (#634) - signUp 함수에서 정상적으로 UiState를 처리하도록 수정

### DIFF
--- a/feature/signup/src/main/java/com/school_of_company/signup/viewmodel/SignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/viewmodel/SignUpViewModel.kt
@@ -165,7 +165,7 @@ internal class SignUpViewModel @Inject constructor(
                         }.collect {  _signUpUiState.value = SignUpUiState.Success }
                     }
                     .onFailure { error ->
-                        SignUpUiState.Error(error)
+                        _signUpUiState.value = SignUpUiState.Error(error)
                     }
                 }
             }

--- a/feature/signup/src/main/java/com/school_of_company/signup/viewmodel/SignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/school_of_company/signup/viewmodel/SignUpViewModel.kt
@@ -153,19 +153,19 @@ internal class SignUpViewModel @Inject constructor(
                 signUpRequestUseCase(body = body)
                     .onSuccess {
                         it.catch { remoteError ->
-                            _signUpUiState.value = SignUpUiState.Error(remoteError)
+                            _signUpUiState.value = when {
+                                remoteError is HttpException -> when (remoteError.code()) {
+                                    409 -> SignUpUiState.Conflict
+                                    404  -> SignUpUiState.NotSmsCheck
+                                    else -> SignUpUiState.Error(remoteError)
+                                }
+
+                                else -> SignUpUiState.Error(remoteError)
+                            }
                         }.collect {  _signUpUiState.value = SignUpUiState.Success }
                     }
                     .onFailure { error ->
-                        _signUpUiState.value = when {
-                            error is HttpException -> when (error.code()) {
-                                409 -> SignUpUiState.Conflict
-                                404  -> SignUpUiState.NotSmsCheck
-                                else -> SignUpUiState.Error(error)
-                            }
-
-                            else -> SignUpUiState.Error(error)
-                        }
+                        SignUpUiState.Error(error)
                     }
                 }
             }


### PR DESCRIPTION
## 💡 개요

기존에는 서버에서 응답을 받아오지 못하는 상황에만 응답코드에 대해서 대응하는 UiState를 반환하도록 했지만
이 경우에는 실제로 응답 코드가 없어서 정상적으로 UiState를 반환할수 없었습니다.

## 📃 작업내용

통신을 성공하고 서버에서 에러를 반환할때, status 코드가 반환될때 만 파싱을 하도록 수정했습니다

## 🔀 변경사항

signUpViewModel의 signUp함수의 예외처리 부분

![image](https://github.com/user-attachments/assets/c453ae96-d282-418a-9a09-883d79cf2b97)

->

![image](https://github.com/user-attachments/assets/4781b536-f358-49aa-acfb-47c9aeb878cf)


## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
- 
## 🍴 사용방법

x

## 🎸 기타

x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **버그 수정**
    - 회원가입 중 발생하는 오류에 따라 보다 구체적인 안내 메시지가 표시됩니다. (예: 이미 가입된 경우, SMS 인증 미완료 등)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->