### PR TITLE
🔀 :: (#705) - CD 동작시 성공과 실패에 따른 디스코드 웹훅에 세부사항을 추가했습니다.

### DIFF
--- a/.github/workflows/expo_cd.yml
+++ b/.github/workflows/expo_cd.yml
@@ -9,9 +9,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Record start time
+        run: echo "START_TIME=$(date +%s)" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+
+      - name: Get commit info
+        run: |
+          echo "COMMIT_HASH=${GITHUB_SHA:0:8}" >> $GITHUB_ENV
+          echo "COMMIT_MSG=$(git log -1 --pretty=format:'%s')" >> $GITHUB_ENV
 
       - name: Gradle caching
         uses: actions/cache@v4
@@ -46,6 +54,19 @@ jobs:
       - name: Assemble Release Bundle
         run: ./gradlew bundleRelease --no-daemon
 
+      - name: Get bundle info
+        run: |
+          if [ -f "app/build/outputs/bundle/release/app-release.aab" ]; then
+            BUNDLE_SIZE=$(du -h "app/build/outputs/bundle/release/app-release.aab" | cut -f1)
+            echo "BUNDLE_SIZE=${BUNDLE_SIZE}" >> $GITHUB_ENV
+          else
+            echo "BUNDLE_SIZE=빌드 실패" >> $GITHUB_ENV
+          fi
+          
+          END_TIME=$(date +%s)
+          BUILD_TIME=$((END_TIME - START_TIME))
+          echo "BUILD_TIME=${BUILD_TIME}초" >> $GITHUB_ENV
+
       - name: Sign Release
         uses: r0adkll/sign-android-release@v1
         with:
@@ -76,11 +97,15 @@ jobs:
           title: CD 성공~
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}
-          image: ${{ secrets.SUCCESS_IMAGE }}
-          description: 뀨
+          description: |
+            버전: v1.2.3
+            빌드 시간: ${{ env.BUILD_TIME }}
+            용량: ${{ env.BUNDLE_SIZE }}
+            커밋: "${{ env.COMMIT_MSG }}" (${{ env.COMMIT_HASH }})
+            링크: [Play Console](https://play.google.com/console/developers) | [로그 보기](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           color: 65280
-          url: "https://github.com/sarisia/actions-status-discord"
-          username: Android-CD Bot
+          url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          username: Expo-CD Bot
 
       - name: Android CD Discord Notification (Fail)
         uses: sarisia/actions-status-discord@v1
@@ -89,8 +114,10 @@ jobs:
           title: CD 실패~
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           status: ${{ job.status }}
-          image: ${{ secrets.FAILED_IMAGE }}
-          description: 뀨...
+          description: |
+            커밋: "${{ env.COMMIT_MSG }}" (${{ env.COMMIT_HASH }})
+            소요 시간: ${{ env.BUILD_TIME }}
+            링크: [로그 확인하기](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
           color: 16711680
-          url: "https://github.com/sarisia/actions-status-discord"
-          username: Android-CD Bot
+          url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          username: Expo-CD Bot


### PR DESCRIPTION
## 💡 개요
- CD 동작시 성공과 실패에 따른 디스코드 웹훅에 정보가 부족한 것 같아 개발자들이 한번에 알아볼 수 있도록 세부사항을 추가합니다.
## 📃 작업내용
- CD 동작시 성공과 실패에 따른 디스코드 웹훅에 세부사항을 추가했습니다.
## 🔀 변경사항
- refactor expo_cd.yml
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 배포 알림 강화: 성공/실패 메시지에 버전, 빌드 시간, 번들 용량, 커밋 정보, 실행 로그 링크를 포함.
  * 알림 발신자명을 “Expo-CD Bot”으로統一하고 동적 실행 링크를 사용.

* Chores
  * Android CD 파이프라인에 시작/종료 시간 기록, 커밋 메타데이터, 번들 용량 수집 단계를 추가.
  * 빌드 결과(시간·용량)를 자동 계산해 알림에 반영.
  * 알림 포맷을 간결한 다중 행 요약으로 정리하고 불필요한 이미지 필드를 제거.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->