### PR TITLE
🔀 :: (#641) - 박람회 삭제 성공 이후 바로 리스트 상태 업데이트를 할 수 있도록 하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -73,6 +73,7 @@ internal fun ExpoCreatedRoute(
             is DeleteExpoInformationUiState.Loading -> Unit
             is DeleteExpoInformationUiState.Success -> {
                 setSelectedIndex(-1)
+                expoViewModel.getExpoList()
                 makeToast(context, "박람회가 삭제되었습니다.")
             }
             is DeleteExpoInformationUiState.Error -> {


### PR DESCRIPTION
## 💡 개요
- 등록된 박람회를 삭제한 이후에 바로 리스트를 불러오는 동작이 없어 사용자가 스와이프를 하여 상태를 다시 업데이트 해야하는 문제가 있습니다.
## 📃 작업내용
- 박람회 삭제 성공 이후 바로 리스트 상태 업데이트를 할 수 있도록 하였습니다.
## 🔀 변경사항
- chore ExpoCreatedScreen
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 박람회 삭제가 성공적으로 이루어진 후, 박람회 목록이 즉시 새로고침되도록 개선되었습니다.  
- **기타**
  - 불필요한 Preview 관련 import가 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->