### PR TITLE
🔀 :: (#695) - ProgramDetailParticipantManagementList에 key 값을 이용한 최적화 적용

### DIFF
--- a/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementList.kt
+++ b/feature/program/src/main/java/com/school_of_company/program/view/component/ProgramDetailParticipantManagementList.kt
@@ -24,7 +24,10 @@ internal fun ProgramDetailParticipantManagementList(
                 .background(color = colors.white)
                 .padding(start = 16.dp)
         ) {
-            itemsIndexed(item.participant) { index, item ->
+            itemsIndexed(
+                items = item.participant,
+                key = { _, item -> item.id },
+            ) { index, item ->
                 ProgramDetailParticipantManagementListItem(
                     index = index + 1,
                     data = item,
@@ -32,5 +35,6 @@ internal fun ProgramDetailParticipantManagementList(
                 )
             }
         }
+
     }
 }


### PR DESCRIPTION
## 💡 개요

`LazyColumn`에서 `key` 값을 지정하여 불필요한 리컴포지션을 방지하고 성능을 최적화했습니다.

**Before**

![image](https://github.com/user-attachments/assets/bc28ea6f-2589-4635-8601-93b8a1a11594)

**After**

![image](https://github.com/user-attachments/assets/27cbfc09-9131-478f-a716-d9f759eb7905)


## 📃 작업내용

* `itemsIndexed`에 `key` 파라미터를 추가하여 각 항목의 고유한 `id`를 전달하도록 수정
* 불필요한 리컴포지션 방지 및 LazyList 효율 개선
* key 값을 전달하면 리컴포지션 이전에 key 값이 같은 UI를 재사용함

## 🔀 변경사항

* `ProgramDetailParticipantManagementList.kt`:

```kotlin
itemsIndexed(item.participant) { index, item ->
   ...
}
```
->
  ```kotlin
  itemsIndexed(
      items = item,
      key = { _, item -> item.id }
  ) { index, item -> 
      ...
  }
  ```

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타