### PR TITLE
🔀 :: (#681) - 폼 모듈의 리컴포지션을 최적화했습니다

### DIFF
--- a/core/model/src/main/java/com/school_of_company/model/model/form/FormRequestAndResponseModel.kt
+++ b/core/model/src/main/java/com/school_of_company/model/model/form/FormRequestAndResponseModel.kt
@@ -1,11 +1,15 @@
 package com.school_of_company.model.model.form
 
+import androidx.compose.runtime.Immutable
+
 data class FormRequestAndResponseModel(
     val informationText: String,
     val participantType: String, // TRAINEE, STANDARD
     val dynamicForm: List<DynamicFormModel>,
 )
 
+
+@Immutable
 data class DynamicFormModel(
     val title: String,
     val formType: String, // SENTENCE, CHECKBOX, DROPDOWN, IMAGE, MULTIPLE

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
@@ -25,11 +25,9 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.school_of_company.design_system.R
-import com.school_of_company.design_system.component.button.ExpoButton
 import com.school_of_company.design_system.component.button.ExpoStateButton
 import com.school_of_company.design_system.component.button.state.ButtonState
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
-import com.school_of_company.design_system.component.modifier.padding.paddingHorizontal
 import com.school_of_company.design_system.component.topbar.ExpoTopBar
 import com.school_of_company.design_system.icon.LeftArrowIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
@@ -40,6 +38,8 @@ import com.school_of_company.form.view.component.PersonaInformationFormCard
 import com.school_of_company.form.viewModel.FormViewModel
 import com.school_of_company.form.viewModel.uiState.FormUiState
 import com.school_of_company.model.model.form.DynamicFormModel
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun FormCreateRoute(
@@ -87,7 +87,7 @@ internal fun FormCreateRoute(
 private fun FormCreateScreen(
     modifier: Modifier = Modifier,
     informationTextState: String,
-    formList: List<DynamicFormModel>,
+    formList: PersistentList<DynamicFormModel>,
     focusManager: FocusManager = LocalFocusManager.current,
     scrollState: ScrollState = rememberScrollState(),
     popUpBackStack: () -> Unit,
@@ -179,7 +179,7 @@ private fun FormCreateScreen(
 private fun FormCreateScreenPreview() {
     FormCreateScreen(
         informationTextState = "informationTextState",
-        formList = listOf(
+        formList = persistentListOf(
             DynamicFormModel(
                 title = "제목",
                 formType = FormType.DROPDOWN.name,

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
@@ -54,6 +54,7 @@ internal fun FormCreateRoute(
     val formState by viewModel.formState.collectAsStateWithLifecycle()
     val formUiState by viewModel.formUiState.collectAsStateWithLifecycle()
     val informationTextState by viewModel.informationTextState.collectAsStateWithLifecycle()
+    val focusManager: FocusManager = LocalFocusManager.current
 
     LaunchedEffect(formUiState) {
         when (formUiState) {
@@ -74,6 +75,7 @@ internal fun FormCreateRoute(
         modifier = modifier,
         informationTextState = informationTextState,
         formList = formState,
+        clearFocusCallback = { focusManager.clearFocus() },
         popUpBackStack = popUpBackStack,
         addFormAtList = viewModel::addEmptyDynamicFormItem,
         createForm = { viewModel.createForm(expoId, participantType, informationTextState) },
@@ -90,6 +92,7 @@ private fun FormCreateScreen(
     formList: PersistentList<DynamicFormModel>,
     focusManager: FocusManager = LocalFocusManager.current,
     scrollState: ScrollState = rememberScrollState(),
+    clearFocusCallback: () -> Unit,
     popUpBackStack: () -> Unit,
     addFormAtList: () -> Unit,
     createForm: () -> Unit,
@@ -104,13 +107,7 @@ private fun FormCreateScreen(
                 .verticalScroll(scrollState)
                 .background(color = colors.white)
                 .padding(horizontal = 16.dp,)
-                .pointerInput(Unit) {
-                    detectTapGestures(
-                        onTap = {
-                            focusManager.clearFocus()
-                        }
-                    )
-                },
+                .pointerInput(Unit) { detectTapGestures(onTap = { clearFocusCallback() }) },
         ) {
             ExpoTopBar(
                 startIcon = {
@@ -159,7 +156,9 @@ private fun FormCreateScreen(
                     formList.all { form ->
                         when (FormType.valueOf(form.formType)) {
                             FormType.SENTENCE -> form.title.isNotEmpty()
-                            FormType.CHECKBOX, FormType.DROPDOWN, FormType.MULTIPLE ->
+                            FormType.CHECKBOX,
+                            FormType.DROPDOWN,
+                            FormType.MULTIPLE ->
                                 form.title.isNotEmpty() &&
                                 form.itemList.isNotEmpty() &&
                                 form.itemList.all { it.isNotEmpty() }
@@ -188,6 +187,7 @@ private fun FormCreateScreenPreview() {
                 otherJson = true,
             ),
         ),
+        clearFocusCallback = {},
         popUpBackStack = {},
         addFormAtList = { },
         createForm = {},

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormCreateScreen.kt
@@ -107,8 +107,13 @@ private fun FormCreateScreen(
                 .verticalScroll(scrollState)
                 .background(color = colors.white)
                 .padding(horizontal = 16.dp,)
-                .pointerInput(Unit) { detectTapGestures(onTap = { clearFocusCallback() }) },
-        ) {
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onTap = {
+                            clearFocusCallback()
+                        }
+                    )
+                },        ) {
             ExpoTopBar(
                 startIcon = {
                     LeftArrowIcon(

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormModifyScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormModifyScreen.kt
@@ -100,8 +100,8 @@ internal fun FormModifyRoute(
 private fun FormModifyScreen(
     modifier: Modifier = Modifier,
     informationTextState: String,
-    formList: List<DynamicFormModel>,
     focusManager: FocusManager = LocalFocusManager.current,
+    formList: PersistentList<DynamicFormModel>,
     scrollState: ScrollState = rememberScrollState(),
     popUpBackStack: () -> Unit,
     addFormAtList: () -> Unit,
@@ -192,7 +192,7 @@ private fun FormModifyScreen(
 private fun FormModifyScreenPreview() {
     FormModifyScreen(
         informationTextState = "informationTextState",
-        formList = listOf(
+        formList = persistentListOf(
             DynamicFormModel(
                 title = "제목",
                 formType = FormType.DROPDOWN.name,

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormModifyScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormModifyScreen.kt
@@ -69,10 +69,12 @@ internal fun FormModifyRoute(
                 popUpBackStack()
                 onErrorToast(null, R.string.form_modify_success)
             }
+
             is FormUiState.NotFound -> {
                 viewModel.setIsNotFoundError(true)
                 onErrorToast(null, R.string.form_modify_not_found)
             }
+
             is FormUiState.Conflict -> Unit
             is FormUiState.Error -> onErrorToast(null, R.string.form_modify_fail)
         }
@@ -119,7 +121,13 @@ private fun FormModifyScreen(
                 .verticalScroll(scrollState)
                 .background(color = colors.white)
                 .padding(horizontal = 16.dp)
-                .pointerInput(Unit) { detectTapGestures(onTap = { clearFocusCallback() }) },
+                .pointerInput(Unit) {
+                    detectTapGestures(
+                        onTap = {
+                            clearFocusCallback()
+                        }
+                    )
+                },
         ) {
             ExpoTopBar(
                 startIcon = {
@@ -172,8 +180,8 @@ private fun FormModifyScreen(
                             FormType.DROPDOWN,
                             FormType.MULTIPLE ->
                                 form.title.isNotEmpty() &&
-                                form.itemList.isNotEmpty() &&
-                                form.itemList.all { it.isNotEmpty() }
+                                        form.itemList.isNotEmpty() &&
+                                        form.itemList.all { it.isNotEmpty() }
                         }
                     }
                 ) ButtonState.Enable else ButtonState.Disable,

--- a/feature/form/src/main/java/com/school_of_company/form/view/FormModifyScreen.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/view/FormModifyScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.school_of_company.design_system.R
-import com.school_of_company.design_system.component.button.ExpoButton
 import com.school_of_company.design_system.component.button.ExpoStateButton
 import com.school_of_company.design_system.component.button.state.ButtonState
 import com.school_of_company.design_system.component.modifier.clickable.expoClickable
@@ -39,7 +38,8 @@ import com.school_of_company.form.view.component.PersonaInformationFormCard
 import com.school_of_company.form.viewModel.FormViewModel
 import com.school_of_company.form.viewModel.uiState.FormUiState
 import com.school_of_company.model.model.form.DynamicFormModel
-import java.text.Normalizer.Form
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun FormModifyRoute(
@@ -53,6 +53,7 @@ internal fun FormModifyRoute(
     val formState by viewModel.formState.collectAsStateWithLifecycle()
     val formActionUiState by viewModel.formUiState.collectAsStateWithLifecycle()
     val informationTextState by viewModel.informationTextState.collectAsStateWithLifecycle()
+    val focusManager: FocusManager = LocalFocusManager.current
 
     LaunchedEffect(Unit) {
         viewModel.getForm(
@@ -81,6 +82,7 @@ internal fun FormModifyRoute(
         modifier = modifier,
         informationTextState = informationTextState,
         formList = formState,
+        clearFocusCallback = { focusManager.clearFocus() },
         popUpBackStack = popUpBackStack,
         addFormAtList = viewModel::addEmptyDynamicFormItem,
         submitForm = {
@@ -100,9 +102,9 @@ internal fun FormModifyRoute(
 private fun FormModifyScreen(
     modifier: Modifier = Modifier,
     informationTextState: String,
-    focusManager: FocusManager = LocalFocusManager.current,
     formList: PersistentList<DynamicFormModel>,
     scrollState: ScrollState = rememberScrollState(),
+    clearFocusCallback: () -> Unit,
     popUpBackStack: () -> Unit,
     addFormAtList: () -> Unit,
     submitForm: () -> Unit,
@@ -116,14 +118,8 @@ private fun FormModifyScreen(
                 .fillMaxSize()
                 .verticalScroll(scrollState)
                 .background(color = colors.white)
-                .padding(horizontal = 16.dp,)
-                .pointerInput(Unit) {
-                    detectTapGestures(
-                        onTap = {
-                            focusManager.clearFocus()
-                        }
-                    )
-                },
+                .padding(horizontal = 16.dp)
+                .pointerInput(Unit) { detectTapGestures(onTap = { clearFocusCallback() }) },
         ) {
             ExpoTopBar(
                 startIcon = {
@@ -135,7 +131,7 @@ private fun FormModifyScreen(
                 betweenText = "폼 수정하기",
                 modifier = Modifier.padding(
                     top = 68.dp,
-                    bottom = 16.dp
+                    bottom = 16.dp,
                 ),
             )
 
@@ -172,12 +168,15 @@ private fun FormModifyScreen(
                     formList.all { form ->
                         when (FormType.valueOf(form.formType)) {
                             FormType.SENTENCE -> form.title.isNotEmpty()
-                            FormType.CHECKBOX, FormType.DROPDOWN, FormType.MULTIPLE ->
+                            FormType.CHECKBOX,
+                            FormType.DROPDOWN,
+                            FormType.MULTIPLE ->
                                 form.title.isNotEmpty() &&
                                 form.itemList.isNotEmpty() &&
                                 form.itemList.all { it.isNotEmpty() }
                         }
-                    }) ButtonState.Enable else ButtonState.Disable,
+                    }
+                ) ButtonState.Enable else ButtonState.Disable,
                 onClick = submitForm,
                 modifier = Modifier.fillMaxWidth()
             )
@@ -201,6 +200,7 @@ private fun FormModifyScreenPreview() {
                 otherJson = true,
             ),
         ),
+        clearFocusCallback = {},
         popUpBackStack = {},
         addFormAtList = { },
         submitForm = {},

--- a/feature/form/src/main/java/com/school_of_company/form/viewModel/FormViewModel.kt
+++ b/feature/form/src/main/java/com/school_of_company/form/viewModel/FormViewModel.kt
@@ -11,6 +11,7 @@ import com.school_of_company.form.viewModel.uiState.GetFormUiState
 import com.school_of_company.model.model.form.DynamicFormModel
 import com.school_of_company.model.model.form.FormRequestAndResponseModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -34,7 +35,7 @@ internal class FormViewModel @Inject constructor(
 
     private val _getFormUiState = MutableStateFlow<GetFormUiState>(GetFormUiState.Loading)
 
-    internal val formState = savedStateHandle.getStateFlow(FORM_STATE, listOf(DynamicFormModel.createDefault()))
+    internal val formState = savedStateHandle.getStateFlow(FORM_STATE, persistentListOf(DynamicFormModel.createDefault()))
     internal val informationTextState = savedStateHandle.getStateFlow(INFORMATION_TEXT_STATE, "")
 
     private var _isNotFoundError = MutableStateFlow(false)


### PR DESCRIPTION
## 💡 개요

폼 모듈에서 다른 모듈의 dataClass를 참조해서 안정적이지 않다고 여기는 문제,
composable 함수의 파라미터로 list를 사용하고있어서 안정적이지 않다고 여기는 문제가 있었습니다

작업 전

![image](https://github.com/user-attachments/assets/6e965102-dbd8-4a94-a1f3-83c69c452282)


작업 후

![image](https://github.com/user-attachments/assets/ef26b853-a685-4a9d-aeaa-8afecfc1ca4f)

## 📃 작업내용

dataClass에 @Immutable 어노테이션을 붙여서 Compose가 해당 dataClass를 안정적이라고 여기도록 수정했습니다
함수의 파라미터로 List타입을 사용하지 않고 PersistentList를 사용하도록 수정했습니다 

## 🔀 변경사항

![image](https://github.com/user-attachments/assets/c5e46a3a-435e-4ec5-b600-24aad1092a13)

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
x
## 🎸 기타
x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- 폼 관련 화면에서 기존의 List 대신 불변 PersistentList를 사용하도록 변경되었습니다.
	- 포커스 해제 동작이 콜백 방식으로 개선되어, 더 일관된 포커스 관리가 가능합니다.
- **Style**
	- 일부 코드 포맷 및 불필요한 import가 정리되었습니다.
- **Bug Fixes**
	- DynamicFormModel 데이터 클래스에 @Immutable 어노테이션이 추가되어 Compose에서의 상태 관리 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->