### PR TITLE
🔀 :: (#694) - StandardParticipantList에 key 값을 이용한 최적화 적용

### DIFF
--- a/feature/standard/src/main/java/com/school_of_company/standard/view/component/StandardParticipantList.kt
+++ b/feature/standard/src/main/java/com/school_of_company/standard/view/component/StandardParticipantList.kt
@@ -28,7 +28,10 @@ internal fun StandardParticipantList(
                 .background(color = colors.white)
                 .padding(start = 16.dp)
         ) {
-            itemsIndexed(item) { index, item ->
+            itemsIndexed(
+                items = item,
+                key = { _, item -> item.id },
+            ) { index, item ->
                 StandardProgramParticipantListItem(
                     index = index + 1,
                     data = item,


### PR DESCRIPTION
## 💡 개요

`LazyColumn`에서 `key` 값을 지정하여 불필요한 리컴포지션을 방지하고 성능을 최적화했습니다.

**Before**

![image](https://github.com/user-attachments/assets/25cdab96-bbaf-4da5-bf41-215f6d2924d4)

**After**

![image](https://github.com/user-attachments/assets/60703d70-48c0-4cc6-9fae-209525edcb00)

## 📃 작업내용

* `itemsIndexed`에 `key` 파라미터를 추가하여 각 항목의 고유한 `id`를 전달하도록 수정
* 불필요한 리컴포지션 방지 및 LazyList 효율 개선
* key 값을 전달하면 리컴포지션 이전에 key 값이 같은 UI를 재사용함

## 🔀 변경사항

* `StandardParticipantList.kt`:

  ```kotlin
  itemsIndexed(
      items = item,
      key = { _, item -> item.id }
  ) { index, item -> 
      ...
  }
  ```

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 리스트 항목에 고유 키가 적용되어 항목의 상태 보존과 렌더링 성능이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->