### PR TITLE
Revert "🔀 :: (#624) - juso 도메인의 useCase를 삭제 했습니다"

### DIFF
--- a/core/data/src/main/java/com/school_of_company/data/repository/juso/AddressRepository.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/juso/AddressRepository.kt
@@ -4,5 +4,9 @@ import com.school_of_company.model.model.juso.JusoModel
 import kotlinx.coroutines.flow.Flow
 
 interface AddressRepository {
-    fun getAddress(keyword: String): Flow<List<JusoModel>>
+    fun getAddress(
+        currentPage: Int,
+        countPerPage: Int,
+        keyword: String,
+    ): Flow<List<JusoModel>>
 }

--- a/core/data/src/main/java/com/school_of_company/data/repository/juso/AddressRepositoryImpl.kt
+++ b/core/data/src/main/java/com/school_of_company/data/repository/juso/AddressRepositoryImpl.kt
@@ -8,17 +8,16 @@ import kotlinx.coroutines.flow.transform
 import javax.inject.Inject
 
 class AddressRepositoryImpl @Inject constructor(
-    private val addressDataSource: AddressDataSource,
+    private val addressDataSource: AddressDataSource
 ) : AddressRepository {
-    companion object {
-        private const val DEFAULT_PAGE = 1
-        private const val DEFAULT_PAGE_SIZE = 5
-    }
-
-    override fun getAddress(keyword: String): Flow<List<JusoModel>> =
+    override fun getAddress(
+        currentPage: Int,
+        countPerPage: Int,
+        keyword: String
+    ): Flow<List<JusoModel>> =
         addressDataSource.getAddress(
-            countPerPage = DEFAULT_PAGE,
-            currentPage = DEFAULT_PAGE_SIZE,
+            countPerPage = countPerPage,
+            currentPage = currentPage,
             keyword = keyword
         ).transform { list ->
             emit(list.results.juso?.map { juso -> juso.toModel() } ?: emptyList())

--- a/core/domain/src/main/java/com/school_of_company/domain/usecase/juso/GetAddressUseCase.kt
+++ b/core/domain/src/main/java/com/school_of_company/domain/usecase/juso/GetAddressUseCase.kt
@@ -1,0 +1,22 @@
+package com.school_of_company.domain.usecase.juso
+
+import com.school_of_company.data.repository.juso.AddressRepository
+import com.school_of_company.model.model.juso.JusoModel
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetAddressUseCase @Inject constructor(
+    private val repository: AddressRepository,
+) {
+    companion object {
+        private const val DEFAULT_PAGE = 1
+        private const val DEFAULT_PAGE_SIZE = 5
+    }
+
+    operator fun invoke(searchText: String): Flow<List<JusoModel>> =
+        repository.getAddress(
+            currentPage = DEFAULT_PAGE,
+            countPerPage = DEFAULT_PAGE_SIZE,
+            keyword = searchText,
+        )
+}

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.viewModelScope
 import com.school_of_company.common.exception.NoResponseException
 import com.school_of_company.common.result.Result
 import com.school_of_company.common.result.asResult
-import com.school_of_company.data.repository.juso.AddressRepository
 import com.school_of_company.domain.usecase.Image.ImageUpLoadUseCase
 import com.school_of_company.domain.usecase.expo.CheckExpoSurveyDynamicFormEnableUseCase
 import com.school_of_company.domain.usecase.expo.DeleteExpoInformationUseCase
@@ -16,6 +15,7 @@ import com.school_of_company.domain.usecase.expo.GetExpoInformationUseCase
 import com.school_of_company.domain.usecase.expo.GetExpoListUseCase
 import com.school_of_company.domain.usecase.expo.ModifyExpoInformationUseCase
 import com.school_of_company.domain.usecase.expo.RegisterExpoInformationUseCase
+import com.school_of_company.domain.usecase.juso.GetAddressUseCase
 import com.school_of_company.domain.usecase.kakao.GetCoordinatesToAddressUseCase
 import com.school_of_company.domain.usecase.kakao.GetCoordinatesUseCase
 import com.school_of_company.domain.usecase.standard.StandardProgramListUseCase
@@ -61,7 +61,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 internal class ExpoViewModel @Inject constructor(
-    private val addressRepository: AddressRepository,
+    private val getAddressUseCase: GetAddressUseCase,
     private val getExpoListUseCase: GetExpoListUseCase,
     private val imageUpLoadUseCase: ImageUpLoadUseCase,
     private val getCoordinatesUseCase: GetCoordinatesUseCase,
@@ -480,7 +480,7 @@ internal class ExpoViewModel @Inject constructor(
     internal fun searchLocation(searchText: String) =
         viewModelScope.launch {
             onSearchedCoordinateChange(x = "", y = "")
-            addressRepository.getAddress(keyword = searchText)
+            getAddressUseCase(searchText = searchText)
                 .asResult()
                 .collectLatest { result ->
                     when (result) {


### PR DESCRIPTION
Reverts School-of-Company/Expo-Android#626

getAddress함수의 page count와 current page가 뒤바뀌어서 오류가 발생합니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 주소 검색 시 페이지 번호와 페이지당 결과 수를 지정할 수 있도록 기능이 개선되었습니다.

- **리팩터링**
  - 주소 검색 로직이 별도의 유스케이스 클래스로 분리되어 구조가 개선되었습니다.
  - ViewModel에서 주소 검색 관련 의존성이 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->