### PR TITLE
🔀 :: (#642) - Loading을 초기 상태가 아닌 Inital이라는 초기 상태를 UiState에 추가하여 무한 로딩 상태를 처리하였습니다.

### DIFF
--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -180,7 +180,7 @@ internal fun ExpoCreateRoute(
             horizontalAlignment = Alignment.CenterHorizontally,
             modifier = Modifier
                 .fillMaxSize()
-                .background(color = ExpoColor.main)
+                .background(color = ExpoColor.white)
         ) {
             LoadingDot()
         }

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreatedScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -73,6 +72,7 @@ internal fun ExpoCreatedRoute(
             is DeleteExpoInformationUiState.Loading -> Unit
             is DeleteExpoInformationUiState.Success -> {
                 setSelectedIndex(-1)
+                expoViewModel.getExpoList()
                 makeToast(context, "박람회가 삭제되었습니다.")
             }
             is DeleteExpoInformationUiState.Error -> {

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/ExpoViewModel.kt
@@ -115,7 +115,7 @@ internal class ExpoViewModel @Inject constructor(
     private val _getAddressUiState = MutableStateFlow<GetAddressUiState>(GetAddressUiState.Loading)
     internal val getAddressUiState = _getAddressUiState.asStateFlow()
 
-    private val _registerExpoInformationUiState = MutableStateFlow<RegisterExpoInformationUiState>(RegisterExpoInformationUiState.Loading)
+    private val _registerExpoInformationUiState = MutableStateFlow<RegisterExpoInformationUiState>(RegisterExpoInformationUiState.Initial)
     internal val registerExpoInformationUiState = _registerExpoInformationUiState.asStateFlow()
 
     private val _modifyExpoInformationUiState = MutableStateFlow<ModifyExpoInformationUiState>(ModifyExpoInformationUiState.Loading)
@@ -236,7 +236,6 @@ internal class ExpoViewModel @Inject constructor(
 
     internal fun registerExpoInformation(body: ExpoAllRequestParam) =
         viewModelScope.launch {
-            _registerExpoInformationUiState.value = RegisterExpoInformationUiState.Loading
             expoRepository.registerExpoInformation(
                 body = body.copy(
                     startedDay = body.startedDay.autoFormatToDateTime(),
@@ -267,7 +266,7 @@ internal class ExpoViewModel @Inject constructor(
 
     internal fun initRegisterExpo() {
         _imageUpLoadUiState.value = ImageUpLoadUiState.Loading
-        _registerExpoInformationUiState.value = RegisterExpoInformationUiState.Loading
+        _registerExpoInformationUiState.value = RegisterExpoInformationUiState.Initial
         _getCoordinatesUiState.value = GetCoordinatesUiState.Loading
         _getAddressUiState.value = GetAddressUiState.Loading
     }

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/RegisterExpoInformationUiState.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/RegisterExpoInformationUiState.kt
@@ -3,6 +3,7 @@ package com.school_of_company.expo.viewmodel.uistate
 import com.school_of_company.model.entity.expo.ExpoIdResponseEntity
 
 sealed interface RegisterExpoInformationUiState {
+    object Initial : RegisterExpoInformationUiState
     object Loading : RegisterExpoInformationUiState
     data class Success(val data: ExpoIdResponseEntity): RegisterExpoInformationUiState
     data class Error(val exception: Throwable) : RegisterExpoInformationUiState


### PR DESCRIPTION
## 💡 개요
- 박람회 생성화면이 항상 Loading 상태로 유지되어 백그라운드에서 계속 로딩 애니메이션이 동작하고 있는 문제가 있었습니다.
## 📃 작업내용
- Loading을 초기 상태가 아닌 Inital이라는 초기 상태를 UiState에 추가하여 무한 로딩 상태를 처리하였습니다.
   - before

      https://github.com/user-attachments/assets/93052b6b-8399-41e5-9e49-2c8bceafb187

   - after

      https://github.com/user-attachments/assets/eb935ff0-469a-462d-ae68-ccd7c16c51d8

## 🔀 변경사항
- chore ExpoCreateScreen
- chore ExpoViewModel
- chore RegisterExpoInformationUiState
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 로딩 화면의 배경색이 흰색으로 변경되어 시각적 경험이 개선되었습니다.

- **신규 기능**
  - 등록 화면의 초기 상태가 추가되어, 등록 프로세스 시작 전 별도의 초기 상태를 확인할 수 있습니다.
  - 삭제 성공 시 전시 목록이 자동으로 새로고침되어 최신 정보를 즉시 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->