### PR TITLE
🔀 :: (#688) - Expo 모듈 Recomposition 최적화를 진행하였습니다.

### DIFF
--- a/core/model/src/main/java/com/school_of_company/model/entity/expo/ExpoListResponseEntity.kt
+++ b/core/model/src/main/java/com/school_of_company/model/entity/expo/ExpoListResponseEntity.kt
@@ -1,5 +1,8 @@
 package com.school_of_company.model.entity.expo
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 data class ExpoListResponseEntity(
     val id: String,
     val title: String,

--- a/core/model/src/main/java/com/school_of_company/model/model/juso/JusoModel.kt
+++ b/core/model/src/main/java/com/school_of_company/model/model/juso/JusoModel.kt
@@ -1,5 +1,8 @@
 package com.school_of_company.model.model.juso
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 data class JusoModel(
     val roadAddr: String,
     val jibunAddr: String,

--- a/core/model/src/main/java/com/school_of_company/model/param/expo/ExpoCreateRequestParam.kt
+++ b/core/model/src/main/java/com/school_of_company/model/param/expo/ExpoCreateRequestParam.kt
@@ -1,5 +1,7 @@
 package com.school_of_company.model.param.expo
 
+import androidx.compose.runtime.Immutable
+
 data class ExpoAllRequestParam(
     val title: String,
     val description: String,
@@ -13,12 +15,14 @@ data class ExpoAllRequestParam(
     val addTrainingProRequestDto: List<TrainingProRequestParam>,
 )
 
+@Immutable
 data class StandardProRequestParam(
     val title: String,
     val startedAt: String, // yyyy-MM-DD HH:mm
     val endedAt: String, // yyyy-MM-DD HH:mm
 )
 
+@Immutable
 data class TrainingProRequestParam(
     val title: String,
     val startedAt: String, // yyyy-MM-dd HH:mm

--- a/core/model/src/main/java/com/school_of_company/model/param/expo/ExpoModifyRequestParam.kt
+++ b/core/model/src/main/java/com/school_of_company/model/param/expo/ExpoModifyRequestParam.kt
@@ -1,5 +1,7 @@
 package com.school_of_company.model.param.expo
 
+import androidx.compose.runtime.Immutable
+
 data class ExpoModifyRequestParam(
     val title: String,
     val description: String,
@@ -13,6 +15,7 @@ data class ExpoModifyRequestParam(
     val updateTrainingProRequestDto: List<TrainingProIdRequestParam>,
 )
 
+@Immutable
 data class StandardProIdRequestParam(
     val id: Long,
     val title: String,
@@ -20,6 +23,7 @@ data class StandardProIdRequestParam(
     val endedAt: String, // yyyy-MM-DD HH:mm
 )
 
+@Immutable
 data class TrainingProIdRequestParam(
     val id: Long,
     val title: String,

--- a/feature/expo/src/main/java/com/school_of_company/expo/enum/FilterOptionEnum.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/enum/FilterOptionEnum.kt
@@ -1,5 +1,8 @@
 package com.school_of_company.expo.enum
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 enum class FilterOptionEnum {
     TRAINING_FORM_TRUE,
     TRAINING_FORM_FALSE,

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoAddressSearchScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoAddressSearchScreen.kt
@@ -45,6 +45,9 @@ import com.school_of_company.expo.viewmodel.ExpoViewModel
 import com.school_of_company.expo.viewmodel.uistate.GetAddressUiState
 import com.school_of_company.expo.viewmodel.uistate.GetCoordinatesUiState
 import com.school_of_company.model.model.juso.JusoModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
+import okhttp3.internal.toImmutableList
 
 @Composable
 internal fun ExpoAddressSearchRoute(
@@ -115,13 +118,14 @@ private fun ExpoAddressSearchScreen(
     location: String,
     coordinateX: String,
     coordinateY: String,
-    addressList: List<JusoModel>,
-    focusManager: FocusManager = LocalFocusManager.current,
+    addressList: PersistentList<JusoModel>,
     popUpBackStack: () -> Unit,
     onLocationSearch: () -> Unit,
     onLocationChange: (String) -> Unit,
     onAddressItemClick: (String) -> Unit,
 ) {
+    val focusManager: FocusManager = LocalFocusManager.current
+
     ExpoAndroidTheme { colors, typography ->
         Column(
             modifier = modifier

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoCreateScreen.kt
@@ -87,6 +87,8 @@ import com.school_of_company.ui.keyBoardOption.numberKeyboardOptions
 import com.school_of_company.ui.toast.makeToast
 import com.school_of_company.ui.util.filterNonDigits
 import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun ExpoCreateRoute(
@@ -219,9 +221,8 @@ private fun ExpoCreateScreen(
     addressState: String,
     locationState: String,
     imageUri: String?,
-    trainingProgramTextState: List<TrainingProRequestParam>,
-    standardProgramTextState: List<StandardProRequestParam>,
-    focusManager: FocusManager = LocalFocusManager.current,
+    trainingProgramTextState: PersistentList<TrainingProRequestParam>,
+    standardProgramTextState: PersistentList<StandardProRequestParam>,
     scrollState: ScrollState = rememberScrollState(),
     onImageClick: () -> Unit,
     onExpoCreateCallBack: () -> Unit,
@@ -238,6 +239,7 @@ private fun ExpoCreateScreen(
     onTrainingProgramChange: (Int, TrainingProRequestParam) -> Unit,
     onStandardProgramChange: (Int, StandardProRequestParam) -> Unit,
 ) {
+    val focusManager: FocusManager = LocalFocusManager.current
 
     val (openTrainingSettingBottomSheet, isOpenTrainingSettingBottomSheet) = rememberSaveable { mutableStateOf(false) }
     val (openStandardSettingBottomSheet, isOpenStandardSettingBottomSheet) = rememberSaveable { mutableStateOf(false) }
@@ -670,8 +672,8 @@ private fun ExpoCreateScreenPreview() {
         addressState = "",
         locationState = "",
         imageUri = null,
-        trainingProgramTextState = emptyList(),
-        standardProgramTextState = emptyList(),
+        trainingProgramTextState = persistentListOf(),
+        standardProgramTextState = persistentListOf(),
         onImageClick = {},
         onExpoCreateCallBack = {},
         onAddTrainingProgram = {},

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoModifyScreen.kt
@@ -87,6 +87,8 @@ import com.school_of_company.ui.keyBoardOption.numberKeyboardOptions
 import com.school_of_company.ui.toast.makeToast
 import com.school_of_company.ui.util.filterNonDigits
 import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformation
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun ExpoModifyRoute(
@@ -211,7 +213,6 @@ internal fun ExpoModifyRoute(
 @Composable
 private fun ExpoModifyScreen(
     modifier: Modifier = Modifier,
-    focusManager: FocusManager = LocalFocusManager.current,
     scrollState: ScrollState = rememberScrollState(),
     imageUri: String?,
     modifyCallBack: () -> Unit,
@@ -223,8 +224,8 @@ private fun ExpoModifyScreen(
     addressState: String,
     locationState: String,
     introduceTitleState: String,
-    trainingProgramTextState: List<TrainingProIdRequestParam>,
-    standardProgramTextState: List<StandardProIdRequestParam>,
+    trainingProgramTextState: PersistentList<TrainingProIdRequestParam>,
+    standardProgramTextState: PersistentList<StandardProIdRequestParam>,
     navigateToExpoAddressSearch: () -> Unit,
     onAddStandardProgram: () -> Unit,
     onAddTrainingProgram: () -> Unit,
@@ -240,6 +241,7 @@ private fun ExpoModifyScreen(
     updateExistingTrainingProgram: (Int, TrainingProIdRequestParam) -> Unit,
     updateExistingStandardProgram: (Int, StandardProIdRequestParam) -> Unit
 ) {
+    val focusManager: FocusManager = LocalFocusManager.current
 
     val (openTrainingSettingBottomSheet, isOpenTrainingSettingBottomSheet) = rememberSaveable {
         mutableStateOf(
@@ -701,11 +703,11 @@ private fun HomeDetailModifyScreenPreview() {
         imageUri = "",
         modifyCallBack = {},
         navigateToExpoAddressSearch = {},
-        trainingProgramTextState = emptyList(),
+        trainingProgramTextState = persistentListOf(),
         onTrainingProgramChange = { _, _ -> },
         onAddTrainingProgram = {},
         onRemoveTrainingProgram = {},
-        standardProgramTextState = emptyList(),
+        standardProgramTextState = persistentListOf(),
         onStandardProgramChange = { _, _ -> },
         onAddStandardProgram = {},
         onRemoveStandardProgram = {},

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoScreen.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/ExpoScreen.kt
@@ -42,6 +42,7 @@ import com.school_of_company.expo.view.component.ExpoFormFilterDialog
 import com.school_of_company.expo.view.component.ExpoList
 import com.school_of_company.expo.view.component.HomeFilterButton
 import com.school_of_company.expo.viewmodel.uistate.GetExpoListUiState
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 
 @Composable
@@ -187,7 +188,7 @@ private fun ExpoScreen(
     if (openFilterDialog) {
         Dialog(onDismissRequest = {setOpenFilterDialog(false)}) {
             ExpoFormFilterDialog(
-                selectedOptions = listOf(selectedFilter),
+                selectedOptions = persistentListOf(selectedFilter),
                 onStudentFormTrueClick = { onFilterSelected(FilterOptionEnum.STUDENT_FORM_TRUE) },
                 onStudentFormFalseClick = { onFilterSelected(FilterOptionEnum.STUDENT_FORM_FALSE) },
                 onTrainingFormFalseClick = { onFilterSelected(FilterOptionEnum.TRAINING_FORM_FALSE) },

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoAddTextField.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoAddTextField.kt
@@ -27,12 +27,14 @@ import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.param.expo.TrainingProIdRequestParam
 import com.school_of_company.model.param.expo.TrainingProRequestParam
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun ExpoAddTextField(
     modifier: Modifier = Modifier,
     placeHolder: String,
-    trainingTextFieldList: List<TrainingProRequestParam>,
+    trainingTextFieldList: PersistentList<TrainingProRequestParam>,
     onAddTextField: () -> Unit,
     onRemoveTextField: (Int) -> Unit,
     onTrainingSetting: (Int) -> Unit,
@@ -130,7 +132,7 @@ internal fun ExpoAddTextField(
 internal fun ExpoAddModifyTextField(
     modifier: Modifier = Modifier,
     placeHolder: String,
-    trainingTextFieldList: List<TrainingProIdRequestParam>,
+    trainingTextFieldList: PersistentList<TrainingProIdRequestParam>,
     onAddTextField: () -> Unit,
     onRemoveTextField: (Int) -> Unit,
     onTrainingSetting: (Int) -> Unit,
@@ -229,7 +231,7 @@ internal fun ExpoAddModifyTextField(
 private fun ExpoAddTextFieldPreview() {
     ExpoAddTextField(
         placeHolder = "연수를 입력하세요.",
-        trainingTextFieldList = listOf(),
+        trainingTextFieldList = persistentListOf(),
         onValueChange = { _, _ ->},
         onAddTextField = {},
         onRemoveTextField = {},

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFormFilterDialog.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFormFilterDialog.kt
@@ -19,11 +19,13 @@ import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.expo.enum.FilterOptionEnum
 import com.school_of_company.expo.viewmodel.ExpoViewModel
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun ExpoFormFilterDialog(
     modifier: Modifier = Modifier,
-    selectedOptions: List<FilterOptionEnum?>,
+    selectedOptions: PersistentList<FilterOptionEnum?>,
     onTrainingFormTrueClick: () -> Unit,
     onTrainingFormFalseClick: () -> Unit,
     onStudentFormTrueClick: () -> Unit,
@@ -32,7 +34,7 @@ internal fun ExpoFormFilterDialog(
 ) {
     ExpoAndroidTheme { colors, typography ->
 
-        val options = listOf(
+        val options = persistentListOf(
             FilterOption(
                 label = "연수자 폼 (O)",
                 selected = selectedOptions.contains(FilterOptionEnum.TRAINING_FORM_TRUE),
@@ -105,7 +107,7 @@ internal fun ExpoFormFilterDialog(
 @Composable
 private fun ExpoFormFilterDialogPreview() {
     ExpoFormFilterDialog(
-        selectedOptions = listOf(),
+        selectedOptions = persistentListOf(),
         onTrainingFormTrueClick = {},
         onTrainingFormFalseClick = {},
         onStudentFormTrueClick = {},

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFormFilterGroupButton.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoFormFilterGroupButton.kt
@@ -14,11 +14,15 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 
+@Immutable
 internal data class FilterOption(
     val label: String,
     val selected: Boolean,
@@ -29,7 +33,7 @@ internal data class FilterOption(
 @Composable
 internal fun ExpoFormFilterGroupButton(
     modifier: Modifier = Modifier,
-    options: List<FilterOption>
+    options: PersistentList<FilterOption>
 ) {
     ExpoAndroidTheme { colors, typography ->
         FlowRow(
@@ -90,7 +94,7 @@ private fun ExpoFormFilterButton(
 @Composable
 private fun ExpoFormFilterButtonPreview() {
     ExpoFormFilterGroupButton(
-        options = listOf(
+        options = persistentListOf(
             FilterOption("현장실습 O", true) {  },
             FilterOption("현장실습 X", false) { },
             FilterOption("학생참여 O", false) {  },

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoSettingBottomSheet.kt
@@ -57,13 +57,14 @@ import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformatio
 @Composable
 internal fun ExpoSettingBottomSheet(
     modifier: Modifier = Modifier,
-    focusManager: FocusManager = LocalFocusManager.current,
     sheetState: SheetState = rememberModalBottomSheetState(),
     trainingSettingItem: TrainingProRequestParam,
     onCancelClick: () -> Unit,
     onButtonClick: () -> Unit,
     onTrainingSettingChange: (TrainingProRequestParam) -> Unit,
 ) {
+    val focusManager: FocusManager = LocalFocusManager.current
+
     var currentItem by remember { mutableStateOf(trainingSettingItem) }
 
     ExpoAndroidTheme { colors, typography ->

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardAddTextField.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardAddTextField.kt
@@ -27,12 +27,14 @@ import com.school_of_company.design_system.icon.XIcon
 import com.school_of_company.design_system.theme.ExpoAndroidTheme
 import com.school_of_company.model.param.expo.StandardProIdRequestParam
 import com.school_of_company.model.param.expo.StandardProRequestParam
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 internal fun ExpoStandardAddTextField(
     modifier: Modifier = Modifier,
     placeHolder: String,
-    trainingTextFieldList: List<StandardProRequestParam>,
+    trainingTextFieldList: PersistentList<StandardProRequestParam>,
     onAddTextField: () -> Unit,
     onRemoveTextField: (Int) -> Unit,
     onTrainingSetting: (Int) -> Unit,
@@ -131,7 +133,7 @@ internal fun ExpoStandardAddTextField(
 internal fun ExpoStandardAddModifyTextField(
     modifier: Modifier = Modifier,
     placeHolder: String,
-    trainingTextFieldList: List<StandardProIdRequestParam>,
+    trainingTextFieldList: PersistentList<StandardProIdRequestParam>,
     onAddTextField: () -> Unit,
     onRemoveTextField: (Int) -> Unit,
     onTrainingSetting: (Int) -> Unit,
@@ -235,7 +237,7 @@ private fun ExpoStandardAddTextFieldPreview() {
         onRemoveTextField = {},
         onTrainingSetting = {},
         placeHolder = "안녕하세요",
-        trainingTextFieldList = listOf(
+        trainingTextFieldList = persistentListOf(
             StandardProRequestParam(
                 title = "제목",
                 startedAt = "9:10",

--- a/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/view/component/ExpoStandardSettingBottomSheet.kt
@@ -42,12 +42,13 @@ import com.school_of_company.ui.visualTransformation.DateTimeVisualTransformatio
 internal fun ExpoStandardSettingBottomSheet(
     modifier: Modifier = Modifier,
     trainingSettingItem: StandardProRequestParam,
-    focusManager: FocusManager = LocalFocusManager.current,
     sheetState: SheetState = rememberModalBottomSheetState(),
     onCancelClick: () -> Unit,
     onButtonClick: () -> Unit,
     onTrainingSettingChange: (StandardProRequestParam) -> Unit,
 ) {
+    val focusManager: FocusManager = LocalFocusManager.current
+
     var currentItem by remember { mutableStateOf(trainingSettingItem) }
 
     ExpoAndroidTheme { colors, typography ->
@@ -157,12 +158,12 @@ internal fun ExpoStandardSettingBottomSheet(
 internal fun ExpoStandardSettingModifyBottomSheet(
     modifier: Modifier = Modifier,
     trainingSettingItem: StandardProIdRequestParam,
-    focusManager: FocusManager = LocalFocusManager.current,
     sheetState: SheetState = rememberModalBottomSheetState(),
     onCancelClick: () -> Unit,
     onButtonClick: () -> Unit,
     onTrainingSettingChange: (StandardProIdRequestParam) -> Unit,
 ) {
+    val focusManager: FocusManager = LocalFocusManager.current
     var currentItem by remember { mutableStateOf(trainingSettingItem) }
 
     ExpoAndroidTheme { colors, typography ->

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetAddressUiState.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetAddressUiState.kt
@@ -1,10 +1,10 @@
 package com.school_of_company.expo.viewmodel.uistate
 
 import com.school_of_company.model.model.juso.JusoModel
-import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
 
 sealed interface GetAddressUiState {
     object Loading : GetAddressUiState
-    data class Success(val data: ImmutableList<JusoModel>) : GetAddressUiState
+    data class Success(val data: PersistentList<JusoModel>) : GetAddressUiState
     data class Error(val exception: Throwable) : GetAddressUiState
 }

--- a/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetAddressUiState.kt
+++ b/feature/expo/src/main/java/com/school_of_company/expo/viewmodel/uistate/GetAddressUiState.kt
@@ -1,9 +1,10 @@
 package com.school_of_company.expo.viewmodel.uistate
 
 import com.school_of_company.model.model.juso.JusoModel
+import kotlinx.collections.immutable.ImmutableList
 
 sealed interface GetAddressUiState {
     object Loading : GetAddressUiState
-    data class Success(val data: List<JusoModel>) : GetAddressUiState
+    data class Success(val data: ImmutableList<JusoModel>) : GetAddressUiState
     data class Error(val exception: Throwable) : GetAddressUiState
 }


### PR DESCRIPTION
## 💡 개요
- Expo 모듈에서 UnStable한 부분이 있어 Not-Skippable이 되는 경우가 있었습니다.
## 📃 작업내용
- 데이터 클래스의 모든 프로퍼티가 변경 불가능하므로, @immutable 어노테이션을 통해 Compose의 recomposition 최적화를 적용하였습니다.
- 함수의 파라미터로 List타입을 사용하지 않고 PersistentList를 사용하도록 수정했습니다
- before
    <img width="517" alt="스크린샷 2025-05-15 오후 2 18 28" src="https://github.com/user-attachments/assets/111eb3f8-25d7-44dd-85d7-90fec4e61c13" />

- after
    <img width="517" alt="스크린샷 2025-05-15 오후 2 18 58" src="https://github.com/user-attachments/assets/a3d7c905-e4d0-4a59-8263-d50ba4ec0b62" />

## 🔀 변경사항
<img width="309" alt="스크린샷 2025-05-15 오후 2 19 14" src="https://github.com/user-attachments/assets/5b73ebf7-6303-4f37-8283-538e3fbb76aa" />

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- x
## 🎸 기타
- x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
    - 여러 데이터 클래스와 enum에 불변성(`@Immutable`) 어노테이션을 추가했습니다.
    - 여러 컴포저블 함수의 리스트 타입을 표준 리스트에서 불변 리스트(`PersistentList`)로 변경했습니다.
    - 일부 함수에서 `focusManager` 파라미터를 제거하고, 내부에서 직접 관리하도록 수정했습니다.
    - ViewModel 및 UI 상태에서 리스트 타입을 불변 컬렉션으로 변경하여 일관성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->