### PR TITLE
🔀 :: (#707) - Google Play Console의 트랙을 beta에서 production으로 변경하였습니다.

### DIFF
--- a/.github/workflows/expo_cd.yml
+++ b/.github/workflows/expo_cd.yml
@@ -82,13 +82,13 @@ jobs:
           name: app-release
           path: app/build/outputs/bundle/release/app-release.aab
 
-      - name: Deploy to Google Play (Beta)
+      - name: Deploy to Google Play (Production)
         uses: r0adkll/upload-google-play@v1
         with:
           serviceAccountJson: service_account.json
           packageName: com.school_of_company.expo_android
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
-          track: beta
+          track: production
 
       - name: Android CD Discord Notification (Success)
         uses: sarisia/actions-status-discord@v1


### PR DESCRIPTION
## 💡 개요
- master 브랜치 push 시 → Beta 트랙에 자동 배포되는 구조였지만 실제 일반 사용자 배포를 원했습니다.
## 📃 작업내용
- master 브랜치 push 시 → Production 트랙에 자동 배포되는 구조로 변경하였습니다.
## 🔀 변경사항
- chore expo_cd.yml
## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 해당 사항 없음
- 작업(Chores)
  - Google Play 배포 단계 명칭을 프로덕션으로 갱신하고, 릴리스 트랙을 베타에서 프로덕션으로 전환했습니다.
  - 앞으로 앱 업데이트가 프로덕션 채널로 배포되어 일반 사용자에게 직접 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->