### PR TITLE
🔀 :: (#703) - CD 구축을 하였습니다.

### DIFF
--- a/.github/workflows/expo_cd.yml
+++ b/.github/workflows/expo_cd.yml
@@ -1,14 +1,13 @@
-name: Android CI
+name: Android CD
 
 on:
   push:
-    branches: [ "master", "develop" ]
-  pull_request:
-    branches: [ "*" ]
+    branches: [ "master" ]
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,7 +19,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{runner.os}}-gradle-${{hashFiles('**/*.gradle*', '**/gradle-wrapper.properties')}}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
             ${{ runner.os }}-
@@ -41,32 +40,57 @@ jobs:
       - name: Create LOCAL_PROPERTIES
         run: echo '${{ secrets.LOCAL_PROPERTIES }}' > ./local.properties
 
-      - name: Build with Gradle (incremental)
-        run: ./gradlew assembleDebug --no-daemon
+      - name: Create service_account.json
+        run: echo '${{ secrets.SERVICE_ACCOUNT_JSON }}' > service_account.json
 
+      - name: Assemble Release Bundle
+        run: ./gradlew bundleRelease --no-daemon
 
-      - name: Expo-Android CI Discord Notification
+      - name: Sign Release
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: app/build/outputs/bundle/release
+          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
+          alias: ${{ secrets.ALIAS }}
+          keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-release
+          path: app/build/outputs/bundle/release/app-release.aab
+
+      - name: Deploy to Google Play (Beta)
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJson: service_account.json
+          packageName: com.msg.sms_android
+          releaseFiles: app/build/outputs/bundle/release/app-release.aab
+          track: beta
+
+      - name: Android CD Discord Notification (Success)
         uses: sarisia/actions-status-discord@v1
         if: ${{ success() }}
         with:
-          title: CI 성공~
+          title: CD 성공~
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}
           image: ${{ secrets.SUCCESS_IMAGE }}
           description: 뀨
           color: 65280
           url: "https://github.com/sarisia/actions-status-discord"
-          username: Expo-CI Bot
+          username: Android-CD Bot
 
-      - name: Expo-Android CI Discord Notification
+      - name: Android CD Discord Notification (Fail)
         uses: sarisia/actions-status-discord@v1
         if: ${{ failure() }}
         with:
-          title: CI 실패~
+          title: CD 실패~
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}
           image: ${{ secrets.FAILED_IMAGE }}
           description: 뀨...
           color: 16711680
           url: "https://github.com/sarisia/actions-status-discord"
-          username: Expo-CI Bot
+          username: Android-CD Bot


### PR DESCRIPTION
## 💡 개요
-  매번 수동으로 앱 배포를 해야하는 상황이 발생하여 효율이 떨어짐을 느꼈습니다.
## 📃 작업내용
- cd 구축을 하여 master 브랜치에 push가 되면 자동 배포가 되도록 하였습니다.
## 🔀 변경사항
- add expo_cd.yml
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법
- 작업 이후 master 브랜치에 병합하게 되면 자동 배포가 시작됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 마스터 브랜치 푸시 시 Android 앱을 자동으로 빌드·서명하여 Google Play 베타 트랙에 배포하는 CD 파이프라인을 추가했습니다.
  - 빌드/배포 성공·실패에 따라 Discord로 알림을 발송합니다.
  - 캐시 및 환경 설정 자동화로 빌드 안정성과 속도를 개선했습니다.
- Style
  - CI Discord 알림 제목을 한국어(“CI 성공~”, “CI 실패~”)로 변경했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->